### PR TITLE
Release 1.3.0: multi-result tabs, extended object tree, and object search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the "Exasol" extension will be documented in this file.
 
+## [1.3.0] - 2026-03-18
+
+### Added
+- **Extended object tree** — browse UDF scripts, procedures, adapter scripts, scalar/aggregate functions, virtual schema tables, primary/foreign key constraints, and indices
+- **System schemas** — SYS and EXA_STATISTICS system tables browsable under a "System Schemas" folder, with column inspection
+- **Find Database Object** command (`Ctrl+Shift+F` / `Cmd+Shift+F`) — QuickPick search across all object types with type icons, schema context, and tree reveal on selection
+- Parent tracking on tree nodes enabling `TreeView.reveal()` for navigation
+- Enhanced IntelliSense with scripts, functions, virtual tables, and system tables
+- 70+ new unit tests for object tree types, parent chains, search, system schemas, scripts/functions, virtual schemas, and constraints/indices
+
+### Changed
+- Extracted node type configuration into `objectTreeTypes.ts` for maintainability
+- CompletionProvider error logging uses output channel instead of console
+
 ## [1.2.0] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Visual Studio Code extension for working with Exasol databases. Provides datab
 - **Query execution** — full file or selection, cancellable, automatic LIMIT, multi-statement support
 - **Separate result tabs** — toggle via Command Palette to view each statement's result in its own tab
 - **IntelliSense** — context-aware completions for keywords, functions, tables, views, and columns
-- **Object explorer** — browse schemas, tables, views, and columns with row counts and types
+- **Object explorer** — browse schemas, tables, views, columns, scripts, functions, virtual schemas, constraints, indices, and system tables
 - **Object actions** — right-click to preview data, show DDL, generate SELECT, describe table
 - **Results viewer** — sortable, filterable grid with CSV export and cell inspection
 - **Query history** — automatic tracking with execution time, row counts, and error indicators
@@ -29,6 +29,7 @@ A Visual Studio Code extension for working with Exasol databases. Provides datab
 |--------|---------------|-----|
 | Execute query | `Ctrl+Enter` | `Cmd+Enter` |
 | Execute selection | `Ctrl+Shift+Enter` | `Cmd+Shift+Enter` |
+| Find database object | `Ctrl+Shift+F` (objects view) | `Cmd+Shift+F` (objects view) |
 
 ## Configuration
 
@@ -56,7 +57,7 @@ Press `F5` to launch the Extension Development Host.
 
 ```bash
 npm run watch        # Auto-compile on changes
-npm run test:unit    # Unit tests (122 tests)
+npm run test:unit    # Unit tests (192 tests)
 npm run test:local   # Webview rendering tests (jsdom)
 npm run test:e2e     # E2E tests (requires compile first)
 ```

--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
       {
         "command": "exasol.toggleSeparateResultTabs",
         "title": "Exasol: Toggle Separate Result Tabs"
+      },
+      {
+        "command": "exasol.findObject",
+        "title": "Exasol: Find Database Object",
+        "icon": "$(search)"
       }
     ],
     "viewsContainers": {
@@ -216,6 +221,11 @@
         },
         {
           "command": "exasol.refreshConnections",
+          "when": "view == exasol.objects",
+          "group": "navigation"
+        },
+        {
+          "command": "exasol.findObject",
           "when": "view == exasol.objects",
           "group": "navigation"
         },
@@ -344,6 +354,9 @@
         {
           "command": "exasol.formatQuery",
           "when": "editorLangId == exasol-sql"
+        },
+        {
+          "command": "exasol.findObject"
         }
       ]
     },
@@ -429,6 +442,12 @@
         "key": "ctrl+shift+enter",
         "mac": "cmd+shift+enter",
         "when": "editorTextFocus && editorLangId == exasol-sql"
+      },
+      {
+        "command": "exasol.findObject",
+        "key": "ctrl+shift+f",
+        "mac": "cmd+shift+f",
+        "when": "focusedView == exasol.objects"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Exasol",
   "icon": "resources/exasol-icon.png",
   "description": "Feature-rich Exasol database extension for Visual Studio Code with IntelliSense, object browser, query execution, and more",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "exasol",
   "license": "MIT",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { TabResultCollector } from './execution/tabResultCollector';
 import { ConnectionPanel } from './panels/connectionPanel';
 import { SessionManager } from './sessionManager';
 import { ObjectActions } from './objectActions';
+import { ObjectSearchProvider } from './providers/objectSearchProvider';
 import { findStatementAtCursor, splitIntoStatements } from './utils';
 
 // Create output channel for logging
@@ -89,6 +90,12 @@ export function activate(context: vscode.ExtensionContext) {
     const queryHistoryTreeView = vscode.window.createTreeView('exasol.queryHistory', {
         treeDataProvider: queryHistoryProvider,
         showCollapseAll: true
+    });
+
+    // Initialize object search provider
+    const objectSearchProvider = new ObjectSearchProvider(connectionManager, objectTreeProvider, objectTreeView);
+    const findObjectCmd = vscode.commands.registerCommand('exasol.findObject', () => {
+        objectSearchProvider.showSearch();
     });
 
     // Create status bar item for result tabs mode
@@ -373,6 +380,7 @@ export function activate(context: vscode.ExtensionContext) {
         setActiveConnectionCmd,
         copyQualifiedNameCmd,
         selectConnectionCmd,
+        findObjectCmd,
         toggleSeparateResultTabsCmd,
         resultTabsStatusBar,
         resultTabsConfigListener,

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
 import { ConnectionManager } from '../connectionManager';
+import { getOutputChannel } from '../extension';
 import { getRowsFromResult } from '../utils';
 
 interface DatabaseObject {
     schema: string;
     name: string;
-    type: 'table' | 'view';
+    type: 'table' | 'view' | 'script' | 'function' | 'virtual-table' | 'system-table';
     columns?: string[];
 }
 
@@ -282,13 +283,32 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
 
     private getObjectCompletions(objects: DatabaseObject[], skipQuoting = false): vscode.CompletionItem[] {
         return objects.map(obj => {
-            const kind = obj.type === 'table'
-                ? vscode.CompletionItemKind.Class
-                : vscode.CompletionItemKind.Interface;
+            let kind: vscode.CompletionItemKind;
+            switch (obj.type) {
+                case 'table':
+                case 'virtual-table':
+                case 'system-table':
+                    kind = vscode.CompletionItemKind.Class;
+                    break;
+                case 'view':
+                    kind = vscode.CompletionItemKind.Interface;
+                    break;
+                case 'script':
+                    kind = vscode.CompletionItemKind.Method;
+                    break;
+                case 'function':
+                    kind = vscode.CompletionItemKind.Function;
+                    break;
+                default:
+                    kind = vscode.CompletionItemKind.Class;
+            }
 
             const displayName = obj.name.toLowerCase();
             const item = new vscode.CompletionItem(displayName, kind);
-            item.detail = `${obj.type} in ${obj.schema.toLowerCase()}`;
+            const typeLabel = obj.type === 'virtual-table' ? 'virtual table'
+                : obj.type === 'system-table' ? 'system table'
+                : obj.type;
+            item.detail = `${typeLabel} in ${obj.schema.toLowerCase()}`;
             item.insertText = skipQuoting ? displayName : this.quoteIdentifier(obj.name);
             item.sortText = `1_${displayName}`;
 
@@ -332,6 +352,21 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                 const result = await this.safeQuery(driver, schemasQuery);
                 const rows = getRowsFromResult(result);
                 const schemas = rows.map((r: any) => r.SCHEMA_NAME);
+
+                schemas.push('SYS', 'EXA_STATISTICS');
+
+                try {
+                    const vsResult = await this.safeQuery(driver, 'SELECT SCHEMA_NAME FROM SYS.EXA_ALL_VIRTUAL_SCHEMAS ORDER BY SCHEMA_NAME');
+                    const vsRows = getRowsFromResult(vsResult);
+                    for (const row of vsRows) {
+                        if (!schemas.includes(row.SCHEMA_NAME)) {
+                            schemas.push(row.SCHEMA_NAME);
+                        }
+                    }
+                    schemas.sort();
+                } catch (error) {
+                    console.error('Failed to fetch virtual schemas for completions:', error);
+                }
 
                 // Cache schemas
                 this.schemasCache.set(connectionId, schemas);
@@ -397,15 +432,94 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                         columnsByTable.get(key)!.push(row.COLUMN_NAME);
                     }
                 } catch (error) {
-                    console.error('Failed to bulk-fetch columns:', error);
+                    getOutputChannel()?.appendLine(`Completions: Failed to bulk-fetch columns: ${error}`);
                 }
 
                 const objects: DatabaseObject[] = tableRows.map((row: any) => ({
                     schema: row.TABLE_SCHEMA,
                     name: row.TABLE_NAME,
-                    type: row.OBJECT_TYPE === 'view' ? 'view' : 'table',
+                    type: row.OBJECT_TYPE === 'view' ? 'view' as const : 'table' as const,
                     columns: columnsByTable.get(`${row.TABLE_SCHEMA}.${row.TABLE_NAME}`)
                 }));
+
+                try {
+                    const scriptsQuery = `
+                        SELECT SCRIPT_SCHEMA, SCRIPT_NAME
+                        FROM SYS.EXA_ALL_SCRIPTS
+                        WHERE SCRIPT_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                        ORDER BY SCRIPT_SCHEMA, SCRIPT_NAME
+                    `;
+                    const scriptResult = await this.safeQuery(driver, scriptsQuery);
+                    const scriptRows = getRowsFromResult(scriptResult);
+                    for (const row of scriptRows) {
+                        objects.push({
+                            schema: row.SCRIPT_SCHEMA,
+                            name: row.SCRIPT_NAME,
+                            type: 'script'
+                        });
+                    }
+                } catch (error) {
+                    getOutputChannel()?.appendLine(`Completions: Failed to fetch scripts: ${error}`);
+                }
+
+                try {
+                    const functionsQuery = `
+                        SELECT FUNCTION_SCHEMA, FUNCTION_NAME
+                        FROM SYS.EXA_ALL_FUNCTIONS
+                        WHERE FUNCTION_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                        ORDER BY FUNCTION_SCHEMA, FUNCTION_NAME
+                    `;
+                    const funcResult = await this.safeQuery(driver, functionsQuery);
+                    const funcRows = getRowsFromResult(funcResult);
+                    for (const row of funcRows) {
+                        objects.push({
+                            schema: row.FUNCTION_SCHEMA,
+                            name: row.FUNCTION_NAME,
+                            type: 'function'
+                        });
+                    }
+                } catch (error) {
+                    getOutputChannel()?.appendLine(`Completions: Failed to fetch functions: ${error}`);
+                }
+
+                try {
+                    const virtualTablesQuery = `
+                        SELECT TABLE_SCHEMA, TABLE_NAME
+                        FROM SYS.EXA_ALL_VIRTUAL_TABLES
+                        ORDER BY TABLE_SCHEMA, TABLE_NAME
+                    `;
+                    const vtResult = await this.safeQuery(driver, virtualTablesQuery);
+                    const vtRows = getRowsFromResult(vtResult);
+                    for (const row of vtRows) {
+                        objects.push({
+                            schema: row.TABLE_SCHEMA,
+                            name: row.TABLE_NAME,
+                            type: 'virtual-table'
+                        });
+                    }
+                } catch (error) {
+                    getOutputChannel()?.appendLine(`Completions: Failed to fetch virtual tables: ${error}`);
+                }
+
+                try {
+                    const systemTablesQuery = `
+                        SELECT SCHEMA_NAME AS TABLE_SCHEMA, OBJECT_NAME AS TABLE_NAME
+                        FROM SYS.EXA_SYSCAT
+                        WHERE SCHEMA_NAME IN ('SYS', 'EXA_STATISTICS')
+                        ORDER BY SCHEMA_NAME, OBJECT_NAME
+                    `;
+                    const stResult = await this.safeQuery(driver, systemTablesQuery);
+                    const stRows = getRowsFromResult(stResult);
+                    for (const row of stRows) {
+                        objects.push({
+                            schema: row.TABLE_SCHEMA,
+                            name: row.TABLE_NAME,
+                            type: 'system-table'
+                        });
+                    }
+                } catch (error) {
+                    getOutputChannel()?.appendLine(`Completions: Failed to fetch system tables: ${error}`);
+                }
 
                 // Update cache
                 this.cache.set(connectionId, objects);

--- a/src/providers/objectSearchProvider.ts
+++ b/src/providers/objectSearchProvider.ts
@@ -1,0 +1,395 @@
+import * as vscode from 'vscode';
+import { ConnectionManager } from '../connectionManager';
+import { getOutputChannel } from '../extension';
+import { getRowsFromResult } from '../utils';
+import { ObjectTreeProvider, ObjectTreeItem, ObjectNode } from './objectTreeProvider';
+import { getNodeTypeConfig, ObjectTreeItemType } from './objectTreeTypes';
+
+interface SearchableObject {
+    schema: string;
+    name: string;
+    type: ObjectTreeItemType;
+}
+
+type ObjectTreeView = vscode.TreeView<ObjectNode>;
+
+export class ObjectSearchProvider {
+    private readonly itemDataMap = new Map<vscode.QuickPickItem, SearchableObject>();
+
+    constructor(
+        private readonly connectionManager: ConnectionManager,
+        private readonly objectTreeProvider: ObjectTreeProvider,
+        private readonly treeView: ObjectTreeView
+    ) {}
+
+    async showSearch(): Promise<void> {
+        this.itemDataMap.clear();
+
+        const activeConnection = this.connectionManager.getActiveConnection();
+        if (!activeConnection) {
+            vscode.window.showInformationMessage('No active connection');
+            return;
+        }
+
+        const quickPick = vscode.window.createQuickPick();
+        quickPick.placeholder = 'Type to search database objects...';
+        quickPick.matchOnDescription = true;
+        quickPick.matchOnDetail = true;
+        quickPick.busy = true;
+
+        quickPick.show();
+
+        try {
+            const objects = await this.fetchAllObjects(activeConnection.id);
+            quickPick.items = objects.map(obj => this.toQuickPickItem(obj));
+            quickPick.busy = false;
+        } catch (error) {
+            const outputChannel = getOutputChannel();
+            const message = `Failed to fetch objects: ${error}`;
+            outputChannel?.appendLine(`Object search: ${message}`);
+            vscode.window.showErrorMessage(message);
+            quickPick.hide();
+            quickPick.dispose();
+            return;
+        }
+
+        quickPick.onDidAccept(async () => {
+            const selected = quickPick.selectedItems[0];
+            quickPick.hide();
+            quickPick.dispose();
+
+            if (selected) {
+                await this.revealInTree(selected);
+            }
+        });
+
+        quickPick.onDidHide(() => {
+            quickPick.dispose();
+        });
+    }
+
+    private async fetchAllObjects(connectionId: string): Promise<SearchableObject[]> {
+        return await this.connectionManager.executeWithRetry(async () => {
+            const driver = await this.connectionManager.getDriver(connectionId);
+            const objects: SearchableObject[] = [];
+
+            const tablesResult = await driver.query(`
+                SELECT TABLE_SCHEMA, TABLE_NAME, 'table' AS OBJECT_TYPE
+                FROM SYS.EXA_ALL_TABLES
+                WHERE TABLE_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                UNION ALL
+                SELECT VIEW_SCHEMA, VIEW_NAME, 'view'
+                FROM SYS.EXA_ALL_VIEWS
+                WHERE VIEW_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                ORDER BY 1, 2
+            `);
+            for (const row of getRowsFromResult(tablesResult)) {
+                objects.push({
+                    schema: row.TABLE_SCHEMA,
+                    name: row.TABLE_NAME,
+                    type: row.OBJECT_TYPE === 'view' ? 'view' : 'table'
+                });
+            }
+
+            try {
+                const scriptsResult = await driver.query(`
+                    SELECT SCRIPT_SCHEMA, SCRIPT_NAME
+                    FROM SYS.EXA_ALL_SCRIPTS
+                    WHERE SCRIPT_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                    ORDER BY SCRIPT_SCHEMA, SCRIPT_NAME
+                `);
+                for (const row of getRowsFromResult(scriptsResult)) {
+                    objects.push({
+                        schema: row.SCRIPT_SCHEMA,
+                        name: row.SCRIPT_NAME,
+                        type: 'script'
+                    });
+                }
+            } catch {
+                getOutputChannel()?.appendLine('Object search: Failed to fetch scripts');
+            }
+
+            try {
+                const functionsResult = await driver.query(`
+                    SELECT FUNCTION_SCHEMA, FUNCTION_NAME
+                    FROM SYS.EXA_ALL_FUNCTIONS
+                    WHERE FUNCTION_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                    ORDER BY FUNCTION_SCHEMA, FUNCTION_NAME
+                `);
+                for (const row of getRowsFromResult(functionsResult)) {
+                    objects.push({
+                        schema: row.FUNCTION_SCHEMA,
+                        name: row.FUNCTION_NAME,
+                        type: 'function'
+                    });
+                }
+            } catch {
+                getOutputChannel()?.appendLine('Object search: Failed to fetch functions');
+            }
+
+            try {
+                const virtualTablesResult = await driver.query(`
+                    SELECT TABLE_SCHEMA, TABLE_NAME
+                    FROM SYS.EXA_ALL_VIRTUAL_TABLES
+                    ORDER BY TABLE_SCHEMA, TABLE_NAME
+                `);
+                for (const row of getRowsFromResult(virtualTablesResult)) {
+                    objects.push({
+                        schema: row.TABLE_SCHEMA,
+                        name: row.TABLE_NAME,
+                        type: 'virtual-table'
+                    });
+                }
+            } catch {
+                getOutputChannel()?.appendLine('Object search: Failed to fetch virtual tables');
+            }
+
+            try {
+                const systemTablesResult = await driver.query(`
+                    SELECT SCHEMA_NAME AS TABLE_SCHEMA, OBJECT_NAME AS TABLE_NAME
+                    FROM SYS.EXA_SYSCAT
+                    WHERE SCHEMA_NAME IN ('SYS', 'EXA_STATISTICS')
+                    ORDER BY SCHEMA_NAME, OBJECT_NAME
+                `);
+                for (const row of getRowsFromResult(systemTablesResult)) {
+                    objects.push({
+                        schema: row.TABLE_SCHEMA,
+                        name: row.TABLE_NAME,
+                        type: 'system-table'
+                    });
+                }
+            } catch {
+                getOutputChannel()?.appendLine('Object search: Failed to fetch system tables');
+            }
+
+            try {
+                const columnsResult = await driver.query(`
+                    SELECT COLUMN_SCHEMA, COLUMN_TABLE, COLUMN_NAME
+                    FROM SYS.EXA_ALL_COLUMNS
+                    WHERE COLUMN_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
+                    ORDER BY COLUMN_SCHEMA, COLUMN_TABLE, COLUMN_ORDINAL_POSITION
+                `);
+                for (const row of getRowsFromResult(columnsResult)) {
+                    objects.push({
+                        schema: row.COLUMN_SCHEMA,
+                        name: row.COLUMN_NAME,
+                        type: 'column'
+                    });
+                }
+            } catch {
+                getOutputChannel()?.appendLine('Object search: Failed to fetch columns');
+            }
+
+            return objects;
+        }, connectionId);
+    }
+
+    private toQuickPickItem(obj: SearchableObject): vscode.QuickPickItem {
+        const config = getNodeTypeConfig(obj.type);
+        const iconId = config?.icon ?? 'symbol-misc';
+        const typeLabel = this.formatTypeLabel(obj.type);
+
+        const item: vscode.QuickPickItem = {
+            label: `$(${iconId}) ${obj.name}`,
+            description: obj.schema,
+            detail: typeLabel
+        };
+        this.itemDataMap.set(item, obj);
+        return item;
+    }
+
+    private formatTypeLabel(type: ObjectTreeItemType): string {
+        switch (type) {
+            case 'table': return 'Table';
+            case 'view': return 'View';
+            case 'script': return 'Script';
+            case 'function': return 'Function';
+            case 'virtual-table': return 'Virtual Table';
+            case 'system-table': return 'System Table';
+            case 'column': return 'Column';
+            default: return type;
+        }
+    }
+
+    private async revealInTree(item: vscode.QuickPickItem): Promise<void> {
+        const outputChannel = getOutputChannel();
+        const obj = this.itemDataMap.get(item);
+
+        if (!obj) {
+            return;
+        }
+
+        try {
+            const targetNode = await this.findTreeNode(obj.name, obj.schema, this.formatTypeLabel(obj.type));
+            if (targetNode) {
+                await this.treeView.reveal(targetNode, {
+                    select: true,
+                    focus: true,
+                    expand: true
+                });
+            } else {
+                outputChannel?.appendLine(
+                    `Object search: Could not find tree node for ${obj.schema}.${obj.name}`
+                );
+            }
+        } catch (error) {
+            outputChannel?.appendLine(`Object search: Failed to reveal in tree: ${error}`);
+        }
+    }
+
+    private async findTreeNode(
+        objectName: string,
+        schemaName: string,
+        typeLabel: string
+    ): Promise<ObjectTreeItem | undefined> {
+        const treeType = this.typeLabelToTreeType(typeLabel);
+        if (!treeType) {
+            return undefined;
+        }
+
+        const rootNodes = await this.objectTreeProvider.getChildren();
+        const schemaNode = await this.findSchemaNode(rootNodes, schemaName, treeType);
+        if (!schemaNode) {
+            return undefined;
+        }
+
+        if (treeType === 'system-table') {
+            return this.findChildByNameAndType(
+                await this.objectTreeProvider.getChildren(schemaNode),
+                objectName,
+                'system-table'
+            );
+        }
+
+        if (treeType === 'virtual-table') {
+            return this.findChildByNameAndType(
+                await this.objectTreeProvider.getChildren(schemaNode),
+                objectName,
+                'virtual-table'
+            );
+        }
+
+        const folderType = this.getFolderType(treeType);
+        if (!folderType) {
+            return undefined;
+        }
+
+        const schemaChildren = await this.objectTreeProvider.getChildren(schemaNode);
+        const folderNode = this.findChildByType(schemaChildren, folderType);
+        if (!folderNode) {
+            return undefined;
+        }
+
+        if (treeType === 'column') {
+            return this.findColumnInFolder(folderNode, objectName);
+        }
+
+        return this.findChildByNameAndType(
+            await this.objectTreeProvider.getChildren(folderNode),
+            objectName,
+            treeType
+        );
+    }
+
+    private async findSchemaNode(
+        rootNodes: Array<ObjectTreeItem | { label?: string | vscode.TreeItemLabel }>,
+        schemaName: string,
+        treeType: ObjectTreeItemType
+    ): Promise<ObjectTreeItem | undefined> {
+        if (treeType === 'system-table') {
+            const systemSchemasFolder = rootNodes.find(
+                node => node instanceof ObjectTreeItem && node.type === 'system-schemas-folder'
+            ) as ObjectTreeItem | undefined;
+
+            if (!systemSchemasFolder) {
+                return undefined;
+            }
+
+            const systemSchemas = await this.objectTreeProvider.getChildren(systemSchemasFolder);
+            return systemSchemas.find(
+                node => node instanceof ObjectTreeItem &&
+                    node.type === 'system-schema' &&
+                    node.schemaName === schemaName
+            ) as ObjectTreeItem | undefined;
+        }
+
+        return rootNodes.find(
+            node => node instanceof ObjectTreeItem &&
+                (node.type === 'schema' || node.type === 'virtual-schema') &&
+                node.schemaName === schemaName
+        ) as ObjectTreeItem | undefined;
+    }
+
+    private getFolderType(objectType: ObjectTreeItemType): ObjectTreeItemType | undefined {
+        switch (objectType) {
+            case 'table': return 'tables-folder';
+            case 'view': return 'views-folder';
+            case 'script': return 'udfs-folder';
+            case 'function': return 'functions-folder';
+            case 'column': return 'tables-folder';
+            default: return undefined;
+        }
+    }
+
+    private findChildByType(
+        children: Array<ObjectTreeItem | { label?: string | vscode.TreeItemLabel }>,
+        type: ObjectTreeItemType
+    ): ObjectTreeItem | undefined {
+        return children.find(
+            node => node instanceof ObjectTreeItem && node.type === type
+        ) as ObjectTreeItem | undefined;
+    }
+
+    private findChildByNameAndType(
+        children: Array<ObjectTreeItem | { label?: string | vscode.TreeItemLabel }>,
+        name: string,
+        type: ObjectTreeItemType
+    ): ObjectTreeItem | undefined {
+        return children.find(node => {
+            if (!(node instanceof ObjectTreeItem)) {
+                return false;
+            }
+            if (node.type !== type) {
+                return false;
+            }
+            const nodeLabel = typeof node.label === 'string' ? node.label : node.label?.label;
+            return nodeLabel === name;
+        }) as ObjectTreeItem | undefined;
+    }
+
+    private async findColumnInFolder(
+        folderNode: ObjectTreeItem,
+        columnName: string
+    ): Promise<ObjectTreeItem | undefined> {
+        const tables = await this.objectTreeProvider.getChildren(folderNode);
+        for (const table of tables) {
+            if (!(table instanceof ObjectTreeItem)) {
+                continue;
+            }
+            const columns = await this.objectTreeProvider.getChildren(table);
+            const match = columns.find(col => {
+                if (!(col instanceof ObjectTreeItem) || col.type !== 'column') {
+                    return false;
+                }
+                return col.columnInfo?.name === columnName;
+            });
+            if (match) {
+                return match as ObjectTreeItem;
+            }
+        }
+        return undefined;
+    }
+
+    private typeLabelToTreeType(typeLabel: string): ObjectTreeItemType | undefined {
+        switch (typeLabel) {
+            case 'Table': return 'table';
+            case 'View': return 'view';
+            case 'Script': return 'script';
+            case 'Function': return 'function';
+            case 'Virtual Table': return 'virtual-table';
+            case 'System Table': return 'system-table';
+            case 'Column': return 'column';
+            default: return undefined;
+        }
+    }
+}

--- a/src/providers/objectTreeProvider.ts
+++ b/src/providers/objectTreeProvider.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
 import { ConnectionManager, StoredConnection } from '../connectionManager';
 import { getOutputChannel } from '../extension';
-import { getRowsFromResult } from '../utils';
+import { getRowsFromResult, escapeSqlString } from '../utils';
+import { ObjectTreeItemType, getNodeTypeConfig } from './objectTreeTypes';
 
-type ObjectNode = ObjectTreeItem | ObjectMessageItem;
+export type ObjectNode = ObjectTreeItem | ObjectMessageItem;
 
 export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, vscode.TreeDragAndDropController<ObjectNode> {
     private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<ObjectNode | undefined | null | void>();
@@ -69,6 +70,13 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         return element;
     }
 
+    getParent(element: ObjectNode): ObjectTreeItem | null {
+        if (element instanceof ObjectTreeItem) {
+            return element.parent;
+        }
+        return null;
+    }
+
     async getChildren(element?: ObjectNode): Promise<ObjectNode[]> {
         const outputChannel = getOutputChannel();
 
@@ -87,23 +95,68 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
             // Directly show schemas without the connection node
             try {
                 outputChannel?.appendLine(`📂 Objects view: Fetching schemas for active connection '${activeConnection.name}'`);
-                const schemas = await this.fetchSchemas(activeConnection);
-                outputChannel?.appendLine(`📂 Objects view: Found ${schemas.length} schemas`);
-                return schemas.map(schema => {
+                const [schemas, virtualSchemas] = await Promise.all([
+                    this.fetchSchemas(activeConnection),
+                    this.fetchVirtualSchemas(activeConnection)
+                ]);
+                outputChannel?.appendLine(`📂 Objects view: Found ${schemas.length} schemas, ${virtualSchemas.length} virtual schemas`);
+
+                const schemaNodes: ObjectNode[] = schemas.map(schema => {
                     const id = `${activeConnection.id}:${schema.name}`;
-                    return new ObjectTreeItem(
-                        schema.name,
+                    return new ObjectTreeItem({
+                        label: schema.name,
                         id,
-                        vscode.TreeItemCollapsibleState.Collapsed,
-                        'schema',
-                        activeConnection,
-                        schema.name,
-                        undefined,
-                        undefined,
-                        schema.tableCount,
-                        schema.viewCount
-                    );
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'schema',
+                        connection: activeConnection,
+                        schemaName: schema.name,
+                        tableCount: schema.tableCount,
+                        viewCount: schema.viewCount
+                    });
                 });
+
+                const virtualSchemaNodes: ObjectNode[] = virtualSchemas.map(vs => {
+                    const id = `${activeConnection.id}:${vs.name}:virtual-schema`;
+                    const item = new ObjectTreeItem({
+                        label: vs.name,
+                        id,
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'virtual-schema',
+                        connection: activeConnection,
+                        schemaName: vs.name
+                    });
+                    if (vs.adapterName) {
+                        item.description = `via ${vs.adapterName}`;
+                    }
+                    if (vs.lastRefresh || vs.lastRefreshBy) {
+                        const parts: string[] = [];
+                        if (vs.lastRefresh) {
+                            parts.push(`Last refresh: ${vs.lastRefresh}`);
+                        }
+                        if (vs.lastRefreshBy) {
+                            parts.push(`Refreshed by: ${vs.lastRefreshBy}`);
+                        }
+                        item.tooltip = parts.join('\n');
+                    }
+                    return item;
+                });
+
+                const allNodes = [...schemaNodes, ...virtualSchemaNodes];
+                allNodes.sort((a, b) => {
+                    const labelA = (a as ObjectTreeItem).label as string;
+                    const labelB = (b as ObjectTreeItem).label as string;
+                    return labelA.localeCompare(labelB);
+                });
+
+                allNodes.push(new ObjectTreeItem({
+                    label: 'System Schemas',
+                    id: `${activeConnection.id}:system-schemas-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'system-schemas-folder',
+                    connection: activeConnection
+                }));
+
+                return allNodes;
             } catch (error) {
                 const message = `Failed to fetch schemas: ${error}`;
                 outputChannel?.appendLine(`❌ Objects view: ${message}`);
@@ -117,31 +170,92 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         }
 
         if (element.type === 'schema') {
-            return [
-                new ObjectTreeItem(
-                    'Tables',
-                    `${element.connection!.id}:${element.schemaName}:tables-folder`,
-                    vscode.TreeItemCollapsibleState.Collapsed,
-                    'tables-folder',
-                    element.connection,
-                    element.schemaName,
-                    undefined,
-                    undefined,
-                    element.tableCount
-                ),
-                new ObjectTreeItem(
-                    'Views',
-                    `${element.connection!.id}:${element.schemaName}:views-folder`,
-                    vscode.TreeItemCollapsibleState.Collapsed,
-                    'views-folder',
-                    element.connection,
-                    element.schemaName,
-                    undefined,
-                    undefined,
-                    undefined,
-                    element.viewCount
-                )
+            const connId = element.connection!.id;
+            const schema = element.schemaName!;
+
+            const [scriptCounts, functionCount] = await Promise.all([
+                this.fetchScriptCounts(element.connection!, schema),
+                this.fetchFunctionCount(element.connection!, schema)
+            ]);
+
+            const children: ObjectNode[] = [
+                new ObjectTreeItem({
+                    label: 'Tables',
+                    id: `${connId}:${schema}:tables-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'tables-folder',
+                    connection: element.connection,
+                    schemaName: schema,
+                    tableCount: element.tableCount,
+                    parent: element
+                }),
+                new ObjectTreeItem({
+                    label: 'Views',
+                    id: `${connId}:${schema}:views-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'views-folder',
+                    connection: element.connection,
+                    schemaName: schema,
+                    viewCount: element.viewCount,
+                    parent: element
+                })
             ];
+
+            const udfCount = scriptCounts.get('UDF') ?? 0;
+            if (udfCount > 0) {
+                children.push(new ObjectTreeItem({
+                    label: 'UDFs',
+                    id: `${connId}:${schema}:udfs-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'udfs-folder',
+                    connection: element.connection,
+                    schemaName: schema,
+                    itemCount: udfCount,
+                    parent: element
+                }));
+            }
+
+            const procCount = scriptCounts.get('SCRIPTING') ?? 0;
+            if (procCount > 0) {
+                children.push(new ObjectTreeItem({
+                    label: 'Procedures',
+                    id: `${connId}:${schema}:procedures-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'procedures-folder',
+                    connection: element.connection,
+                    schemaName: schema,
+                    itemCount: procCount,
+                    parent: element
+                }));
+            }
+
+            const adapterCount = scriptCounts.get('ADAPTER') ?? 0;
+            if (adapterCount > 0) {
+                children.push(new ObjectTreeItem({
+                    label: 'Adapters',
+                    id: `${connId}:${schema}:adapters-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'adapters-folder',
+                    connection: element.connection,
+                    schemaName: schema,
+                    parent: element
+                }));
+            }
+
+            if (functionCount > 0) {
+                children.push(new ObjectTreeItem({
+                    label: 'Functions',
+                    id: `${connId}:${schema}:functions-folder`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'functions-folder',
+                    connection: element.connection,
+                    schemaName: schema,
+                    itemCount: functionCount,
+                    parent: element
+                }));
+            }
+
+            return children;
         }
 
         if (element.type === 'tables-folder') {
@@ -151,15 +265,16 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                 outputChannel?.appendLine(`📋 Objects view: Found ${tables.length} tables`);
                 return tables.map(table => {
                     const id = `${element.connection!.id}:${element.schemaName}:${table.name}:table`;
-                    return new ObjectTreeItem(
-                        table.name,
+                    return new ObjectTreeItem({
+                        label: table.name,
                         id,
-                        vscode.TreeItemCollapsibleState.Collapsed,
-                        'table',
-                        element.connection,
-                        element.schemaName,
-                        table
-                    );
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'table',
+                        connection: element.connection,
+                        schemaName: element.schemaName,
+                        tableInfo: table,
+                        parent: element
+                    });
                 });
             } catch (error) {
                 const message = `Failed to fetch tables: ${error}`;
@@ -176,15 +291,16 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                 outputChannel?.appendLine(`👁️ Objects view: Found ${views.length} views`);
                 return views.map(view => {
                     const id = `${element.connection!.id}:${element.schemaName}:${view.name}:view`;
-                    return new ObjectTreeItem(
-                        view.name,
+                    return new ObjectTreeItem({
+                        label: view.name,
                         id,
-                        vscode.TreeItemCollapsibleState.Collapsed,
-                        'view',
-                        element.connection,
-                        element.schemaName,
-                        view
-                    );
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'view',
+                        connection: element.connection,
+                        schemaName: element.schemaName,
+                        tableInfo: view,
+                        parent: element
+                    });
                 });
             } catch (error) {
                 const message = `Failed to fetch views: ${error}`;
@@ -194,30 +310,175 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
             }
         }
 
+        if (element.type === 'udfs-folder') {
+            return this.getScriptFolderChildren(element, 'UDF');
+        }
+
+        if (element.type === 'procedures-folder') {
+            return this.getScriptFolderChildren(element, 'SCRIPTING');
+        }
+
+        if (element.type === 'adapters-folder') {
+            return this.getScriptFolderChildren(element, 'ADAPTER');
+        }
+
+        if (element.type === 'functions-folder') {
+            try {
+                outputChannel?.appendLine(`Objects view: Fetching functions for '${element.schemaName}'`);
+                const functions = await this.fetchFunctions(element.connection!, element.schemaName!);
+                outputChannel?.appendLine(`Objects view: Found ${functions.length} functions`);
+                return functions.map(fn => new ObjectTreeItem({
+                    label: fn.name,
+                    id: `${element.connection!.id}:${element.schemaName}:${fn.name}:function`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    type: 'function',
+                    connection: element.connection,
+                    schemaName: element.schemaName,
+                    functionInfo: fn,
+                    parent: element
+                }));
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch functions: ${error}`);
+                return [];
+            }
+        }
+
+        if (element.type === 'constraints-folder') {
+            try {
+                const constraints = await this.fetchConstraints(
+                    element.connection!, element.schemaName!, element.tableInfo!.name
+                );
+                return constraints.map(c => new ObjectTreeItem({
+                    label: c.name,
+                    id: `${element.connection!.id}:${element.schemaName}:${element.tableInfo!.name}:${c.name}:constraint`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'constraint',
+                    connection: element.connection,
+                    schemaName: element.schemaName,
+                    tableInfo: element.tableInfo,
+                    constraintType: c.type,
+                    parent: element
+                }));
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch constraints: ${error}`);
+                return [];
+            }
+        }
+
+        if (element.type === 'indices-folder') {
+            try {
+                const indices = await this.fetchIndices(
+                    element.connection!, element.schemaName!, element.tableInfo!.name
+                );
+                return indices.map(idx => {
+                    const item = new ObjectTreeItem({
+                        label: idx.name,
+                        id: `${element.connection!.id}:${element.schemaName}:${element.tableInfo!.name}:${idx.name}:index`,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        type: 'index',
+                        connection: element.connection,
+                        schemaName: element.schemaName,
+                        tableInfo: element.tableInfo,
+                        parent: element
+                    });
+                    item.description = idx.columns;
+                    return item;
+                });
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch indices: ${error}`);
+                return [];
+            }
+        }
+
+        if (element.type === 'constraint') {
+            try {
+                const columns = await this.fetchConstraintColumns(
+                    element.connection!, element.schemaName!, element.tableInfo!.name, element.label as string
+                );
+                return columns.map(col => new ObjectTreeItem({
+                    label: col.name,
+                    id: `${element.connection!.id}:${element.schemaName}:${element.tableInfo!.name}:${element.label}:${col.name}:constraint-column`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    type: 'column',
+                    connection: element.connection,
+                    schemaName: element.schemaName,
+                    parent: element
+                }));
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch constraint columns: ${error}`);
+                return [];
+            }
+        }
+
         if (element.type === 'table' || element.type === 'view') {
+            const connId = element.connection!.id;
+            const schema = element.schemaName!;
+            const tableName = element.tableInfo!.name;
+
+            let constraintCount = 0;
+            let indexCount = 0;
+
+            try {
+                [constraintCount, indexCount] = await Promise.all([
+                    this.fetchConstraintCount(element.connection!, schema, tableName),
+                    this.fetchIndexCount(element.connection!, schema, tableName)
+                ]);
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch constraint/index counts: ${error}`);
+            }
+
             try {
                 outputChannel?.appendLine(
-                    `📊 Objects view: Fetching columns for ${element.type} '${element.tableInfo!.name}'`
+                    `📊 Objects view: Fetching columns for ${element.type} '${tableName}'`
                 );
                 const columns = await this.fetchColumns(
                     element.connection!,
-                    element.schemaName!,
-                    element.tableInfo!.name
+                    schema,
+                    tableName
                 );
                 outputChannel?.appendLine(`📊 Objects view: Found ${columns.length} columns`);
-                return columns.map(col => {
-                    const id = `${element.connection!.id}:${element.schemaName}:${element.tableInfo!.name}:${col.name}:column`;
-                    return new ObjectTreeItem(
-                        `${col.name} (${col.type})`,
+                const children: ObjectNode[] = columns.map(col => {
+                    const id = `${connId}:${schema}:${tableName}:${col.name}:column`;
+                    return new ObjectTreeItem({
+                        label: `${col.name} (${col.type})`,
                         id,
-                        vscode.TreeItemCollapsibleState.None,
-                        'column',
-                        element.connection,
-                        element.schemaName,
-                        undefined,
-                        col
-                    );
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        type: 'column',
+                        connection: element.connection,
+                        schemaName: element.schemaName,
+                        columnInfo: col,
+                        parent: element
+                    });
                 });
+
+                if (constraintCount > 0) {
+                    children.push(new ObjectTreeItem({
+                        label: 'Constraints',
+                        id: `${connId}:${schema}:${tableName}:constraints-folder`,
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'constraints-folder',
+                        connection: element.connection,
+                        schemaName: schema,
+                        tableInfo: element.tableInfo,
+                        constraintCount,
+                        parent: element
+                    }));
+                }
+
+                if (indexCount > 0) {
+                    children.push(new ObjectTreeItem({
+                        label: 'Indices',
+                        id: `${connId}:${schema}:${tableName}:indices-folder`,
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'indices-folder',
+                        connection: element.connection,
+                        schemaName: schema,
+                        tableInfo: element.tableInfo,
+                        parent: element
+                    }));
+                }
+
+                return children;
             } catch (error) {
                 const message = `Failed to fetch columns: ${error}`;
                 outputChannel?.appendLine(`❌ Objects view: ${message}`);
@@ -226,7 +487,141 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
             }
         }
 
+        if (element.type === 'virtual-schema') {
+            try {
+                outputChannel?.appendLine(`Objects view: Fetching virtual tables for '${element.schemaName}'`);
+                const tables = await this.fetchVirtualTables(element.connection!, element.schemaName!);
+                outputChannel?.appendLine(`Objects view: Found ${tables.length} virtual tables`);
+                return tables.map(table => {
+                    const id = `${element.connection!.id}:${element.schemaName}:${table.name}:virtual-table`;
+                    return new ObjectTreeItem({
+                        label: table.name,
+                        id,
+                        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                        type: 'virtual-table',
+                        connection: element.connection,
+                        schemaName: element.schemaName,
+                        tableInfo: { name: table.name },
+                        parent: element
+                    });
+                });
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch virtual tables: ${error}`);
+                return [];
+            }
+        }
+
+        if (element.type === 'virtual-table') {
+            try {
+                outputChannel?.appendLine(
+                    `Objects view: Fetching virtual columns for '${element.schemaName}'.'${element.tableInfo!.name}'`
+                );
+                const columns = await this.fetchVirtualColumns(
+                    element.connection!, element.schemaName!, element.tableInfo!.name
+                );
+                outputChannel?.appendLine(`Objects view: Found ${columns.length} virtual columns`);
+                return columns.map(col => {
+                    const id = `${element.connection!.id}:${element.schemaName}:${element.tableInfo!.name}:${col.name}:column`;
+                    return new ObjectTreeItem({
+                        label: `${col.name} (${col.type})`,
+                        id,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        type: 'column',
+                        connection: element.connection,
+                        schemaName: element.schemaName,
+                        columnInfo: { name: col.name, type: col.type, nullable: false },
+                        parent: element
+                    });
+                });
+            } catch (error) {
+                outputChannel?.appendLine(`Failed to fetch virtual columns: ${error}`);
+                return [];
+            }
+        }
+
+        if (element.type === 'system-schemas-folder') {
+            const connId = element.connection!.id;
+            return [
+                new ObjectTreeItem({
+                    label: 'SYS',
+                    id: `${connId}:SYS:system-schema`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'system-schema',
+                    connection: element.connection,
+                    schemaName: 'SYS',
+                    parent: element
+                }),
+                new ObjectTreeItem({
+                    label: 'EXA_STATISTICS',
+                    id: `${connId}:EXA_STATISTICS:system-schema`,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'system-schema',
+                    connection: element.connection,
+                    schemaName: 'EXA_STATISTICS',
+                    parent: element
+                })
+            ];
+        }
+
+        if (element.type === 'system-schema') {
+            const tables = await this.fetchSystemTables(element.connection!, element.schemaName!);
+            return tables.map(table => {
+                const id = `${element.connection!.id}:${element.schemaName}:${table.name}:system-table`;
+                return new ObjectTreeItem({
+                    label: table.name,
+                    id,
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    type: 'system-table',
+                    connection: element.connection,
+                    schemaName: element.schemaName,
+                    tableInfo: { name: table.name },
+                    parent: element
+                });
+            });
+        }
+
+        if (element.type === 'system-table') {
+            const columns = await this.fetchSystemTableColumns(
+                element.connection!, element.schemaName!, element.tableInfo!.name
+            );
+            return columns.map(col => {
+                const id = `${element.connection!.id}:${element.schemaName}:${element.tableInfo!.name}:${col.name}:column`;
+                return new ObjectTreeItem({
+                    label: `${col.name} (${col.type})`,
+                    id,
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    type: 'column',
+                    connection: element.connection,
+                    schemaName: element.schemaName,
+                    columnInfo: { name: col.name, type: col.type, nullable: false },
+                    parent: element
+                });
+            });
+        }
+
         return [];
+    }
+
+    private async getScriptFolderChildren(element: ObjectTreeItem, scriptType: string): Promise<ObjectNode[]> {
+        const outputChannel = getOutputChannel();
+        try {
+            const scripts = await this.fetchScripts(element.connection!, element.schemaName!, scriptType);
+            outputChannel?.appendLine(`Objects view: Found ${scripts.length} ${scriptType} scripts`);
+            return scripts.map(script => new ObjectTreeItem({
+                label: script.name,
+                id: `${element.connection!.id}:${element.schemaName}:${script.name}:script`,
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                type: 'script',
+                connection: element.connection,
+                schemaName: element.schemaName,
+                scriptType,
+                scriptInfo: script,
+                parent: element
+            }));
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch ${scriptType} scripts: ${error}`);
+            return [];
+        }
     }
 
     private async fetchSchemas(connection: StoredConnection): Promise<Array<{ name: string; tableCount?: number; viewCount?: number }>> {
@@ -308,7 +703,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                             TABLE_NAME,
                             TABLE_ROW_COUNT
                         FROM SYS.EXA_ALL_TABLES
-                        WHERE TABLE_SCHEMA = '${schemaName}'
+                        WHERE TABLE_SCHEMA = '${escapeSqlString(schemaName)}'
                         ORDER BY TABLE_NAME
                     `,
                     map: rows => rows.map((row: any) => ({
@@ -324,7 +719,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                     sql: `
                         SELECT TABLE_NAME
                         FROM SYS.EXA_ALL_TABLES
-                        WHERE TABLE_SCHEMA = '${schemaName}'
+                        WHERE TABLE_SCHEMA = '${escapeSqlString(schemaName)}'
                         ORDER BY TABLE_NAME
                     `,
                     map: rows => rows.map((row: any) => ({
@@ -339,7 +734,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                     sql: `
                         SELECT OBJECT_NAME AS TABLE_NAME
                         FROM SYS.EXA_ALL_OBJECTS
-                        WHERE OBJECT_SCHEMA = '${schemaName}'
+                        WHERE OBJECT_SCHEMA = '${escapeSqlString(schemaName)}'
                         AND OBJECT_TYPE = 'TABLE'
                         ORDER BY OBJECT_NAME
                     `,
@@ -355,7 +750,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                     sql: `
                         SELECT DISTINCT COLUMN_TABLE AS TABLE_NAME
                         FROM SYS.EXA_ALL_COLUMNS
-                        WHERE COLUMN_SCHEMA = '${schemaName}'
+                        WHERE COLUMN_SCHEMA = '${escapeSqlString(schemaName)}'
                         AND (COLUMN_OBJECT_TYPE = 'TABLE' OR COLUMN_OBJECT_TYPE IS NULL)
                         ORDER BY COLUMN_TABLE
                     `,
@@ -414,7 +809,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                     sql: `
                         SELECT TABLE_NAME AS VIEW_NAME
                         FROM SYS.EXA_ALL_VIEWS
-                        WHERE VIEW_SCHEMA = '${schemaName}'
+                        WHERE VIEW_SCHEMA = '${escapeSqlString(schemaName)}'
                         ORDER BY TABLE_NAME
                     `,
                     map: rows => rows.map((row: any) => ({ name: row.VIEW_NAME ?? row.TABLE_NAME })),
@@ -429,7 +824,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                         SELECT
                             OBJECT_NAME AS VIEW_NAME
                         FROM SYS.EXA_ALL_OBJECTS
-                        WHERE OBJECT_SCHEMA = '${schemaName}'
+                        WHERE OBJECT_SCHEMA = '${escapeSqlString(schemaName)}'
                         AND OBJECT_TYPE = 'VIEW'
                         ORDER BY OBJECT_NAME
                     `,
@@ -446,7 +841,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                         SELECT DISTINCT
                             COLUMN_TABLE AS VIEW_NAME
                         FROM SYS.EXA_ALL_COLUMNS
-                        WHERE COLUMN_SCHEMA = '${schemaName}'
+                        WHERE COLUMN_SCHEMA = '${escapeSqlString(schemaName)}'
                         AND (
                             COLUMN_OBJECT_TYPE IS NULL OR
                             COLUMN_OBJECT_TYPE = 'VIEW' OR
@@ -505,8 +900,8 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                         COLUMN_TYPE,
                         COLUMN_IS_NULLABLE
                     FROM SYS.EXA_ALL_COLUMNS
-                    WHERE COLUMN_SCHEMA = '${schemaName}'
-                    AND COLUMN_TABLE = '${tableName}'
+                    WHERE COLUMN_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND COLUMN_TABLE = '${escapeSqlString(tableName)}'
                     ORDER BY COLUMN_ORDINAL_POSITION
                 `);
                 const rows = getRowsFromResult(result);
@@ -518,6 +913,393 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
             }, connection.id);
         } catch (error) {
             throw new Error(`Failed to fetch columns: ${error}`);
+        }
+    }
+
+    private async fetchScriptCounts(
+        connection: StoredConnection,
+        schemaName: string
+    ): Promise<Map<string, number>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT SCRIPT_TYPE, COUNT(*) AS SCRIPT_COUNT
+                    FROM SYS.EXA_ALL_SCRIPTS
+                    WHERE SCRIPT_SCHEMA = '${escapeSqlString(schemaName)}'
+                    GROUP BY SCRIPT_TYPE
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                const counts = new Map<string, number>();
+                for (const row of rows) {
+                    const scriptType = row.SCRIPT_TYPE as string;
+                    const count = this.parseRowCount(row.SCRIPT_COUNT) ?? 0;
+                    if (scriptType && count > 0) {
+                        counts.set(scriptType, count);
+                    }
+                }
+                return counts;
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch script counts for '${schemaName}': ${error}`);
+            return new Map();
+        }
+    }
+
+    private async fetchFunctionCount(
+        connection: StoredConnection,
+        schemaName: string
+    ): Promise<number> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT COUNT(*) AS FUNCTION_COUNT
+                    FROM SYS.EXA_ALL_FUNCTIONS
+                    WHERE FUNCTION_SCHEMA = '${escapeSqlString(schemaName)}'
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                if (rows.length > 0) {
+                    return this.parseRowCount(rows[0].FUNCTION_COUNT) ?? 0;
+                }
+                return 0;
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch function count for '${schemaName}': ${error}`);
+            return 0;
+        }
+    }
+
+    private async fetchScripts(
+        connection: StoredConnection,
+        schemaName: string,
+        scriptType: string
+    ): Promise<Array<{ name: string; language: string; inputType: string | null; scriptType: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT
+                        SCRIPT_NAME,
+                        SCRIPT_LANGUAGE,
+                        SCRIPT_INPUT_TYPE,
+                        SCRIPT_TYPE
+                    FROM SYS.EXA_ALL_SCRIPTS
+                    WHERE SCRIPT_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND SCRIPT_TYPE = '${escapeSqlString(scriptType)}'
+                    ORDER BY SCRIPT_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.SCRIPT_NAME,
+                    language: row.SCRIPT_LANGUAGE,
+                    inputType: row.SCRIPT_INPUT_TYPE ?? null,
+                    scriptType: row.SCRIPT_TYPE
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch scripts (${scriptType}) for '${schemaName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchFunctions(
+        connection: StoredConnection,
+        schemaName: string
+    ): Promise<Array<{ name: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT FUNCTION_NAME
+                    FROM SYS.EXA_ALL_FUNCTIONS
+                    WHERE FUNCTION_SCHEMA = '${escapeSqlString(schemaName)}'
+                    ORDER BY FUNCTION_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.FUNCTION_NAME
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch functions for '${schemaName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchConstraintCount(
+        connection: StoredConnection,
+        schemaName: string,
+        tableName: string
+    ): Promise<number> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT COUNT(*) AS CONSTRAINT_COUNT
+                    FROM SYS.EXA_ALL_CONSTRAINTS
+                    WHERE CONSTRAINT_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND CONSTRAINT_TABLE = '${escapeSqlString(tableName)}'
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                if (rows.length > 0) {
+                    return this.parseRowCount(rows[0].CONSTRAINT_COUNT) ?? 0;
+                }
+                return 0;
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch constraint count for '${schemaName}'.'${tableName}': ${error}`);
+            return 0;
+        }
+    }
+
+    private async fetchIndexCount(
+        connection: StoredConnection,
+        schemaName: string,
+        tableName: string
+    ): Promise<number> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT COUNT(*) AS INDEX_COUNT
+                    FROM SYS.EXA_ALL_INDICES
+                    WHERE INDEX_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND INDEX_TABLE = '${escapeSqlString(tableName)}'
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                if (rows.length > 0) {
+                    return this.parseRowCount(rows[0].INDEX_COUNT) ?? 0;
+                }
+                return 0;
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch index count for '${schemaName}'.'${tableName}': ${error}`);
+            return 0;
+        }
+    }
+
+    private async fetchConstraints(
+        connection: StoredConnection,
+        schemaName: string,
+        tableName: string
+    ): Promise<Array<{ name: string; type: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT CONSTRAINT_NAME, CONSTRAINT_TYPE
+                    FROM SYS.EXA_ALL_CONSTRAINTS
+                    WHERE CONSTRAINT_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND CONSTRAINT_TABLE = '${escapeSqlString(tableName)}'
+                    ORDER BY CONSTRAINT_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.CONSTRAINT_NAME,
+                    type: row.CONSTRAINT_TYPE
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch constraints for '${schemaName}'.'${tableName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchConstraintColumns(
+        connection: StoredConnection,
+        schemaName: string,
+        tableName: string,
+        constraintName: string
+    ): Promise<Array<{ name: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT COLUMN_NAME, ORDINAL_POSITION
+                    FROM SYS.EXA_ALL_CONSTRAINT_COLUMNS
+                    WHERE CONSTRAINT_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND CONSTRAINT_TABLE = '${escapeSqlString(tableName)}'
+                    AND CONSTRAINT_NAME = '${escapeSqlString(constraintName)}'
+                    ORDER BY ORDINAL_POSITION
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.COLUMN_NAME
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch constraint columns for '${constraintName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchIndices(
+        connection: StoredConnection,
+        schemaName: string,
+        tableName: string
+    ): Promise<Array<{ name: string; columns: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT INDEX_NAME, INDEX_TYPE, INDEX_COLUMNS
+                    FROM SYS.EXA_ALL_INDICES
+                    WHERE INDEX_SCHEMA = '${escapeSqlString(schemaName)}'
+                    AND INDEX_TABLE = '${escapeSqlString(tableName)}'
+                    ORDER BY INDEX_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.INDEX_NAME ?? row.INDEX_TYPE ?? 'INDEX',
+                    columns: row.INDEX_COLUMNS ?? ''
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch indices for '${schemaName}'.'${tableName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchVirtualSchemas(
+        connection: StoredConnection
+    ): Promise<Array<{ name: string; adapterName?: string; lastRefresh?: string; lastRefreshBy?: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT
+                        SCHEMA_NAME,
+                        ADAPTER_SCRIPT_SCHEMA,
+                        ADAPTER_SCRIPT_NAME,
+                        LAST_REFRESH,
+                        LAST_REFRESH_BY
+                    FROM SYS.EXA_ALL_VIRTUAL_SCHEMAS
+                    ORDER BY SCHEMA_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.SCHEMA_NAME,
+                    adapterName: row.ADAPTER_SCRIPT_NAME ?? undefined,
+                    lastRefresh: row.LAST_REFRESH ?? undefined,
+                    lastRefreshBy: row.LAST_REFRESH_BY ?? undefined
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch virtual schemas: ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchVirtualTables(
+        connection: StoredConnection,
+        virtualSchemaName: string
+    ): Promise<Array<{ name: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT TABLE_NAME
+                    FROM SYS.EXA_ALL_VIRTUAL_TABLES
+                    WHERE TABLE_SCHEMA = '${escapeSqlString(virtualSchemaName)}'
+                    ORDER BY TABLE_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.TABLE_NAME
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch virtual tables for '${virtualSchemaName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchVirtualColumns(
+        connection: StoredConnection,
+        virtualSchemaName: string,
+        tableName: string
+    ): Promise<Array<{ name: string; type: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT COLUMN_NAME, COLUMN_TYPE
+                    FROM SYS.EXA_ALL_VIRTUAL_COLUMNS
+                    WHERE COLUMN_SCHEMA = '${escapeSqlString(virtualSchemaName)}'
+                    AND COLUMN_TABLE = '${escapeSqlString(tableName)}'
+                    ORDER BY COLUMN_ORDINAL_POSITION
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.COLUMN_NAME,
+                    type: row.COLUMN_TYPE
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch virtual columns for '${virtualSchemaName}'.'${tableName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchSystemTables(
+        connection: StoredConnection,
+        schemaName: string
+    ): Promise<Array<{ name: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    SELECT OBJECT_NAME
+                    FROM SYS.EXA_SYSCAT
+                    WHERE SCHEMA_NAME = '${escapeSqlString(schemaName)}'
+                    ORDER BY OBJECT_NAME
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.OBJECT_NAME
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch system tables for '${schemaName}': ${error}`);
+            return [];
+        }
+    }
+
+    private async fetchSystemTableColumns(
+        connection: StoredConnection,
+        schemaName: string,
+        tableName: string
+    ): Promise<Array<{ name: string; type: string }>> {
+        const outputChannel = getOutputChannel();
+        try {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id);
+                const result = await driver.query(`
+                    DESCRIBE "${escapeSqlString(schemaName)}"."${escapeSqlString(tableName)}"
+                `, undefined, undefined, 'raw');
+                const rows = getRowsFromResult(result);
+                return rows.map((row: any) => ({
+                    name: row.COLUMN_NAME,
+                    type: row.SQL_TYPE ?? 'UNKNOWN'
+                }));
+            }, connection.id);
+        } catch (error) {
+            outputChannel?.appendLine(`Failed to fetch system table columns for '${schemaName}'.'${tableName}': ${error}`);
+            return [];
         }
     }
 
@@ -564,54 +1346,94 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
     }
 }
 
-class ObjectTreeItem extends vscode.TreeItem {
-    constructor(
-        public readonly label: string,
-        public readonly id: string,
-        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
-        public readonly type: 'schema' | 'tables-folder' | 'table' | 'views-folder' | 'view' | 'column',
-        public readonly connection?: StoredConnection,
-        public readonly schemaName?: string,
-        public readonly tableInfo?: { name: string; rowCount?: number },
-        public readonly columnInfo?: { name: string; type: string; nullable: boolean },
-        public readonly tableCount?: number,
-        public readonly viewCount?: number
-    ) {
-        super(label, collapsibleState);
-        this.id = id;
+interface ObjectTreeItemOptions {
+    label: string;
+    id: string;
+    collapsibleState: vscode.TreeItemCollapsibleState;
+    type: ObjectTreeItemType;
+    connection?: StoredConnection;
+    schemaName?: string;
+    tableInfo?: { name: string; rowCount?: number };
+    columnInfo?: { name: string; type: string; nullable: boolean };
+    tableCount?: number;
+    viewCount?: number;
+    constraintCount?: number;
+    scriptType?: string;
+    constraintType?: string;
+    itemCount?: number;
+    scriptInfo?: { name: string; language: string; inputType: string | null; scriptType: string };
+    functionInfo?: { name: string };
+    parent?: ObjectTreeItem | null;
+}
 
-        switch (type) {
+export class ObjectTreeItem extends vscode.TreeItem {
+    public readonly type: ObjectTreeItemType;
+    public readonly connection?: StoredConnection;
+    public readonly schemaName?: string;
+    public readonly tableInfo?: { name: string; rowCount?: number };
+    public readonly columnInfo?: { name: string; type: string; nullable: boolean };
+    public readonly tableCount?: number;
+    public readonly viewCount?: number;
+    public readonly constraintCount?: number;
+    public readonly scriptType?: string;
+    public readonly constraintType?: string;
+    public readonly itemCount?: number;
+    public readonly scriptInfo?: { name: string; language: string; inputType: string | null; scriptType: string };
+    public readonly functionInfo?: { name: string };
+    public readonly parent: ObjectTreeItem | null;
+
+    constructor(options: ObjectTreeItemOptions) {
+        super(options.label, options.collapsibleState);
+        this.id = options.id;
+        this.type = options.type;
+        this.connection = options.connection;
+        this.schemaName = options.schemaName;
+        this.tableInfo = options.tableInfo;
+        this.columnInfo = options.columnInfo;
+        this.tableCount = options.tableCount;
+        this.viewCount = options.viewCount;
+        this.constraintCount = options.constraintCount;
+        this.scriptType = options.scriptType;
+        this.constraintType = options.constraintType;
+        this.itemCount = options.itemCount;
+        this.scriptInfo = options.scriptInfo;
+        this.functionInfo = options.functionInfo;
+        this.parent = options.parent ?? null;
+
+        const config = getNodeTypeConfig(options.type, {
+            scriptType: this.scriptType,
+            constraintType: this.constraintType
+        });
+        if (config) {
+            this.iconPath = new vscode.ThemeIcon(config.icon);
+            this.contextValue = config.contextValue;
+        }
+
+        switch (options.type) {
             case 'schema':
-                this.iconPath = new vscode.ThemeIcon('symbol-namespace');
-                this.contextValue = 'schema';
-                // Display table and view counts
-                if (tableCount !== undefined || viewCount !== undefined) {
+                if (this.tableCount !== undefined || this.viewCount !== undefined) {
                     const parts: string[] = [];
-                    if (tableCount !== undefined && tableCount > 0) {
-                        parts.push(`${tableCount} ${tableCount === 1 ? 'table' : 'tables'}`);
+                    if (this.tableCount !== undefined && this.tableCount > 0) {
+                        parts.push(`${this.tableCount} ${this.tableCount === 1 ? 'table' : 'tables'}`);
                     }
-                    if (viewCount !== undefined && viewCount > 0) {
-                        parts.push(`${viewCount} ${viewCount === 1 ? 'view' : 'views'}`);
+                    if (this.viewCount !== undefined && this.viewCount > 0) {
+                        parts.push(`${this.viewCount} ${this.viewCount === 1 ? 'view' : 'views'}`);
                     }
                     if (parts.length > 0) {
                         this.description = parts.join(', ');
-                    } else if (tableCount === 0 && viewCount === 0) {
+                    } else if (this.tableCount === 0 && this.viewCount === 0) {
                         this.description = 'empty';
                     }
                 }
                 break;
             case 'tables-folder':
-                this.iconPath = new vscode.ThemeIcon('folder');
-                this.contextValue = 'tables-folder';
-                if (tableCount !== undefined) {
-                    this.description = `${tableCount}`;
+                if (this.tableCount !== undefined) {
+                    this.description = `${this.tableCount}`;
                 }
                 break;
             case 'table':
-                this.iconPath = new vscode.ThemeIcon('table');
-                this.contextValue = 'table';
-                if (tableInfo?.rowCount !== undefined) {
-                    this.description = `${tableInfo.rowCount.toLocaleString()} rows`;
+                if (this.tableInfo?.rowCount !== undefined) {
+                    this.description = `${this.tableInfo.rowCount.toLocaleString()} rows`;
                 }
                 this.command = {
                     command: 'exasol.openObject',
@@ -620,15 +1442,11 @@ class ObjectTreeItem extends vscode.TreeItem {
                 };
                 break;
             case 'views-folder':
-                this.iconPath = new vscode.ThemeIcon('folder');
-                this.contextValue = 'views-folder';
-                if (viewCount !== undefined) {
-                    this.description = `${viewCount}`;
+                if (this.viewCount !== undefined) {
+                    this.description = `${this.viewCount}`;
                 }
                 break;
             case 'view':
-                this.iconPath = new vscode.ThemeIcon('eye');
-                this.contextValue = 'view';
                 this.command = {
                     command: 'exasol.openObject',
                     title: 'Open View',
@@ -636,10 +1454,46 @@ class ObjectTreeItem extends vscode.TreeItem {
                 };
                 break;
             case 'column':
-                this.iconPath = new vscode.ThemeIcon('symbol-field');
-                this.contextValue = 'column';
-                if (columnInfo) {
-                    this.tooltip = `${columnInfo.name}: ${columnInfo.type}${columnInfo.nullable ? ' (nullable)' : ''}`;
+                if (this.columnInfo) {
+                    this.tooltip = `${this.columnInfo.name}: ${this.columnInfo.type}${this.columnInfo.nullable ? ' (nullable)' : ''}`;
+                }
+                break;
+            case 'constraints-folder':
+                if (this.constraintCount !== undefined) {
+                    this.description = `${this.constraintCount}`;
+                }
+                break;
+            case 'udfs-folder':
+            case 'procedures-folder':
+            case 'functions-folder':
+                if (this.itemCount !== undefined) {
+                    this.description = `${this.itemCount}`;
+                }
+                break;
+            case 'script':
+                if (this.scriptInfo) {
+                    if (this.scriptInfo.scriptType === 'UDF' && this.scriptInfo.inputType) {
+                        this.description = `${this.scriptInfo.language}, ${this.scriptInfo.inputType}`;
+                    } else {
+                        this.description = this.scriptInfo.language;
+                    }
+                }
+                this.command = {
+                    command: 'exasol.openScriptSource',
+                    title: 'Open Script Source',
+                    arguments: [this]
+                };
+                break;
+            case 'function':
+                this.command = {
+                    command: 'exasol.openFunctionSource',
+                    title: 'Open Function Source',
+                    arguments: [this]
+                };
+                break;
+            case 'constraint':
+                if (this.constraintType) {
+                    this.description = this.constraintType;
                 }
                 break;
         }

--- a/src/providers/objectTreeTypes.ts
+++ b/src/providers/objectTreeTypes.ts
@@ -1,0 +1,97 @@
+export type ObjectTreeItemType =
+    | 'schema'
+    | 'tables-folder'
+    | 'table'
+    | 'views-folder'
+    | 'view'
+    | 'column'
+    | 'virtual-schema'
+    | 'virtual-table'
+    | 'udfs-folder'
+    | 'procedures-folder'
+    | 'adapters-folder'
+    | 'functions-folder'
+    | 'script'
+    | 'function'
+    | 'constraints-folder'
+    | 'indices-folder'
+    | 'constraint'
+    | 'index'
+    | 'system-schemas-folder'
+    | 'system-schema'
+    | 'system-table';
+
+export interface NodeTypeConfig {
+    icon: string;
+    contextValue: string;
+}
+
+export function getNodeTypeConfig(
+    type: ObjectTreeItemType,
+    metadata?: { scriptType?: string; constraintType?: string }
+): NodeTypeConfig | undefined {
+    switch (type) {
+        case 'schema':
+            return { icon: 'symbol-namespace', contextValue: 'schema' };
+        case 'tables-folder':
+            return { icon: 'folder', contextValue: 'tables-folder' };
+        case 'table':
+            return { icon: 'table', contextValue: 'table' };
+        case 'views-folder':
+            return { icon: 'folder', contextValue: 'views-folder' };
+        case 'view':
+            return { icon: 'eye', contextValue: 'view' };
+        case 'column':
+            return { icon: 'symbol-field', contextValue: 'column' };
+        case 'virtual-schema':
+            return { icon: 'remote', contextValue: 'virtual-schema' };
+        case 'virtual-table':
+            return { icon: 'table', contextValue: 'virtual-table' };
+        case 'udfs-folder':
+            return { icon: 'folder', contextValue: 'udfs-folder' };
+        case 'procedures-folder':
+            return { icon: 'folder', contextValue: 'procedures-folder' };
+        case 'adapters-folder':
+            return { icon: 'folder', contextValue: 'adapters-folder' };
+        case 'functions-folder':
+            return { icon: 'folder', contextValue: 'functions-folder' };
+        case 'script':
+            return { icon: getScriptIcon(metadata?.scriptType), contextValue: 'script' };
+        case 'function':
+            return { icon: 'symbol-function', contextValue: 'function' };
+        case 'constraints-folder':
+            return { icon: 'folder', contextValue: 'constraints-folder' };
+        case 'indices-folder':
+            return { icon: 'folder', contextValue: 'indices-folder' };
+        case 'constraint':
+            return { icon: getConstraintIcon(metadata?.constraintType), contextValue: 'constraint' };
+        case 'index':
+            return { icon: 'list-tree', contextValue: 'index' };
+        case 'system-schemas-folder':
+            return { icon: 'library', contextValue: 'system-schemas-folder' };
+        case 'system-schema':
+            return { icon: 'database', contextValue: 'system-schema' };
+        case 'system-table':
+            return { icon: 'table', contextValue: 'system-table' };
+        default:
+            return undefined;
+    }
+}
+
+function getScriptIcon(scriptType?: string): string {
+    switch (scriptType) {
+        case 'SCRIPTING':
+            return 'symbol-event';
+        case 'ADAPTER':
+            return 'extensions';
+        default:
+            return 'symbol-method';
+    }
+}
+
+function getConstraintIcon(constraintType?: string): string {
+    if (constraintType === 'FOREIGN KEY') {
+        return 'link';
+    }
+    return 'key';
+}

--- a/src/test/helpers/mockConnectionManager.ts
+++ b/src/test/helpers/mockConnectionManager.ts
@@ -1,0 +1,67 @@
+import type { StoredConnection } from '../../connectionManager';
+
+export const TEST_CONNECTION: StoredConnection = {
+    id: 'conn-1',
+    name: 'Test Connection',
+    host: 'localhost',
+    port: 8563,
+    user: 'sys',
+    password: 'secret'
+};
+
+export function createRawResult(columns: string[], rows: any[][]): any {
+    return {
+        status: 'ok',
+        responseData: {
+            numResults: 1,
+            results: [
+                {
+                    resultType: 'resultSet',
+                    resultSet: {
+                        columns: columns.map(name => ({ name })),
+                        numColumns: columns.length,
+                        numRows: rows.length,
+                        numRowsInMessage: rows.length,
+                        data: columns.map((_, colIdx) => rows.map(row => row[colIdx]))
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export function createEmptyRawResult(columns: string[]): any {
+    return {
+        status: 'ok',
+        responseData: {
+            numResults: 1,
+            results: [
+                {
+                    resultType: 'resultSet',
+                    resultSet: {
+                        columns: columns.map(name => ({ name })),
+                        numColumns: columns.length,
+                        numRows: 0,
+                        numRowsInMessage: 0,
+                        data: columns.map(() => [])
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export class MockConnectionManager {
+    driver: any;
+    private activeConn: StoredConnection | null;
+
+    constructor(driver: any, connection: StoredConnection = TEST_CONNECTION) {
+        this.driver = driver;
+        this.activeConn = connection;
+    }
+
+    getConnections(): StoredConnection[] { return [this.activeConn!]; }
+    getActiveConnection(): StoredConnection | null { return this.activeConn; }
+    async getDriver(): Promise<any> { return this.driver; }
+    async executeWithRetry<T>(fn: () => Promise<T>): Promise<T> { return fn(); }
+}

--- a/src/test/helpers/vscodeMock.ts
+++ b/src/test/helpers/vscodeMock.ts
@@ -1,0 +1,93 @@
+class MockTreeItem {
+    label: string;
+    collapsibleState: number;
+    id?: string;
+    description?: string;
+    iconPath?: any;
+    contextValue?: string;
+    tooltip?: string;
+    command?: any;
+
+    constructor(label: string, collapsibleState: number = 0) {
+        this.label = label;
+        this.collapsibleState = collapsibleState;
+    }
+}
+
+class MockThemeIcon {
+    id: string;
+    constructor(id: string) {
+        this.id = id;
+    }
+}
+
+class MockEventEmitter {
+    private listeners: Array<(...args: any[]) => void> = [];
+    event = (listener: (...args: any[]) => void) => {
+        this.listeners.push(listener);
+        return { dispose: () => {} };
+    };
+    fire(...args: any[]) {
+        for (const fn of this.listeners) { fn(...args); }
+    }
+}
+
+export const vscodeMock = {
+    TreeItem: MockTreeItem,
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon: MockThemeIcon,
+    EventEmitter: MockEventEmitter,
+    workspace: {
+        getConfiguration() {
+            return { get: () => undefined };
+        }
+    },
+    DataTransferItem: class {},
+    DataTransfer: class {},
+    Uri: { parse: (s: string) => s },
+};
+
+export function registerVscodeMock(): void {
+    const NodeModule = require('module');
+    const originalResolveFilename = NodeModule._resolveFilename;
+    NodeModule._resolveFilename = function (request: string, ...args: any[]) {
+        if (request === 'vscode') {
+            return 'vscode';
+        }
+        return originalResolveFilename.call(this, request, ...args);
+    };
+    require.cache['vscode'] = {
+        id: 'vscode',
+        filename: 'vscode',
+        loaded: true,
+        exports: vscodeMock,
+        paths: [],
+        children: [],
+        path: '',
+        require: require,
+        isPreloading: false,
+    } as any;
+}
+
+export function registerExtensionMock(): void {
+    const path = require('path');
+    const extensionMock = {
+        getOutputChannel: () => ({
+            appendLine: () => {},
+            show: () => {}
+        })
+    };
+    delete require.cache[require.resolve('../../extension')];
+    const extensionResolvedPath = require.resolve('../../extension');
+    require.cache[extensionResolvedPath] = {
+        id: extensionResolvedPath,
+        filename: extensionResolvedPath,
+        loaded: true,
+        exports: extensionMock,
+        paths: [],
+        children: [],
+        path: path.dirname(extensionResolvedPath),
+        require: require,
+        isPreloading: false,
+    } as any;
+}

--- a/src/test/objectBrowser.test.ts
+++ b/src/test/objectBrowser.test.ts
@@ -142,18 +142,28 @@ suite('Object Browser Test Suite', () => {
         assert.ok(getLabelText(idColumn).includes('('), 'Column label should include type');
     });
 
-    test('Should filter system schemas', async function() {
+    test('Should filter system schemas from user list and show System Schemas folder', async function() {
         this.timeout(30000);
 
         const schemas = await objectTreeProvider.getChildren();
 
+        // SYS and EXA_STATISTICS should NOT appear as top-level user schemas
         const systemSchemas = schemas.filter(s => {
             const label = getLabelText(s);
             return label === 'SYS' || label === 'EXA_STATISTICS';
-        }
-        );
+        });
+        assert.strictEqual(systemSchemas.length, 0, 'Should filter out system schemas from user schema list');
 
-        assert.strictEqual(systemSchemas.length, 0, 'Should filter out system schemas');
+        // A "System Schemas" folder should appear at root level (after user and virtual schemas)
+        const systemSchemasFolder = schemas.find(s => getLabelText(s) === 'System Schemas');
+        assert.ok(systemSchemasFolder, 'Should have a "System Schemas" folder at root level');
+
+        // The "System Schemas" folder should be the last item
+        const lastItem = schemas[schemas.length - 1];
+        assert.strictEqual(
+            getLabelText(lastItem), 'System Schemas',
+            'System Schemas folder should appear after user and virtual schemas'
+        );
     });
 
     suiteTeardown(async function() {

--- a/src/test/objectTreeConstraintsIndices.test.ts
+++ b/src/test/objectTreeConstraintsIndices.test.ts
@@ -1,0 +1,257 @@
+import * as assert from 'assert';
+import { ObjectTreeProvider } from '../providers/objectTreeProvider';
+import { TEST_CONNECTION, createRawResult, MockConnectionManager } from './helpers/mockConnectionManager';
+
+const connection = TEST_CONNECTION;
+
+suite('ObjectTreeProvider Constraints & Indices', () => {
+
+    suite('fetchConstraints', () => {
+        test('returns constraint nodes with name, type, and correct icon metadata', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_CONSTRAINTS')) {
+                        return createRawResult(
+                            ['CONSTRAINT_NAME', 'CONSTRAINT_TYPE'],
+                            [
+                                ['PK_USERS', 'PRIMARY KEY'],
+                                ['FK_ORDERS_USER', 'FOREIGN KEY'],
+                                ['NN_EMAIL', 'NOT NULL']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const constraints = await (provider as any).fetchConstraints(connection, 'TEST_SCHEMA', 'USERS');
+
+            assert.strictEqual(constraints.length, 3);
+            assert.strictEqual(constraints[0].name, 'PK_USERS');
+            assert.strictEqual(constraints[0].type, 'PRIMARY KEY');
+            assert.strictEqual(constraints[1].name, 'FK_ORDERS_USER');
+            assert.strictEqual(constraints[1].type, 'FOREIGN KEY');
+            assert.strictEqual(constraints[2].name, 'NN_EMAIL');
+            assert.strictEqual(constraints[2].type, 'NOT NULL');
+        });
+
+        test('returns empty array on query error', async () => {
+            const driver = {
+                async query() { throw new Error('Connection failed'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const constraints = await (provider as any).fetchConstraints(connection, 'TEST_SCHEMA', 'USERS');
+            assert.deepStrictEqual(constraints, []);
+        });
+    });
+
+    suite('fetchConstraintColumns', () => {
+        test('returns column names for a constraint', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_CONSTRAINT_COLUMNS')) {
+                        return createRawResult(
+                            ['COLUMN_NAME', 'ORDINAL_POSITION'],
+                            [
+                                ['USER_ID', 1],
+                                ['EMAIL', 2]
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const columns = await (provider as any).fetchConstraintColumns(
+                connection, 'TEST_SCHEMA', 'USERS', 'PK_USERS'
+            );
+
+            assert.strictEqual(columns.length, 2);
+            assert.strictEqual(columns[0].name, 'USER_ID');
+            assert.strictEqual(columns[1].name, 'EMAIL');
+        });
+
+        test('returns empty array on query error', async () => {
+            const driver = {
+                async query() { throw new Error('Connection failed'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const columns = await (provider as any).fetchConstraintColumns(
+                connection, 'TEST_SCHEMA', 'USERS', 'PK_USERS'
+            );
+            assert.deepStrictEqual(columns, []);
+        });
+    });
+
+    suite('fetchIndices', () => {
+        test('returns index nodes with name and column list', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_INDICES')) {
+                        return createRawResult(
+                            ['INDEX_NAME', 'INDEX_TYPE', 'INDEX_COLUMNS'],
+                            [
+                                ['IDX_EMAIL', 'LOCAL', 'EMAIL'],
+                                ['IDX_NAME_DOB', 'LOCAL', 'LAST_NAME, DATE_OF_BIRTH']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const indices = await (provider as any).fetchIndices(connection, 'TEST_SCHEMA', 'USERS');
+
+            assert.strictEqual(indices.length, 2);
+            assert.strictEqual(indices[0].name, 'IDX_EMAIL');
+            assert.strictEqual(indices[0].columns, 'EMAIL');
+            assert.strictEqual(indices[1].name, 'IDX_NAME_DOB');
+            assert.strictEqual(indices[1].columns, 'LAST_NAME, DATE_OF_BIRTH');
+        });
+
+        test('returns empty array on query error', async () => {
+            const driver = {
+                async query() { throw new Error('Connection failed'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const indices = await (provider as any).fetchIndices(connection, 'TEST_SCHEMA', 'USERS');
+            assert.deepStrictEqual(indices, []);
+        });
+    });
+
+    suite('table node expansion with constraints and indices folders', () => {
+        test('includes Constraints and Indices folders when counts are non-zero', async () => {
+            const driver = {
+                async query(sql: string) {
+                    // Column query
+                    if (sql.includes('EXA_ALL_COLUMNS') && !sql.includes('COUNT')) {
+                        return createRawResult(
+                            ['COLUMN_NAME', 'COLUMN_TYPE', 'COLUMN_IS_NULLABLE'],
+                            [['ID', 'DECIMAL(18,0)', false]]
+                        );
+                    }
+                    // Constraint count
+                    if (sql.includes('EXA_ALL_CONSTRAINTS') && sql.includes('COUNT')) {
+                        return createRawResult(['CONSTRAINT_COUNT'], [[2]]);
+                    }
+                    // Index count
+                    if (sql.includes('EXA_ALL_INDICES') && sql.includes('COUNT')) {
+                        return createRawResult(['INDEX_COUNT'], [[1]]);
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const tableElement = {
+                type: 'table' as const,
+                connection,
+                schemaName: 'TEST_SCHEMA',
+                tableInfo: { name: 'USERS' },
+                label: 'USERS',
+                id: 'conn-1:TEST_SCHEMA:USERS:table'
+            };
+
+            const children = await provider.getChildren(tableElement as any);
+
+            const labels = children.map((c: any) => c.label);
+            assert.ok(labels.some((l: string) => l === 'Constraints'), 'Should have Constraints folder');
+            assert.ok(labels.some((l: string) => l === 'Indices'), 'Should have Indices folder');
+        });
+
+        test('omits Constraints folder when constraint count is zero', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_COLUMNS') && !sql.includes('COUNT')) {
+                        return createRawResult(
+                            ['COLUMN_NAME', 'COLUMN_TYPE', 'COLUMN_IS_NULLABLE'],
+                            [['ID', 'DECIMAL(18,0)', false]]
+                        );
+                    }
+                    if (sql.includes('EXA_ALL_CONSTRAINTS') && sql.includes('COUNT')) {
+                        return createRawResult(['CONSTRAINT_COUNT'], [[0]]);
+                    }
+                    if (sql.includes('EXA_ALL_INDICES') && sql.includes('COUNT')) {
+                        return createRawResult(['INDEX_COUNT'], [[0]]);
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const tableElement = {
+                type: 'table' as const,
+                connection,
+                schemaName: 'TEST_SCHEMA',
+                tableInfo: { name: 'USERS' },
+                label: 'USERS',
+                id: 'conn-1:TEST_SCHEMA:USERS:table'
+            };
+
+            const children = await provider.getChildren(tableElement as any);
+            const labels = children.map((c: any) => c.label);
+            assert.ok(!labels.includes('Constraints'), 'Should NOT have Constraints folder');
+            assert.ok(!labels.includes('Indices'), 'Should NOT have Indices folder');
+        });
+
+        test('still shows columns when constraint query fails', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_COLUMNS') && !sql.includes('COUNT')) {
+                        return createRawResult(
+                            ['COLUMN_NAME', 'COLUMN_TYPE', 'COLUMN_IS_NULLABLE'],
+                            [['ID', 'DECIMAL(18,0)', false]]
+                        );
+                    }
+                    if (sql.includes('EXA_ALL_CONSTRAINTS')) {
+                        throw new Error('Access denied');
+                    }
+                    if (sql.includes('EXA_ALL_INDICES')) {
+                        throw new Error('Access denied');
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const tableElement = {
+                type: 'table' as const,
+                connection,
+                schemaName: 'TEST_SCHEMA',
+                tableInfo: { name: 'USERS' },
+                label: 'USERS',
+                id: 'conn-1:TEST_SCHEMA:USERS:table'
+            };
+
+            const children = await provider.getChildren(tableElement as any);
+            assert.ok(children.length > 0, 'Should still have column children');
+            const labels = children.map((c: any) => c.label);
+            assert.ok(!labels.includes('Constraints'), 'Should NOT have Constraints folder on error');
+            assert.ok(!labels.includes('Indices'), 'Should NOT have Indices folder on error');
+        });
+    });
+});

--- a/src/test/objectTreeScriptsFunctions.test.ts
+++ b/src/test/objectTreeScriptsFunctions.test.ts
@@ -1,0 +1,623 @@
+import * as assert from 'assert';
+import { ObjectTreeProvider } from '../providers/objectTreeProvider';
+import { TEST_CONNECTION, createRawResult, createEmptyRawResult, MockConnectionManager } from './helpers/mockConnectionManager';
+
+const connection = TEST_CONNECTION;
+
+suite('ObjectTreeProvider Scripts & Functions', () => {
+
+    suite('fetchScriptCounts', () => {
+        test('returns counts grouped by script type', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('GROUP BY')) {
+                        return createRawResult(
+                            ['SCRIPT_TYPE', 'SCRIPT_COUNT'],
+                            [
+                                ['UDF', 5],
+                                ['SCRIPTING', 2],
+                                ['ADAPTER', 1]
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const counts = await (provider as any).fetchScriptCounts(connection, 'MY_SCHEMA');
+
+            assert.strictEqual(counts.get('UDF'), 5);
+            assert.strictEqual(counts.get('SCRIPTING'), 2);
+            assert.strictEqual(counts.get('ADAPTER'), 1);
+        });
+
+        test('returns empty map on query failure', async () => {
+            const driver = {
+                async query() { throw new Error('Access denied'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const counts = await (provider as any).fetchScriptCounts(connection, 'MY_SCHEMA');
+
+            assert.strictEqual(counts.size, 0);
+        });
+
+        test('skips types with zero count', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('GROUP BY')) {
+                        return createRawResult(
+                            ['SCRIPT_TYPE', 'SCRIPT_COUNT'],
+                            [
+                                ['UDF', 3],
+                                ['SCRIPTING', 0]
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const counts = await (provider as any).fetchScriptCounts(connection, 'MY_SCHEMA');
+
+            assert.strictEqual(counts.get('UDF'), 3);
+            assert.ok(!counts.has('SCRIPTING'), 'Zero-count types should not be in map');
+        });
+    });
+
+    suite('fetchFunctionCount', () => {
+        test('returns function count for a schema', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_FUNCTIONS') && sql.includes('COUNT')) {
+                        return createRawResult(
+                            ['FUNCTION_COUNT'],
+                            [[7]]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const count = await (provider as any).fetchFunctionCount(connection, 'MY_SCHEMA');
+
+            assert.strictEqual(count, 7);
+        });
+
+        test('returns 0 on query failure', async () => {
+            const driver = {
+                async query() { throw new Error('Access denied'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const count = await (provider as any).fetchFunctionCount(connection, 'MY_SCHEMA');
+
+            assert.strictEqual(count, 0);
+        });
+    });
+
+    suite('fetchScripts', () => {
+        test('returns UDF scripts with language and input type', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'UDF'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [
+                                ['MY_UDF', 'PYTHON3', 'SET', 'UDF'],
+                                ['ANOTHER_UDF', 'JAVA', 'SCALAR', 'UDF']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const scripts = await (provider as any).fetchScripts(connection, 'MY_SCHEMA', 'UDF');
+
+            assert.strictEqual(scripts.length, 2);
+            assert.strictEqual(scripts[0].name, 'MY_UDF');
+            assert.strictEqual(scripts[0].language, 'PYTHON3');
+            assert.strictEqual(scripts[0].inputType, 'SET');
+            assert.strictEqual(scripts[0].scriptType, 'UDF');
+            assert.strictEqual(scripts[1].name, 'ANOTHER_UDF');
+            assert.strictEqual(scripts[1].inputType, 'SCALAR');
+        });
+
+        test('returns procedure scripts', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'SCRIPTING'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [
+                                ['MY_PROC', 'LUA', null, 'SCRIPTING']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const scripts = await (provider as any).fetchScripts(connection, 'MY_SCHEMA', 'SCRIPTING');
+
+            assert.strictEqual(scripts.length, 1);
+            assert.strictEqual(scripts[0].name, 'MY_PROC');
+            assert.strictEqual(scripts[0].language, 'LUA');
+            assert.strictEqual(scripts[0].inputType, null);
+            assert.strictEqual(scripts[0].scriptType, 'SCRIPTING');
+        });
+
+        test('returns adapter scripts', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'ADAPTER'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [
+                                ['S3_ADAPTER', 'JAVA', null, 'ADAPTER']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const scripts = await (provider as any).fetchScripts(connection, 'MY_SCHEMA', 'ADAPTER');
+
+            assert.strictEqual(scripts.length, 1);
+            assert.strictEqual(scripts[0].name, 'S3_ADAPTER');
+            assert.strictEqual(scripts[0].scriptType, 'ADAPTER');
+        });
+
+        test('returns empty array on query failure', async () => {
+            const driver = {
+                async query() { throw new Error('Connection failed'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const scripts = await (provider as any).fetchScripts(connection, 'MY_SCHEMA', 'UDF');
+            assert.deepStrictEqual(scripts, []);
+        });
+    });
+
+    suite('fetchFunctions', () => {
+        test('returns function names for a schema', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_FUNCTIONS') && !sql.includes('COUNT')) {
+                        return createRawResult(
+                            ['FUNCTION_NAME'],
+                            [
+                                ['MY_FUNC'],
+                                ['ANOTHER_FUNC']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const functions = await (provider as any).fetchFunctions(connection, 'MY_SCHEMA');
+
+            assert.strictEqual(functions.length, 2);
+            assert.strictEqual(functions[0].name, 'MY_FUNC');
+            assert.strictEqual(functions[1].name, 'ANOTHER_FUNC');
+        });
+
+        test('returns empty array on query failure', async () => {
+            const driver = {
+                async query() { throw new Error('Connection failed'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const functions = await (provider as any).fetchFunctions(connection, 'MY_SCHEMA');
+            assert.deepStrictEqual(functions, []);
+        });
+    });
+
+    suite('schema node expansion with script and function folders', () => {
+        test('includes UDFs, Procedures, and Functions folders when counts are non-zero', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('GROUP BY')) {
+                        return createRawResult(
+                            ['SCRIPT_TYPE', 'SCRIPT_COUNT'],
+                            [
+                                ['UDF', 3],
+                                ['SCRIPTING', 2]
+                            ]
+                        );
+                    }
+                    if (sql.includes('EXA_ALL_FUNCTIONS') && sql.includes('COUNT')) {
+                        return createRawResult(['FUNCTION_COUNT'], [[4]]);
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const schemaElement = {
+                type: 'schema' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'MY_SCHEMA',
+                id: 'conn-1:MY_SCHEMA',
+                tableCount: 5,
+                viewCount: 2
+            };
+
+            const children = await provider.getChildren(schemaElement as any);
+            const labels = children.map((c: any) => c.label);
+
+            assert.ok(labels.includes('Tables'), 'Should have Tables folder');
+            assert.ok(labels.includes('Views'), 'Should have Views folder');
+            assert.ok(labels.includes('UDFs'), 'Should have UDFs folder');
+            assert.ok(labels.includes('Procedures'), 'Should have Procedures folder');
+            assert.ok(labels.includes('Functions'), 'Should have Functions folder');
+            assert.ok(!labels.includes('Adapters'), 'Should NOT have Adapters folder (zero count)');
+        });
+
+        test('omits all script and function folders when counts are zero', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('GROUP BY')) {
+                        return createEmptyRawResult(['SCRIPT_TYPE', 'SCRIPT_COUNT']);
+                    }
+                    if (sql.includes('EXA_ALL_FUNCTIONS') && sql.includes('COUNT')) {
+                        return createRawResult(['FUNCTION_COUNT'], [[0]]);
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const schemaElement = {
+                type: 'schema' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'MY_SCHEMA',
+                id: 'conn-1:MY_SCHEMA',
+                tableCount: 5,
+                viewCount: 2
+            };
+
+            const children = await provider.getChildren(schemaElement as any);
+            const labels = children.map((c: any) => c.label);
+
+            assert.ok(labels.includes('Tables'), 'Should always have Tables folder');
+            assert.ok(labels.includes('Views'), 'Should always have Views folder');
+            assert.ok(!labels.includes('UDFs'), 'Should NOT have UDFs folder');
+            assert.ok(!labels.includes('Procedures'), 'Should NOT have Procedures folder');
+            assert.ok(!labels.includes('Adapters'), 'Should NOT have Adapters folder');
+            assert.ok(!labels.includes('Functions'), 'Should NOT have Functions folder');
+        });
+
+        test('still shows Tables and Views when script count query fails', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS')) {
+                        throw new Error('Access denied');
+                    }
+                    if (sql.includes('EXA_ALL_FUNCTIONS')) {
+                        throw new Error('Access denied');
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const schemaElement = {
+                type: 'schema' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'MY_SCHEMA',
+                id: 'conn-1:MY_SCHEMA',
+                tableCount: 5,
+                viewCount: 2
+            };
+
+            const children = await provider.getChildren(schemaElement as any);
+            const labels = children.map((c: any) => c.label);
+
+            assert.ok(labels.includes('Tables'), 'Tables folder should still exist');
+            assert.ok(labels.includes('Views'), 'Views folder should still exist');
+            assert.strictEqual(children.length, 2, 'Only Tables and Views when script/function queries fail');
+        });
+    });
+
+    suite('UDFs folder expansion', () => {
+        test('expands UDFs folder to show script nodes', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'UDF'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [
+                                ['MY_UDF', 'PYTHON3', 'SET', 'UDF'],
+                                ['SCALAR_UDF', 'JAVA', 'SCALAR', 'UDF']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const udfsFolderElement = {
+                type: 'udfs-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'UDFs',
+                id: 'conn-1:MY_SCHEMA:udfs-folder'
+            };
+
+            const children = await provider.getChildren(udfsFolderElement as any);
+
+            assert.strictEqual(children.length, 2);
+            assert.strictEqual((children[0] as any).label, 'MY_UDF');
+            assert.strictEqual((children[0] as any).type, 'script');
+            assert.strictEqual((children[1] as any).label, 'SCALAR_UDF');
+            assert.strictEqual((children[1] as any).type, 'script');
+        });
+    });
+
+    suite('Procedures folder expansion', () => {
+        test('expands procedures folder to show procedure script nodes', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'SCRIPTING'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [
+                                ['MY_PROC', 'LUA', null, 'SCRIPTING']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const procsFolderElement = {
+                type: 'procedures-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'Procedures',
+                id: 'conn-1:MY_SCHEMA:procedures-folder'
+            };
+
+            const children = await provider.getChildren(procsFolderElement as any);
+
+            assert.strictEqual(children.length, 1);
+            assert.strictEqual((children[0] as any).label, 'MY_PROC');
+            assert.strictEqual((children[0] as any).type, 'script');
+        });
+    });
+
+    suite('Adapters folder expansion', () => {
+        test('expands adapters folder to show adapter script nodes', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'ADAPTER'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [
+                                ['S3_ADAPTER', 'JAVA', null, 'ADAPTER']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const adaptersFolderElement = {
+                type: 'adapters-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'Adapters',
+                id: 'conn-1:MY_SCHEMA:adapters-folder'
+            };
+
+            const children = await provider.getChildren(adaptersFolderElement as any);
+
+            assert.strictEqual(children.length, 1);
+            assert.strictEqual((children[0] as any).label, 'S3_ADAPTER');
+            assert.strictEqual((children[0] as any).type, 'script');
+        });
+    });
+
+    suite('Functions folder expansion', () => {
+        test('expands functions folder to show function nodes', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_FUNCTIONS') && !sql.includes('COUNT')) {
+                        return createRawResult(
+                            ['FUNCTION_NAME'],
+                            [
+                                ['MY_FUNC'],
+                                ['ANOTHER_FUNC']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const functionsFolderElement = {
+                type: 'functions-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'Functions',
+                id: 'conn-1:MY_SCHEMA:functions-folder'
+            };
+
+            const children = await provider.getChildren(functionsFolderElement as any);
+
+            assert.strictEqual(children.length, 2);
+            assert.strictEqual((children[0] as any).label, 'MY_FUNC');
+            assert.strictEqual((children[0] as any).type, 'function');
+            assert.strictEqual((children[1] as any).label, 'ANOTHER_FUNC');
+            assert.strictEqual((children[1] as any).type, 'function');
+        });
+
+        test('returns empty array when functions folder query fails', async () => {
+            const driver = {
+                async query() { throw new Error('Connection failed'); }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const functionsFolderElement = {
+                type: 'functions-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'Functions',
+                id: 'conn-1:MY_SCHEMA:functions-folder'
+            };
+
+            const children = await provider.getChildren(functionsFolderElement as any);
+
+            assert.strictEqual(children.length, 0);
+        });
+    });
+
+    suite('script node metadata', () => {
+        test('UDF script node has language and input type as description', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'UDF'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [['MY_UDF', 'PYTHON3', 'SET', 'UDF']]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const udfsFolderElement = {
+                type: 'udfs-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'UDFs',
+                id: 'conn-1:MY_SCHEMA:udfs-folder'
+            };
+
+            const children = await provider.getChildren(udfsFolderElement as any);
+            const scriptNode = children[0] as any;
+
+            assert.strictEqual(scriptNode.description, 'PYTHON3, SET');
+        });
+
+        test('procedure script node has only language as description', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'SCRIPTING'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [['MY_PROC', 'LUA', null, 'SCRIPTING']]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const procsFolderElement = {
+                type: 'procedures-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'Procedures',
+                id: 'conn-1:MY_SCHEMA:procedures-folder'
+            };
+
+            const children = await provider.getChildren(procsFolderElement as any);
+            const scriptNode = children[0] as any;
+
+            assert.strictEqual(scriptNode.description, 'LUA');
+        });
+
+        test('script node has click command to open source', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes("'UDF'")) {
+                        return createRawResult(
+                            ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                            [['MY_UDF', 'PYTHON3', 'SET', 'UDF']]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const udfsFolderElement = {
+                type: 'udfs-folder' as const,
+                connection,
+                schemaName: 'MY_SCHEMA',
+                label: 'UDFs',
+                id: 'conn-1:MY_SCHEMA:udfs-folder'
+            };
+
+            const children = await provider.getChildren(udfsFolderElement as any);
+            const scriptNode = children[0] as any;
+
+            assert.ok(scriptNode.command, 'Script node should have a command');
+            assert.strictEqual(scriptNode.command.command, 'exasol.openScriptSource');
+        });
+    });
+});

--- a/src/test/objectTreeVirtualSchemas.test.ts
+++ b/src/test/objectTreeVirtualSchemas.test.ts
@@ -1,0 +1,289 @@
+import * as assert from 'assert';
+import { ObjectTreeProvider } from '../providers/objectTreeProvider';
+import { TEST_CONNECTION, createRawResult, MockConnectionManager } from './helpers/mockConnectionManager';
+
+const connection = TEST_CONNECTION;
+
+suite('ObjectTreeProvider Virtual Schemas', () => {
+
+    suite('fetchVirtualSchemas', () => {
+        test('returns virtual schema data from EXA_ALL_VIRTUAL_SCHEMAS', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createRawResult(
+                            ['SCHEMA_NAME', 'ADAPTER_SCRIPT_SCHEMA', 'ADAPTER_SCRIPT_NAME', 'LAST_REFRESH', 'LAST_REFRESH_BY'],
+                            [
+                                ['VS_S3', 'ADAPTER_SCHEMA', 'S3_ADAPTER', '2024-01-15 10:30:00', 'SYS'],
+                                ['VS_JDBC', 'ADAPTER_SCHEMA', 'JDBC_ADAPTER', '2024-01-16 11:00:00', 'ADMIN']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const schemas = await (provider as any).fetchVirtualSchemas(connection);
+
+            assert.strictEqual(schemas.length, 2);
+            assert.strictEqual(schemas[0].name, 'VS_S3');
+            assert.strictEqual(schemas[0].adapterName, 'S3_ADAPTER');
+            assert.strictEqual(schemas[0].lastRefresh, '2024-01-15 10:30:00');
+            assert.strictEqual(schemas[0].lastRefreshBy, 'SYS');
+            assert.strictEqual(schemas[1].name, 'VS_JDBC');
+            assert.strictEqual(schemas[1].adapterName, 'JDBC_ADAPTER');
+        });
+
+        test('returns empty array on query failure', async () => {
+            const driver = {
+                async query() {
+                    throw new Error('table not found');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const schemas = await (provider as any).fetchVirtualSchemas(connection);
+
+            assert.strictEqual(schemas.length, 0);
+        });
+    });
+
+    suite('fetchVirtualTables', () => {
+        test('returns virtual tables for a virtual schema', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        assert.ok(sql.includes("'VS_S3'"), 'query should filter by virtual schema name');
+                        return createRawResult(
+                            ['TABLE_NAME'],
+                            [
+                                ['BUCKET_DATA'],
+                                ['LOG_FILES']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const tables = await (provider as any).fetchVirtualTables(connection, 'VS_S3');
+
+            assert.strictEqual(tables.length, 2);
+            assert.strictEqual(tables[0].name, 'BUCKET_DATA');
+            assert.strictEqual(tables[1].name, 'LOG_FILES');
+        });
+
+        test('returns empty array on query failure', async () => {
+            const driver = {
+                async query() {
+                    throw new Error('table not found');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const tables = await (provider as any).fetchVirtualTables(connection, 'VS_S3');
+
+            assert.strictEqual(tables.length, 0);
+        });
+    });
+
+    suite('fetchVirtualColumns', () => {
+        test('returns virtual columns for a virtual table', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_VIRTUAL_COLUMNS')) {
+                        assert.ok(sql.includes("'VS_S3'"), 'query should filter by virtual schema');
+                        assert.ok(sql.includes("'BUCKET_DATA'"), 'query should filter by table name');
+                        return createRawResult(
+                            ['COLUMN_NAME', 'COLUMN_TYPE'],
+                            [
+                                ['ID', 'DECIMAL(18,0)'],
+                                ['FILE_PATH', 'VARCHAR(2000)'],
+                                ['SIZE', 'DECIMAL(18,0)']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const columns = await (provider as any).fetchVirtualColumns(connection, 'VS_S3', 'BUCKET_DATA');
+
+            assert.strictEqual(columns.length, 3);
+            assert.strictEqual(columns[0].name, 'ID');
+            assert.strictEqual(columns[0].type, 'DECIMAL(18,0)');
+            assert.strictEqual(columns[1].name, 'FILE_PATH');
+            assert.strictEqual(columns[1].type, 'VARCHAR(2000)');
+        });
+
+        test('returns empty array on query failure', async () => {
+            const driver = {
+                async query() {
+                    throw new Error('table not found');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const columns = await (provider as any).fetchVirtualColumns(connection, 'VS_S3', 'BUCKET_DATA');
+
+            assert.strictEqual(columns.length, 0);
+        });
+    });
+
+    suite('getChildren merges virtual schemas with regular schemas', () => {
+        test('virtual schemas appear sorted alongside regular schemas at root level', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_SCHEMAS') && !sql.includes('VIRTUAL')) {
+                        return createRawResult(
+                            ['SCHEMA_NAME', 'TABLE_COUNT', 'VIEW_COUNT'],
+                            [
+                                ['ALPHA', 5, 2],
+                                ['GAMMA', 3, 1]
+                            ]
+                        );
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createRawResult(
+                            ['SCHEMA_NAME', 'ADAPTER_SCRIPT_SCHEMA', 'ADAPTER_SCRIPT_NAME', 'LAST_REFRESH', 'LAST_REFRESH_BY'],
+                            [
+                                ['BETA_VS', 'ADAPTER_SCHEMA', 'S3_ADAPTER', '2024-01-15 10:30:00', 'SYS']
+                            ]
+                        );
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const children = await provider.getChildren();
+
+            assert.strictEqual(children.length, 3, 'Should have 3 items total');
+            assert.strictEqual((children[0] as any).label, 'ALPHA');
+            assert.strictEqual((children[0] as any).type, 'schema');
+            assert.strictEqual((children[1] as any).label, 'BETA_VS');
+            assert.strictEqual((children[1] as any).type, 'virtual-schema');
+            assert.strictEqual((children[2] as any).label, 'GAMMA');
+            assert.strictEqual((children[2] as any).type, 'schema');
+        });
+
+        test('virtual schema failure does not block regular schemas', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_SCHEMAS') && !sql.includes('VIRTUAL')) {
+                        return createRawResult(
+                            ['SCHEMA_NAME', 'TABLE_COUNT', 'VIEW_COUNT'],
+                            [
+                                ['MY_SCHEMA', 10, 5]
+                            ]
+                        );
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        throw new Error('EXA_ALL_VIRTUAL_SCHEMAS not found');
+                    }
+                    throw new Error(`Unexpected query: ${sql}`);
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const children = await provider.getChildren();
+
+            assert.strictEqual(children.length, 1, 'Regular schemas should still load');
+            assert.strictEqual((children[0] as any).label, 'MY_SCHEMA');
+            assert.strictEqual((children[0] as any).type, 'schema');
+        });
+    });
+
+    suite('getChildren for virtual-schema node', () => {
+        test('expands virtual schema to show virtual tables', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        return createRawResult(
+                            ['TABLE_NAME'],
+                            [
+                                ['TABLE_A'],
+                                ['TABLE_B']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const mockElement = {
+                type: 'virtual-schema',
+                label: 'VS_S3',
+                schemaName: 'VS_S3',
+                connection
+            };
+
+            const children = await provider.getChildren(mockElement as any);
+
+            assert.strictEqual(children.length, 2);
+            assert.strictEqual((children[0] as any).label, 'TABLE_A');
+            assert.strictEqual((children[0] as any).type, 'virtual-table');
+            assert.strictEqual((children[1] as any).label, 'TABLE_B');
+            assert.strictEqual((children[1] as any).type, 'virtual-table');
+        });
+    });
+
+    suite('getChildren for virtual-table node', () => {
+        test('expands virtual table to show virtual columns', async () => {
+            const driver = {
+                async query(sql: string) {
+                    if (sql.includes('EXA_ALL_VIRTUAL_COLUMNS')) {
+                        return createRawResult(
+                            ['COLUMN_NAME', 'COLUMN_TYPE'],
+                            [
+                                ['COL_A', 'INTEGER'],
+                                ['COL_B', 'VARCHAR(100)']
+                            ]
+                        );
+                    }
+                    throw new Error('Unexpected query');
+                }
+            };
+
+            const manager = new MockConnectionManager(driver, connection);
+            const provider = new ObjectTreeProvider(manager as any);
+
+            const mockElement = {
+                type: 'virtual-table',
+                label: 'MY_TABLE',
+                schemaName: 'VS_S3',
+                tableInfo: { name: 'MY_TABLE' },
+                connection
+            };
+
+            const children = await provider.getChildren(mockElement as any);
+
+            assert.strictEqual(children.length, 2);
+            assert.strictEqual((children[0] as any).label, 'COL_A (INTEGER)');
+            assert.strictEqual((children[0] as any).type, 'column');
+            assert.strictEqual((children[1] as any).label, 'COL_B (VARCHAR(100))');
+        });
+    });
+});

--- a/src/test/unit/escapeSqlString.test.ts
+++ b/src/test/unit/escapeSqlString.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import { escapeSqlString } from '../../utils';
+
+suite('escapeSqlString', () => {
+    test('returns the same string when no single quotes present', () => {
+        assert.strictEqual(escapeSqlString('SCHEMA_NAME'), 'SCHEMA_NAME');
+    });
+
+    test('doubles a single quote in the middle of the string', () => {
+        assert.strictEqual(escapeSqlString("O'Brien"), "O''Brien");
+    });
+
+    test('doubles multiple single quotes', () => {
+        assert.strictEqual(escapeSqlString("it's a 'test'"), "it''s a ''test''");
+    });
+
+    test('handles empty string', () => {
+        assert.strictEqual(escapeSqlString(''), '');
+    });
+
+    test('handles string that is just a single quote', () => {
+        assert.strictEqual(escapeSqlString("'"), "''");
+    });
+
+    test('handles consecutive single quotes', () => {
+        assert.strictEqual(escapeSqlString("''"), "''''");
+    });
+});

--- a/src/test/unit/objectSearch.test.ts
+++ b/src/test/unit/objectSearch.test.ts
@@ -1,0 +1,306 @@
+import * as assert from 'assert';
+import { registerVscodeMock, registerExtensionMock, vscodeMock } from '../helpers/vscodeMock';
+
+// Track calls to vscode.window methods
+const windowCalls: { method: string; args: any[] }[] = [];
+let mockQuickPick: any;
+
+function resetWindowCalls(): void {
+    windowCalls.length = 0;
+    mockQuickPick = {
+        placeholder: '',
+        matchOnDescription: false,
+        matchOnDetail: false,
+        busy: false,
+        items: [] as any[],
+        selectedItems: [] as any[],
+        onDidAccept: (_cb: () => void) => { mockQuickPick._acceptCallback = _cb; },
+        onDidHide: (_cb: () => void) => { mockQuickPick._hideCallback = _cb; },
+        show: () => { windowCalls.push({ method: 'quickPick.show', args: [] }); },
+        hide: () => { windowCalls.push({ method: 'quickPick.hide', args: [] }); },
+        dispose: () => { windowCalls.push({ method: 'quickPick.dispose', args: [] }); },
+        _acceptCallback: null as (() => void) | null,
+        _hideCallback: null as (() => void) | null,
+    };
+}
+
+// Enhance the vscode mock with window methods
+(vscodeMock as any).window = {
+    showInformationMessage: (...args: any[]) => {
+        windowCalls.push({ method: 'showInformationMessage', args });
+        return Promise.resolve(undefined);
+    },
+    showErrorMessage: (...args: any[]) => {
+        windowCalls.push({ method: 'showErrorMessage', args });
+        return Promise.resolve(undefined);
+    },
+    createQuickPick: () => {
+        windowCalls.push({ method: 'createQuickPick', args: [] });
+        return mockQuickPick;
+    }
+};
+
+registerVscodeMock();
+registerExtensionMock();
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ObjectSearchProvider } = require('../../providers/objectSearchProvider');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ObjectTreeProvider } = require('../../providers/objectTreeProvider');
+
+import { createRawResult, createEmptyRawResult, MockConnectionManager } from '../helpers/mockConnectionManager';
+
+suite('ObjectSearchProvider', () => {
+
+    let searchProvider: any;
+    let mockDriver: any;
+    let mockCM: any;
+    let objectTreeProvider: any;
+    let mockTreeView: any;
+
+    setup(() => {
+        resetWindowCalls();
+        mockDriver = {
+            query: async (sql: string) => {
+                if (sql.includes('EXA_ALL_TABLES') && sql.includes('UNION')) {
+                    return createRawResult(
+                        ['TABLE_SCHEMA', 'TABLE_NAME', 'OBJECT_TYPE'],
+                        [
+                            ['MY_SCHEMA', 'USERS', 'table'],
+                            ['MY_SCHEMA', 'ACTIVE_USERS', 'view']
+                        ]
+                    );
+                }
+                if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('SCRIPT_SCHEMA')) {
+                    return createRawResult(
+                        ['SCRIPT_SCHEMA', 'SCRIPT_NAME'],
+                        [['MY_SCHEMA', 'MY_UDF']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_FUNCTIONS') && sql.includes('FUNCTION_SCHEMA')) {
+                    return createRawResult(
+                        ['FUNCTION_SCHEMA', 'FUNCTION_NAME'],
+                        [['MY_SCHEMA', 'MY_FUNC']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                    return createRawResult(
+                        ['TABLE_SCHEMA', 'TABLE_NAME'],
+                        [['VS_SCHEMA', 'REMOTE_TABLE']]
+                    );
+                }
+                if (sql.includes('EXA_SYSCAT')) {
+                    return createRawResult(
+                        ['TABLE_SCHEMA', 'TABLE_NAME'],
+                        [['SYS', 'EXA_ALL_COLUMNS']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_COLUMNS') && sql.includes('COLUMN_SCHEMA')) {
+                    return createRawResult(
+                        ['COLUMN_SCHEMA', 'COLUMN_TABLE', 'COLUMN_NAME'],
+                        [['MY_SCHEMA', 'USERS', 'ID']]
+                    );
+                }
+                return createEmptyRawResult(['DUMMY']);
+            }
+        };
+        mockCM = new MockConnectionManager(mockDriver);
+        objectTreeProvider = new ObjectTreeProvider(mockCM);
+        mockTreeView = {
+            reveal: async () => {}
+        };
+        searchProvider = new ObjectSearchProvider(mockCM, objectTreeProvider, mockTreeView);
+    });
+
+    test('shows info message when no active connection', async () => {
+        mockCM = new MockConnectionManager(mockDriver);
+        // Override to return null
+        mockCM.getActiveConnection = () => null;
+        searchProvider = new ObjectSearchProvider(mockCM, objectTreeProvider, mockTreeView);
+
+        await searchProvider.showSearch();
+
+        const infoCall = windowCalls.find(c => c.method === 'showInformationMessage');
+        assert.ok(infoCall, 'Should call showInformationMessage');
+        assert.ok(
+            infoCall.args[0].includes('No active connection'),
+            'Message should mention no active connection'
+        );
+    });
+
+    test('creates QuickPick and shows it', async () => {
+        await searchProvider.showSearch();
+
+        const createCall = windowCalls.find(c => c.method === 'createQuickPick');
+        assert.ok(createCall, 'Should call createQuickPick');
+        const showCall = windowCalls.find(c => c.method === 'quickPick.show');
+        assert.ok(showCall, 'Should call quickPick.show');
+    });
+
+    test('populates QuickPick items with correct structure', async () => {
+        await searchProvider.showSearch();
+
+        assert.ok(mockQuickPick.items.length > 0, 'Should have items');
+
+        const tableItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('USERS') && i.detail === 'Table'
+        );
+        assert.ok(tableItem, 'Should find USERS table item');
+        assert.strictEqual(tableItem.description, 'MY_SCHEMA', 'Description should be schema name');
+        assert.ok(tableItem.label.includes('$('), 'Label should contain icon codicon');
+
+        const viewItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('ACTIVE_USERS') && i.detail === 'View'
+        );
+        assert.ok(viewItem, 'Should find ACTIVE_USERS view item');
+
+        const scriptItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('MY_UDF') && i.detail === 'Script'
+        );
+        assert.ok(scriptItem, 'Should find MY_UDF script item');
+
+        const funcItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('MY_FUNC') && i.detail === 'Function'
+        );
+        assert.ok(funcItem, 'Should find MY_FUNC function item');
+
+        const virtualItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('REMOTE_TABLE') && i.detail === 'Virtual Table'
+        );
+        assert.ok(virtualItem, 'Should find REMOTE_TABLE virtual table item');
+
+        const sysItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('EXA_ALL_COLUMNS') && i.detail === 'System Table'
+        );
+        assert.ok(sysItem, 'Should find EXA_ALL_COLUMNS system table item');
+
+        const colItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('ID') && i.detail === 'Column'
+        );
+        assert.ok(colItem, 'Should find ID column item');
+    });
+
+    test('sets busy true initially then false after loading', async () => {
+        await searchProvider.showSearch();
+
+        assert.strictEqual(mockQuickPick.busy, false, 'Busy should be false after loading');
+    });
+
+    test('shows error message on database error', async () => {
+        const failDriver = {
+            query: async () => { throw new Error('Connection lost'); }
+        };
+        const failCM = new MockConnectionManager(failDriver);
+        const failSearch = new ObjectSearchProvider(failCM, objectTreeProvider, mockTreeView);
+
+        await failSearch.showSearch();
+
+        const errorCall = windowCalls.find(c => c.method === 'showErrorMessage');
+        assert.ok(errorCall, 'Should call showErrorMessage');
+        assert.ok(
+            errorCall.args[0].includes('Failed to fetch objects'),
+            'Error message should mention failure to fetch objects'
+        );
+
+        const hideCall = windowCalls.find(c => c.method === 'quickPick.hide');
+        assert.ok(hideCall, 'Should hide QuickPick on error');
+    });
+
+    test('onDidAccept calls treeView.reveal with the selected item', async () => {
+        const revealCalls: { node: any; options: any }[] = [];
+        mockTreeView.reveal = async (node: any, options: any) => {
+            revealCalls.push({ node, options });
+        };
+
+        // We need an objectTreeProvider that returns nodes matching the search results
+        const mockSchemaNode = new (require('../../providers/objectTreeProvider').ObjectTreeItem)({
+            label: 'MY_SCHEMA',
+            type: 'schema',
+            connectionId: 'conn-1',
+            schemaName: 'MY_SCHEMA',
+        });
+        const mockTablesFolder = new (require('../../providers/objectTreeProvider').ObjectTreeItem)({
+            label: 'Tables',
+            type: 'tables-folder',
+            connectionId: 'conn-1',
+            schemaName: 'MY_SCHEMA',
+        });
+        const mockTableNode = new (require('../../providers/objectTreeProvider').ObjectTreeItem)({
+            label: 'USERS',
+            type: 'table',
+            connectionId: 'conn-1',
+            schemaName: 'MY_SCHEMA',
+        });
+
+        objectTreeProvider.getChildren = async (element?: any) => {
+            if (!element) {
+                return [mockSchemaNode];
+            }
+            if (element === mockSchemaNode) {
+                return [mockTablesFolder];
+            }
+            if (element === mockTablesFolder) {
+                return [mockTableNode];
+            }
+            return [];
+        };
+
+        searchProvider = new ObjectSearchProvider(mockCM, objectTreeProvider, mockTreeView);
+        await searchProvider.showSearch();
+
+        const tableItem = mockQuickPick.items.find(
+            (i: any) => i.label.includes('USERS') && i.detail === 'Table'
+        );
+        assert.ok(tableItem, 'Should find USERS table item');
+
+        mockQuickPick.selectedItems = [tableItem];
+        assert.ok(mockQuickPick._acceptCallback, 'Accept callback should be registered');
+        await mockQuickPick._acceptCallback();
+
+        assert.strictEqual(revealCalls.length, 1, 'Should call reveal exactly once');
+        assert.strictEqual(revealCalls[0].node, mockTableNode, 'Should reveal the correct tree node');
+        assert.deepStrictEqual(revealCalls[0].options, {
+            select: true,
+            focus: true,
+            expand: true
+        }, 'Should pass correct reveal options');
+    });
+
+    test('formatTypeLabel and typeLabelToTreeType are inverse operations', () => {
+        const searchableTypes = [
+            'table', 'view', 'script', 'function', 'virtual-table', 'system-table', 'column'
+        ];
+
+        for (const type of searchableTypes) {
+            const label = searchProvider.formatTypeLabel(type);
+            const roundTripped = searchProvider.typeLabelToTreeType(label);
+            assert.strictEqual(
+                roundTripped,
+                type,
+                `Round-trip failed for '${type}': formatTypeLabel('${type}') = '${label}', typeLabelToTreeType('${label}') = '${roundTripped}'`
+            );
+        }
+    });
+
+    test('QuickPick items have correct icon for each type', async () => {
+        await searchProvider.showSearch();
+
+        const tableItem = mockQuickPick.items.find(
+            (i: any) => i.detail === 'Table'
+        );
+        assert.ok(tableItem, 'Should find a table item');
+        assert.ok(tableItem.label.includes('$(table)'), 'Table should use table icon');
+
+        const viewItem = mockQuickPick.items.find(
+            (i: any) => i.detail === 'View'
+        );
+        assert.ok(viewItem, 'Should find a view item');
+        assert.ok(viewItem.label.includes('$(eye)'), 'View should use eye icon');
+
+        const colItem = mockQuickPick.items.find(
+            (i: any) => i.detail === 'Column'
+        );
+        assert.ok(colItem, 'Should find a column item');
+        assert.ok(colItem.label.includes('$(symbol-field)'), 'Column should use symbol-field icon');
+    });
+});

--- a/src/test/unit/objectTreeGetParent.test.ts
+++ b/src/test/unit/objectTreeGetParent.test.ts
@@ -1,0 +1,407 @@
+import * as assert from 'assert';
+import { registerVscodeMock, registerExtensionMock } from '../helpers/vscodeMock';
+
+registerVscodeMock();
+registerExtensionMock();
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ObjectTreeProvider } = require('../../providers/objectTreeProvider');
+
+import { createRawResult, createEmptyRawResult } from '../helpers/mockConnectionManager';
+import { MockConnectionManager } from '../helpers/mockConnectionManager';
+
+function getLabelText(item: any): string {
+    if (!item || !item.label) { return ''; }
+    return typeof item.label === 'string' ? item.label : item.label?.label ?? '';
+}
+
+suite('ObjectTreeProvider — getParent()', () => {
+
+    let provider: any;
+    let mockDriver: any;
+
+    setup(() => {
+        mockDriver = {
+            query: async (sql: string) => {
+                if (sql.includes('EXA_SCHEMAS')) {
+                    return createRawResult(
+                        ['SCHEMA_NAME', 'TABLE_COUNT', 'VIEW_COUNT'],
+                        [['MY_SCHEMA', 2, 1]]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS') && !sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                    return createEmptyRawResult(['SCHEMA_NAME']);
+                }
+                if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                    return createEmptyRawResult(['TABLE_SCHEMA', 'TABLE_NAME']);
+                }
+                if (sql.includes('EXA_ALL_TABLES') && sql.includes('MY_SCHEMA')) {
+                    return createRawResult(
+                        ['TABLE_NAME', 'TABLE_ROW_COUNT'],
+                        [['USERS', 100], ['ORDERS', 200]]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIEWS') && sql.includes('MY_SCHEMA')) {
+                    return createRawResult(
+                        ['VIEW_NAME'],
+                        [['ACTIVE_USERS']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_COLUMNS') && sql.includes('USERS')) {
+                    return createRawResult(
+                        ['COLUMN_NAME', 'COLUMN_TYPE', 'COLUMN_IS_NULLABLE'],
+                        [['ID', 'DECIMAL(18,0)', false], ['NAME', 'VARCHAR(100)', true]]
+                    );
+                }
+                if (sql.includes('SCRIPT_TYPE') && sql.includes('COUNT')) {
+                    return createEmptyRawResult(['SCRIPT_TYPE', 'CNT']);
+                }
+                if (sql.includes('EXA_ALL_FUNCTIONS') && sql.includes('COUNT')) {
+                    return createRawResult(['CNT'], [[0]]);
+                }
+                if (sql.includes('EXA_ALL_CONSTRAINTS') && sql.includes('COUNT')) {
+                    return createRawResult(['CNT'], [[0]]);
+                }
+                if (sql.includes('EXA_ALL_INDICES') && sql.includes('COUNT')) {
+                    return createRawResult(['CNT'], [[0]]);
+                }
+                if (sql.includes('EXA_SYSCAT')) {
+                    return createRawResult(
+                        ['OBJECT_NAME'],
+                        [['EXA_ALL_COLUMNS']]
+                    );
+                }
+                if (sql.includes('DESCRIBE')) {
+                    return createRawResult(
+                        ['COLUMN_NAME', 'SQL_TYPE'],
+                        [['COL1', 'VARCHAR(128) UTF8']]
+                    );
+                }
+                return createEmptyRawResult(['DUMMY']);
+            }
+        };
+        const mockCM = new MockConnectionManager(mockDriver);
+        provider = new ObjectTreeProvider(mockCM);
+    });
+
+    test('getParent exists and is a function', () => {
+        assert.strictEqual(typeof provider.getParent, 'function');
+    });
+
+    test('root schemas have null parent', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'MY_SCHEMA');
+        assert.ok(schema, 'Should find MY_SCHEMA');
+        const parent = provider.getParent(schema);
+        assert.strictEqual(parent, null, 'Schema parent should be null');
+    });
+
+    test('system-schemas-folder has null parent', async () => {
+        const rootChildren = await provider.getChildren();
+        const folder = rootChildren.find((c: any) => getLabelText(c) === 'System Schemas');
+        assert.ok(folder, 'Should find System Schemas folder');
+        const parent = provider.getParent(folder);
+        assert.strictEqual(parent, null, 'System-schemas-folder parent should be null');
+    });
+
+    test('tables-folder parent is schema', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'MY_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const tablesFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Tables');
+        assert.ok(tablesFolder, 'Should find Tables folder');
+        const parent = provider.getParent(tablesFolder);
+        assert.strictEqual(parent, schema, 'Tables-folder parent should be the schema');
+    });
+
+    test('views-folder parent is schema', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'MY_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const viewsFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Views');
+        assert.ok(viewsFolder, 'Should find Views folder');
+        const parent = provider.getParent(viewsFolder);
+        assert.strictEqual(parent, schema, 'Views-folder parent should be the schema');
+    });
+
+    test('table parent is tables-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'MY_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const tablesFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Tables');
+        const tables = await provider.getChildren(tablesFolder);
+        const usersTable = tables.find((c: any) => getLabelText(c) === 'USERS');
+        assert.ok(usersTable, 'Should find USERS table');
+        const parent = provider.getParent(usersTable);
+        assert.strictEqual(parent, tablesFolder, 'Table parent should be tables-folder');
+    });
+
+    test('column parent is table', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'MY_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const tablesFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Tables');
+        const tables = await provider.getChildren(tablesFolder);
+        const usersTable = tables.find((c: any) => getLabelText(c) === 'USERS');
+        const columns = await provider.getChildren(usersTable);
+        assert.ok(columns.length > 0, 'Should have columns');
+        const parent = provider.getParent(columns[0]);
+        assert.strictEqual(parent, usersTable, 'Column parent should be the table');
+    });
+
+    test('system-schema parent is system-schemas-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const systemSchemasFolder = rootChildren.find(
+            (c: any) => getLabelText(c) === 'System Schemas'
+        );
+        const systemSchemas = await provider.getChildren(systemSchemasFolder);
+        const sysNode = systemSchemas.find((c: any) => getLabelText(c) === 'SYS');
+        assert.ok(sysNode, 'Should find SYS');
+        const parent = provider.getParent(sysNode);
+        assert.strictEqual(parent, systemSchemasFolder, 'System-schema parent should be system-schemas-folder');
+    });
+
+    test('system-table parent is system-schema', async () => {
+        const rootChildren = await provider.getChildren();
+        const systemSchemasFolder = rootChildren.find(
+            (c: any) => getLabelText(c) === 'System Schemas'
+        );
+        const systemSchemas = await provider.getChildren(systemSchemasFolder);
+        const sysNode = systemSchemas.find((c: any) => getLabelText(c) === 'SYS');
+        const tables = await provider.getChildren(sysNode);
+        assert.ok(tables.length > 0, 'Should have system tables');
+        const parent = provider.getParent(tables[0]);
+        assert.strictEqual(parent, sysNode, 'System-table parent should be system-schema');
+    });
+
+    test('view parent is views-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'MY_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const viewsFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Views');
+        const views = await provider.getChildren(viewsFolder);
+        const activeUsersView = views.find((c: any) => getLabelText(c) === 'ACTIVE_USERS');
+        assert.ok(activeUsersView, 'Should find ACTIVE_USERS view');
+        const parent = provider.getParent(activeUsersView);
+        assert.strictEqual(parent, viewsFolder, 'View parent should be views-folder');
+    });
+});
+
+suite('ObjectTreeProvider — getParent() extended node types', () => {
+
+    let provider: any;
+    let mockDriver: any;
+
+    setup(() => {
+        mockDriver = {
+            query: async (sql: string) => {
+                if (sql.includes('EXA_SCHEMAS')) {
+                    return createRawResult(
+                        ['SCHEMA_NAME', 'TABLE_COUNT', 'VIEW_COUNT'],
+                        [['TEST_SCHEMA', 1, 0]]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS') && !sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                    return createRawResult(
+                        ['SCHEMA_NAME', 'ADAPTER_SCRIPT_SCHEMA', 'ADAPTER_SCRIPT_NAME', 'LAST_REFRESH', 'LAST_REFRESH_BY'],
+                        [['VS_ORACLE', 'MY_SCHEMA', 'ORA_ADAPTER', null, null]]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIRTUAL_TABLES') && sql.includes('VS_ORACLE')) {
+                    return createRawResult(
+                        ['TABLE_NAME'],
+                        [['REMOTE_TABLE']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                    return createEmptyRawResult(['TABLE_NAME']);
+                }
+                if (sql.includes('EXA_ALL_TABLES') && sql.includes('TEST_SCHEMA')) {
+                    return createRawResult(
+                        ['TABLE_NAME', 'TABLE_ROW_COUNT'],
+                        [['MY_TABLE', 50]]
+                    );
+                }
+                if (sql.includes('EXA_ALL_VIEWS') && sql.includes('TEST_SCHEMA')) {
+                    return createEmptyRawResult(['VIEW_NAME']);
+                }
+                if (sql.includes('EXA_ALL_COLUMNS') && sql.includes('MY_TABLE')) {
+                    return createRawResult(
+                        ['COLUMN_NAME', 'COLUMN_TYPE', 'COLUMN_IS_NULLABLE'],
+                        [['COL_A', 'INTEGER', false]]
+                    );
+                }
+                if (sql.includes('SCRIPT_TYPE') && sql.includes('COUNT')) {
+                    return createRawResult(
+                        ['SCRIPT_TYPE', 'SCRIPT_COUNT'],
+                        [['UDF', 1], ['SCRIPTING', 1], ['ADAPTER', 1]]
+                    );
+                }
+                if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('UDF')) {
+                    return createRawResult(
+                        ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                        [['MY_UDF', 'PYTHON3', 'SCALAR', 'UDF']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('SCRIPTING')) {
+                    return createRawResult(
+                        ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                        [['MY_PROC', 'LUA', null, 'SCRIPTING']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_SCRIPTS') && sql.includes('ADAPTER')) {
+                    return createRawResult(
+                        ['SCRIPT_NAME', 'SCRIPT_LANGUAGE', 'SCRIPT_INPUT_TYPE', 'SCRIPT_TYPE'],
+                        [['ORA_ADAPTER', 'JAVA', null, 'ADAPTER']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_FUNCTIONS') && sql.includes('COUNT')) {
+                    return createRawResult(['FUNCTION_COUNT'], [[1]]);
+                }
+                if (sql.includes('FUNCTION_NAME') && sql.includes('TEST_SCHEMA')) {
+                    return createRawResult(
+                        ['FUNCTION_NAME'],
+                        [['MY_FUNC']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_CONSTRAINTS') && sql.includes('COUNT')) {
+                    return createRawResult(['CONSTRAINT_COUNT'], [[1]]);
+                }
+                if (sql.includes('CONSTRAINT_NAME') && sql.includes('MY_TABLE')) {
+                    return createRawResult(
+                        ['CONSTRAINT_NAME', 'CONSTRAINT_TYPE'],
+                        [['PK_MY_TABLE', 'PRIMARY KEY']]
+                    );
+                }
+                if (sql.includes('EXA_ALL_INDICES') && sql.includes('COUNT')) {
+                    return createRawResult(['INDEX_COUNT'], [[1]]);
+                }
+                if (sql.includes('INDEX_NAME') && sql.includes('MY_TABLE')) {
+                    return createRawResult(
+                        ['INDEX_NAME', 'INDEX_TYPE', 'INDEX_COLUMNS'],
+                        [['IDX_COL_A', 'LOCAL', 'COL_A']]
+                    );
+                }
+                if (sql.includes('EXA_SYSCAT')) {
+                    return createRawResult(
+                        ['OBJECT_NAME'],
+                        [['EXA_ALL_COLUMNS']]
+                    );
+                }
+                if (sql.includes('DESCRIBE')) {
+                    return createRawResult(
+                        ['COLUMN_NAME', 'SQL_TYPE'],
+                        [['VC1', 'VARCHAR(128) UTF8']]
+                    );
+                }
+                return createEmptyRawResult(['DUMMY']);
+            }
+        };
+        const mockCM = new MockConnectionManager(mockDriver);
+        provider = new ObjectTreeProvider(mockCM);
+    });
+
+    test('virtual-schema has null parent', async () => {
+        const rootChildren = await provider.getChildren();
+        const vs = rootChildren.find((c: any) => getLabelText(c) === 'VS_ORACLE');
+        assert.ok(vs, 'Should find VS_ORACLE');
+        const parent = provider.getParent(vs);
+        assert.strictEqual(parent, null, 'Virtual-schema parent should be null');
+    });
+
+    test('virtual-table parent is virtual-schema', async () => {
+        const rootChildren = await provider.getChildren();
+        const vs = rootChildren.find((c: any) => getLabelText(c) === 'VS_ORACLE');
+        const vsTables = await provider.getChildren(vs);
+        const remoteTable = vsTables.find((c: any) => getLabelText(c) === 'REMOTE_TABLE');
+        assert.ok(remoteTable, 'Should find REMOTE_TABLE');
+        const parent = provider.getParent(remoteTable);
+        assert.strictEqual(parent, vs, 'Virtual-table parent should be virtual-schema');
+    });
+
+    test('script parent is udfs-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'TEST_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const udfsFolder = schemaChildren.find((c: any) => getLabelText(c) === 'UDFs');
+        assert.ok(udfsFolder, 'Should find UDFs folder');
+        const scripts = await provider.getChildren(udfsFolder);
+        const myUdf = scripts.find((c: any) => getLabelText(c) === 'MY_UDF');
+        assert.ok(myUdf, 'Should find MY_UDF script');
+        const parent = provider.getParent(myUdf);
+        assert.strictEqual(parent, udfsFolder, 'Script parent should be udfs-folder');
+    });
+
+    test('script parent is procedures-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'TEST_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const procsFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Procedures');
+        assert.ok(procsFolder, 'Should find Procedures folder');
+        const scripts = await provider.getChildren(procsFolder);
+        const myProc = scripts.find((c: any) => getLabelText(c) === 'MY_PROC');
+        assert.ok(myProc, 'Should find MY_PROC script');
+        const parent = provider.getParent(myProc);
+        assert.strictEqual(parent, procsFolder, 'Script parent should be procedures-folder');
+    });
+
+    test('script parent is adapters-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'TEST_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const adaptersFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Adapters');
+        assert.ok(adaptersFolder, 'Should find Adapters folder');
+        const scripts = await provider.getChildren(adaptersFolder);
+        const adapter = scripts.find((c: any) => getLabelText(c) === 'ORA_ADAPTER');
+        assert.ok(adapter, 'Should find ORA_ADAPTER script');
+        const parent = provider.getParent(adapter);
+        assert.strictEqual(parent, adaptersFolder, 'Script parent should be adapters-folder');
+    });
+
+    test('function parent is functions-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'TEST_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const functionsFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Functions');
+        assert.ok(functionsFolder, 'Should find Functions folder');
+        const functions = await provider.getChildren(functionsFolder);
+        const myFunc = functions.find((c: any) => getLabelText(c) === 'MY_FUNC');
+        assert.ok(myFunc, 'Should find MY_FUNC');
+        const parent = provider.getParent(myFunc);
+        assert.strictEqual(parent, functionsFolder, 'Function parent should be functions-folder');
+    });
+
+    test('constraint parent is constraints-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'TEST_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const tablesFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Tables');
+        const tables = await provider.getChildren(tablesFolder);
+        const myTable = tables.find((c: any) => getLabelText(c) === 'MY_TABLE');
+        const tableChildren = await provider.getChildren(myTable);
+        const constraintsFolder = tableChildren.find((c: any) => getLabelText(c) === 'Constraints');
+        assert.ok(constraintsFolder, 'Should find Constraints folder');
+        const constraints = await provider.getChildren(constraintsFolder);
+        const pk = constraints.find((c: any) => getLabelText(c) === 'PK_MY_TABLE');
+        assert.ok(pk, 'Should find PK_MY_TABLE');
+        const parent = provider.getParent(pk);
+        assert.strictEqual(parent, constraintsFolder, 'Constraint parent should be constraints-folder');
+    });
+
+    test('index parent is indices-folder', async () => {
+        const rootChildren = await provider.getChildren();
+        const schema = rootChildren.find((c: any) => getLabelText(c) === 'TEST_SCHEMA');
+        const schemaChildren = await provider.getChildren(schema);
+        const tablesFolder = schemaChildren.find((c: any) => getLabelText(c) === 'Tables');
+        const tables = await provider.getChildren(tablesFolder);
+        const myTable = tables.find((c: any) => getLabelText(c) === 'MY_TABLE');
+        const tableChildren = await provider.getChildren(myTable);
+        const indicesFolder = tableChildren.find((c: any) => getLabelText(c) === 'Indices');
+        assert.ok(indicesFolder, 'Should find Indices folder');
+        const indices = await provider.getChildren(indicesFolder);
+        const idx = indices.find((c: any) => getLabelText(c) === 'IDX_COL_A');
+        assert.ok(idx, 'Should find IDX_COL_A');
+        const parent = provider.getParent(idx);
+        assert.strictEqual(parent, indicesFolder, 'Index parent should be indices-folder');
+    });
+});

--- a/src/test/unit/objectTreeSystemSchemas.test.ts
+++ b/src/test/unit/objectTreeSystemSchemas.test.ts
@@ -1,0 +1,253 @@
+import * as assert from 'assert';
+import { registerVscodeMock, registerExtensionMock } from '../helpers/vscodeMock';
+
+registerVscodeMock();
+registerExtensionMock();
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ObjectTreeProvider } = require('../../providers/objectTreeProvider');
+
+import { TEST_CONNECTION, createRawResult, createEmptyRawResult } from '../helpers/mockConnectionManager';
+import { MockConnectionManager } from '../helpers/mockConnectionManager';
+
+function getLabelText(item: any): string {
+    if (!item || !item.label) { return ''; }
+    return typeof item.label === 'string' ? item.label : item.label?.label ?? '';
+}
+
+suite('ObjectTreeProvider — System Schemas', () => {
+
+    suite('System Schemas folder at root level', () => {
+        test('appears after user and virtual schemas', async () => {
+            const mockDriver = {
+                query: async (sql: string) => {
+                    if (sql.includes('EXA_SCHEMAS')) {
+                        return createRawResult(
+                            ['SCHEMA_NAME'],
+                            [['MY_SCHEMA'], ['PUBLIC']]
+                        );
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createRawResult(
+                            ['SCHEMA_NAME'],
+                            [['VS_ONE']]
+                        );
+                    }
+                    // Virtual schema tables query
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        return createEmptyRawResult(['TABLE_SCHEMA', 'TABLE_NAME']);
+                    }
+                    return createEmptyRawResult(['DUMMY']);
+                }
+            };
+            const mockCM = new MockConnectionManager(mockDriver);
+            const provider = new ObjectTreeProvider(mockCM);
+
+            const rootChildren = await provider.getChildren();
+
+            // Last item should be "System Schemas"
+            const lastItem = rootChildren[rootChildren.length - 1];
+            assert.strictEqual(getLabelText(lastItem), 'System Schemas');
+
+            // SYS and EXA_STATISTICS should not appear as root-level schema nodes
+            const labels = rootChildren.map((c: any) => getLabelText(c));
+            assert.ok(!labels.includes('SYS'), 'SYS should not be a root-level user schema');
+            assert.ok(!labels.includes('EXA_STATISTICS'), 'EXA_STATISTICS should not be a root-level user schema');
+        });
+    });
+
+    suite('System Schemas folder contains SYS and EXA_STATISTICS', () => {
+        test('expanding the folder returns two children', async () => {
+            const mockDriver = {
+                query: async () => createEmptyRawResult(['DUMMY'])
+            };
+            const mockCM = new MockConnectionManager(mockDriver);
+            const provider = new ObjectTreeProvider(mockCM);
+
+            const rootChildren = await provider.getChildren();
+            const systemSchemasFolder = rootChildren.find(
+                (c: any) => getLabelText(c) === 'System Schemas'
+            );
+
+            const children = await provider.getChildren(systemSchemasFolder);
+            assert.strictEqual(children.length, 2);
+
+            const labels = children.map((c: any) => getLabelText(c));
+            assert.ok(labels.includes('SYS'), 'Should contain SYS');
+            assert.ok(labels.includes('EXA_STATISTICS'), 'Should contain EXA_STATISTICS');
+        });
+    });
+
+    suite('System tables listed alphabetically', () => {
+        test('returns tables in alphabetical order from the DB', async () => {
+            const mockDriver = {
+                query: async (sql: string) => {
+                    if (sql.includes('EXA_SCHEMAS')) {
+                        return createRawResult(['SCHEMA_NAME'], [['MY_SCHEMA']]);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createEmptyRawResult(['SCHEMA_NAME']);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        return createEmptyRawResult(['TABLE_SCHEMA', 'TABLE_NAME']);
+                    }
+                    if (sql.includes('EXA_SYSCAT') && sql.includes("'SYS'")) {
+                        return createRawResult(
+                            ['OBJECT_NAME'],
+                            [['EXA_ALL_COLUMNS'], ['EXA_ALL_OBJECTS'], ['EXA_ALL_TABLES']]
+                        );
+                    }
+                    return createEmptyRawResult(['DUMMY']);
+                }
+            };
+            const mockCM = new MockConnectionManager(mockDriver);
+            const provider = new ObjectTreeProvider(mockCM);
+
+            // Navigate to SYS system-schema node
+            const rootChildren = await provider.getChildren();
+            const systemSchemasFolder = rootChildren.find(
+                (c: any) => getLabelText(c) === 'System Schemas'
+            );
+            const systemSchemas = await provider.getChildren(systemSchemasFolder);
+            const sysNode = systemSchemas.find((c: any) => getLabelText(c) === 'SYS');
+
+            const tables = await provider.getChildren(sysNode);
+            assert.strictEqual(tables.length, 3);
+            assert.strictEqual(getLabelText(tables[0]), 'EXA_ALL_COLUMNS');
+            assert.strictEqual(getLabelText(tables[1]), 'EXA_ALL_OBJECTS');
+            assert.strictEqual(getLabelText(tables[2]), 'EXA_ALL_TABLES');
+        });
+    });
+
+    suite('Table columns expandable', () => {
+        test('expanding a system table returns columns with types', async () => {
+            const mockDriver = {
+                query: async (sql: string) => {
+                    if (sql.includes('EXA_SCHEMAS')) {
+                        return createRawResult(['SCHEMA_NAME'], [['MY_SCHEMA']]);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createEmptyRawResult(['SCHEMA_NAME']);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        return createEmptyRawResult(['TABLE_SCHEMA', 'TABLE_NAME']);
+                    }
+                    if (sql.includes('EXA_SYSCAT') && sql.includes("'SYS'")) {
+                        return createRawResult(
+                            ['OBJECT_NAME'],
+                            [['EXA_ALL_COLUMNS']]
+                        );
+                    }
+                    if (sql.includes('DESCRIBE')) {
+                        return createRawResult(
+                            ['COLUMN_NAME', 'SQL_TYPE'],
+                            [
+                                ['COLUMN_SCHEMA', 'VARCHAR(128) UTF8'],
+                                ['COLUMN_TABLE', 'VARCHAR(128) UTF8'],
+                                ['COLUMN_NAME', 'VARCHAR(128) UTF8']
+                            ]
+                        );
+                    }
+                    return createEmptyRawResult(['DUMMY']);
+                }
+            };
+            const mockCM = new MockConnectionManager(mockDriver);
+            const provider = new ObjectTreeProvider(mockCM);
+
+            // Navigate: root > System Schemas > SYS > EXA_ALL_COLUMNS
+            const rootChildren = await provider.getChildren();
+            const systemSchemasFolder = rootChildren.find(
+                (c: any) => getLabelText(c) === 'System Schemas'
+            );
+            const systemSchemas = await provider.getChildren(systemSchemasFolder);
+            const sysNode = systemSchemas.find((c: any) => getLabelText(c) === 'SYS');
+            const tables = await provider.getChildren(sysNode);
+            const table = tables.find((c: any) => getLabelText(c) === 'EXA_ALL_COLUMNS');
+
+            const columns = await provider.getChildren(table);
+            assert.strictEqual(columns.length, 3);
+
+            // Columns should show name and type
+            const firstLabel = getLabelText(columns[0]);
+            assert.ok(
+                firstLabel.includes('COLUMN_SCHEMA'),
+                `First column label should contain COLUMN_SCHEMA, got: ${firstLabel}`
+            );
+        });
+    });
+
+    suite('Permission error — graceful fallback', () => {
+        test('fetchSystemTables returns empty array on error', async () => {
+            const mockDriver = {
+                query: async (sql: string) => {
+                    if (sql.includes('EXA_SCHEMAS')) {
+                        return createRawResult(['SCHEMA_NAME'], [['MY_SCHEMA']]);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createEmptyRawResult(['SCHEMA_NAME']);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        return createEmptyRawResult(['TABLE_SCHEMA', 'TABLE_NAME']);
+                    }
+                    if (sql.includes('EXA_SYSCAT') && sql.includes("'SYS'")) {
+                        throw new Error('insufficient privileges');
+                    }
+                    return createEmptyRawResult(['DUMMY']);
+                }
+            };
+            const mockCM = new MockConnectionManager(mockDriver);
+            const provider = new ObjectTreeProvider(mockCM);
+
+            // Navigate to SYS
+            const rootChildren = await provider.getChildren();
+            const systemSchemasFolder = rootChildren.find(
+                (c: any) => getLabelText(c) === 'System Schemas'
+            );
+            const systemSchemas = await provider.getChildren(systemSchemasFolder);
+            const sysNode = systemSchemas.find((c: any) => getLabelText(c) === 'SYS');
+
+            // Should return empty array, not throw
+            const tables = await provider.getChildren(sysNode);
+            assert.strictEqual(tables.length, 0, 'Should return empty array on permission error');
+        });
+
+        test('fetchSystemTableColumns returns empty array on error', async () => {
+            const mockDriver = {
+                query: async (sql: string) => {
+                    if (sql.includes('EXA_SCHEMAS')) {
+                        return createRawResult(['SCHEMA_NAME'], [['MY_SCHEMA']]);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_SCHEMAS')) {
+                        return createEmptyRawResult(['SCHEMA_NAME']);
+                    }
+                    if (sql.includes('EXA_ALL_VIRTUAL_TABLES')) {
+                        return createEmptyRawResult(['TABLE_SCHEMA', 'TABLE_NAME']);
+                    }
+                    if (sql.includes('EXA_SYSCAT') && sql.includes("'SYS'")) {
+                        return createRawResult(['OBJECT_NAME'], [['EXA_ALL_COLUMNS']]);
+                    }
+                    if (sql.includes('DESCRIBE')) {
+                        throw new Error('insufficient privileges');
+                    }
+                    return createEmptyRawResult(['DUMMY']);
+                }
+            };
+            const mockCM = new MockConnectionManager(mockDriver);
+            const provider = new ObjectTreeProvider(mockCM);
+
+            // Navigate to SYS > EXA_ALL_COLUMNS
+            const rootChildren = await provider.getChildren();
+            const systemSchemasFolder = rootChildren.find(
+                (c: any) => getLabelText(c) === 'System Schemas'
+            );
+            const systemSchemas = await provider.getChildren(systemSchemasFolder);
+            const sysNode = systemSchemas.find((c: any) => getLabelText(c) === 'SYS');
+            const tables = await provider.getChildren(sysNode);
+            const table = tables[0];
+
+            // Should return empty array, not throw
+            const columns = await provider.getChildren(table);
+            assert.strictEqual(columns.length, 0, 'Should return empty array on permission error');
+        });
+    });
+});

--- a/src/test/unit/objectTreeTypes.test.ts
+++ b/src/test/unit/objectTreeTypes.test.ts
@@ -1,0 +1,217 @@
+import * as assert from 'assert';
+import { ObjectTreeItemType, getNodeTypeConfig } from '../../providers/objectTreeTypes';
+
+suite('ObjectTreeItemType and getNodeTypeConfig', () => {
+
+    suite('existing node types', () => {
+        test('schema returns symbol-namespace icon', () => {
+            const config = getNodeTypeConfig('schema');
+            assert.ok(config);
+            assert.strictEqual(config.icon, 'symbol-namespace');
+            assert.strictEqual(config.contextValue, 'schema');
+        });
+
+        test('tables-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('tables-folder');
+            assert.ok(config);
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'tables-folder');
+        });
+
+        test('table returns table icon', () => {
+            const config = getNodeTypeConfig('table');
+            assert.ok(config);
+            assert.strictEqual(config.icon, 'table');
+            assert.strictEqual(config.contextValue, 'table');
+        });
+
+        test('views-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('views-folder');
+            assert.ok(config);
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'views-folder');
+        });
+
+        test('view returns eye icon', () => {
+            const config = getNodeTypeConfig('view');
+            assert.ok(config);
+            assert.strictEqual(config.icon, 'eye');
+            assert.strictEqual(config.contextValue, 'view');
+        });
+
+        test('column returns symbol-field icon', () => {
+            const config = getNodeTypeConfig('column');
+            assert.ok(config);
+            assert.strictEqual(config.icon, 'symbol-field');
+            assert.strictEqual(config.contextValue, 'column');
+        });
+    });
+
+    suite('new node types', () => {
+        test('virtual-schema returns remote icon', () => {
+            const config = getNodeTypeConfig('virtual-schema');
+            assert.ok(config, 'virtual-schema should return a config');
+            assert.strictEqual(config.icon, 'remote');
+            assert.strictEqual(config.contextValue, 'virtual-schema');
+        });
+
+        test('virtual-table returns table icon', () => {
+            const config = getNodeTypeConfig('virtual-table');
+            assert.ok(config, 'virtual-table should return a config');
+            assert.strictEqual(config.icon, 'table');
+            assert.strictEqual(config.contextValue, 'virtual-table');
+        });
+
+        test('udfs-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('udfs-folder');
+            assert.ok(config, 'udfs-folder should return a config');
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'udfs-folder');
+        });
+
+        test('procedures-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('procedures-folder');
+            assert.ok(config, 'procedures-folder should return a config');
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'procedures-folder');
+        });
+
+        test('adapters-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('adapters-folder');
+            assert.ok(config, 'adapters-folder should return a config');
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'adapters-folder');
+        });
+
+        test('functions-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('functions-folder');
+            assert.ok(config, 'functions-folder should return a config');
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'functions-folder');
+        });
+
+        test('script with UDF type returns symbol-method icon', () => {
+            const config = getNodeTypeConfig('script', { scriptType: 'UDF' });
+            assert.ok(config, 'script (UDF) should return a config');
+            assert.strictEqual(config.icon, 'symbol-method');
+            assert.strictEqual(config.contextValue, 'script');
+        });
+
+        test('script with SCRIPTING type returns symbol-event icon', () => {
+            const config = getNodeTypeConfig('script', { scriptType: 'SCRIPTING' });
+            assert.ok(config, 'script (SCRIPTING) should return a config');
+            assert.strictEqual(config.icon, 'symbol-event');
+            assert.strictEqual(config.contextValue, 'script');
+        });
+
+        test('script with ADAPTER type returns extensions icon', () => {
+            const config = getNodeTypeConfig('script', { scriptType: 'ADAPTER' });
+            assert.ok(config, 'script (ADAPTER) should return a config');
+            assert.strictEqual(config.icon, 'extensions');
+            assert.strictEqual(config.contextValue, 'script');
+        });
+
+        test('script with no type defaults to symbol-method icon', () => {
+            const config = getNodeTypeConfig('script');
+            assert.ok(config, 'script (default) should return a config');
+            assert.strictEqual(config.icon, 'symbol-method');
+            assert.strictEqual(config.contextValue, 'script');
+        });
+
+        test('function returns symbol-function icon', () => {
+            const config = getNodeTypeConfig('function');
+            assert.ok(config, 'function should return a config');
+            assert.strictEqual(config.icon, 'symbol-function');
+            assert.strictEqual(config.contextValue, 'function');
+        });
+
+        test('constraints-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('constraints-folder');
+            assert.ok(config, 'constraints-folder should return a config');
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'constraints-folder');
+        });
+
+        test('indices-folder returns folder icon', () => {
+            const config = getNodeTypeConfig('indices-folder');
+            assert.ok(config, 'indices-folder should return a config');
+            assert.strictEqual(config.icon, 'folder');
+            assert.strictEqual(config.contextValue, 'indices-folder');
+        });
+
+        test('constraint with PRIMARY KEY type returns key icon', () => {
+            const config = getNodeTypeConfig('constraint', { constraintType: 'PRIMARY KEY' });
+            assert.ok(config, 'constraint (PK) should return a config');
+            assert.strictEqual(config.icon, 'key');
+            assert.strictEqual(config.contextValue, 'constraint');
+        });
+
+        test('constraint with FOREIGN KEY type returns link icon', () => {
+            const config = getNodeTypeConfig('constraint', { constraintType: 'FOREIGN KEY' });
+            assert.ok(config, 'constraint (FK) should return a config');
+            assert.strictEqual(config.icon, 'link');
+            assert.strictEqual(config.contextValue, 'constraint');
+        });
+
+        test('constraint with other type returns key icon', () => {
+            const config = getNodeTypeConfig('constraint', { constraintType: 'NOT NULL' });
+            assert.ok(config, 'constraint (other) should return a config');
+            assert.strictEqual(config.icon, 'key');
+            assert.strictEqual(config.contextValue, 'constraint');
+        });
+
+        test('constraint with no type defaults to key icon', () => {
+            const config = getNodeTypeConfig('constraint');
+            assert.ok(config, 'constraint (default) should return a config');
+            assert.strictEqual(config.icon, 'key');
+            assert.strictEqual(config.contextValue, 'constraint');
+        });
+
+        test('index returns list-tree icon', () => {
+            const config = getNodeTypeConfig('index');
+            assert.ok(config, 'index should return a config');
+            assert.strictEqual(config.icon, 'list-tree');
+            assert.strictEqual(config.contextValue, 'index');
+        });
+
+        test('system-schemas-folder returns library icon', () => {
+            const config = getNodeTypeConfig('system-schemas-folder');
+            assert.ok(config, 'system-schemas-folder should return a config');
+            assert.strictEqual(config.icon, 'library');
+            assert.strictEqual(config.contextValue, 'system-schemas-folder');
+        });
+
+        test('system-schema returns database icon', () => {
+            const config = getNodeTypeConfig('system-schema');
+            assert.ok(config, 'system-schema should return a config');
+            assert.strictEqual(config.icon, 'database');
+            assert.strictEqual(config.contextValue, 'system-schema');
+        });
+
+        test('system-table returns table icon', () => {
+            const config = getNodeTypeConfig('system-table');
+            assert.ok(config, 'system-table should return a config');
+            assert.strictEqual(config.icon, 'table');
+            assert.strictEqual(config.contextValue, 'system-table');
+        });
+    });
+
+    suite('type safety', () => {
+        test('all new types are valid ObjectTreeItemType values', () => {
+            const allTypes: ObjectTreeItemType[] = [
+                'schema', 'tables-folder', 'table', 'views-folder', 'view', 'column',
+                'virtual-schema', 'virtual-table',
+                'udfs-folder', 'procedures-folder', 'adapters-folder', 'functions-folder',
+                'script', 'function',
+                'constraints-folder', 'indices-folder', 'constraint', 'index',
+                'system-schemas-folder', 'system-schema', 'system-table'
+            ];
+            for (const type of allTypes) {
+                const config = getNodeTypeConfig(type);
+                assert.ok(config, `${type} should return a valid config`);
+                assert.ok(config.icon, `${type} should have an icon`);
+                assert.ok(config.contextValue, `${type} should have a contextValue`);
+            }
+        });
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,14 @@
 import type { ExasolDriver, SQLQueriesResponse, SQLQueryColumn, SQLResponse } from '@exasol/exasol-driver-ts';
 
 /**
+ * Escape a string value for safe interpolation into SQL single-quoted literals.
+ * Doubles all single-quote characters to prevent SQL injection.
+ */
+export function escapeSqlString(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+/**
  * Type guard for raw Exasol driver responses (responseType: 'raw')
  */
 function isRawResponse(result: unknown): result is SQLResponse<SQLQueriesResponse> {


### PR DESCRIPTION
## Summary

- **Multi-result tabs** — each statement result in its own tab with per-tab sort/filter/scroll state, close buttons, and error indicators
- **Extended object tree** — scripts (UDF/procedure/adapter), functions, virtual schema tables, constraints, indices, and system schemas (SYS, EXA_STATISTICS)
- **Find Database Object** — QuickPick search command (`Ctrl+Shift+F`) across all object types with tree reveal on selection
- **SQL formatting** — configurable keyword case, indentation, and statement spacing via sql-formatter
- 192 unit tests (up from ~60), plus jsdom webview rendering tests and e2e harness

## Test plan

- [x] `npm run compile` passes
- [x] `npm run test:unit` — 192 passing, 0 failures
- [x] Manual: open command palette → "Find Database Object" → select object → verify tree reveal
- [x] Manual: execute multi-statement query → verify separate tabs with close buttons
- [x] Manual: expand object tree → verify scripts, functions, virtual schemas, constraints, indices, system schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)