### PR TITLE
Use raw response mode for all driver queries to fix numResults crash

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,3 +22,4 @@ specs/**
 examples/**
 .serena/**
 vendor/**
+.venv/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to the "Exasol" extension will be documented in this file.
 ## [1.3.3] - 2026-03-31
 
 ### Changed
-- Show individual list of errors instead of `AggregateError` when multiple error occur
+- Show individual list of errors instead of `AggregateError` when multiple errors occur
 
+### Fixed
+- Fixed TypeError crash ("Cannot read properties of undefined reading 'numResults'") when database returns error responses during queries, object tree browsing, search, and autocomplete
+- SQL error messages now include the error code (e.g., `SQL Error [42000]: object not found`)
 
 ## [1.3.2] - 2026-03-24
 

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as crypto from 'crypto';
 import * as tls from 'tls';
 import { ExasolDriver, ExaWebsocket } from '@exasol/exasol-driver-ts';
+import { rawQuery } from './utils';
 import { WebSocket } from 'ws';
 import { getOutputChannel } from './extension';
 import {
@@ -639,7 +640,7 @@ export class ConnectionManager {
             // No mutex here — callers (executeWithRetry) already hold the mutex,
             // so this runs inside the exclusive section.
             await withTimeout(
-                driver.query('SELECT 1'),
+                rawQuery(driver, 'SELECT 1'),
                 validationTimeout,
                 'Validation timeout'
             );

--- a/src/objectActions.ts
+++ b/src/objectActions.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ConnectionManager, StoredConnection } from './connectionManager';
 import { QueryExecutor, QueryResult, ColumnMetadata } from './queryExecutor';
 import { ResultsPanel } from './panels/resultsPanel';
-import { getColumnsFromResult, getRowsFromResult } from './utils';
+import { getColumnsFromResult, getRowsFromResult, rawQuery } from './utils';
 
 export class ObjectActions {
     constructor(
@@ -54,7 +54,7 @@ export class ObjectActions {
                         const driver = await this.connectionManager.getDriver(connection.id);
 
                         const startTime = Date.now();
-                        const result = await driver.query(query);
+                        const result = await rawQuery(driver, query);
                         const executionTime = Date.now() - startTime;
 
                         const columnsMeta = getColumnsFromResult(result);
@@ -95,7 +95,7 @@ export class ObjectActions {
                     AND COLUMN_TABLE = '${tableName}'
                     ORDER BY COLUMN_ORDINAL_POSITION
                 `;
-                const result = await driver.query(query);
+                const result = await rawQuery(driver, query);
                 return getRowsFromResult(result);
             }, connection.id);
 
@@ -131,7 +131,7 @@ export class ObjectActions {
                     WHERE VIEW_SCHEMA = '${schemaName}'
                     AND VIEW_NAME = '${viewName}'
                 `;
-                const result = await driver.query(query);
+                const result = await rawQuery(driver, query);
                 return getRowsFromResult(result);
             }, connection.id);
 
@@ -164,7 +164,7 @@ export class ObjectActions {
                     AND COLUMN_TABLE = '${tableName}'
                     ORDER BY COLUMN_ORDINAL_POSITION
                 `;
-                const result = await driver.query(query);
+                const result = await rawQuery(driver, query);
                 return getRowsFromResult(result);
             }, connection.id);
 
@@ -211,7 +211,7 @@ export class ObjectActions {
                 `;
 
                 const startTime = Date.now();
-                const result = await driver.query(query);
+                const result = await rawQuery(driver, query);
                 const executionTime = Date.now() - startTime;
 
                 const columnsMeta = getColumnsFromResult(result);

--- a/src/providers/completionProvider.ts
+++ b/src/providers/completionProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ConnectionManager, BACKGROUND_QUERY_TIMEOUT_MS } from '../connectionManager';
 import { getOutputChannel } from '../extension';
-import { getRowsFromResult } from '../utils';
+import { getRowsFromResult, rawQuery } from '../utils';
 
 interface DatabaseObject {
     schema: string;
@@ -158,7 +158,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
         try {
             await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connectionId, 'background');
-                const result = await this.safeQuery(driver, 'SELECT keyword FROM sys.exa_sql_keywords WHERE reserved');
+                const result = await rawQuery(driver, 'SELECT keyword FROM sys.exa_sql_keywords WHERE reserved');
                 const rows = getRowsFromResult(result);
                 this.reservedKeywords = new Set(rows.map((r: any) => r.KEYWORD.toUpperCase()));
                 this.reservedKeywordsLoaded = true;
@@ -349,14 +349,14 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                     WHERE SCHEMA_NAME NOT IN ('SYS', 'EXA_STATISTICS')
                     ORDER BY SCHEMA_NAME
                 `;
-                const result = await this.safeQuery(driver, schemasQuery);
+                const result = await rawQuery(driver, schemasQuery);
                 const rows = getRowsFromResult(result);
                 const schemas = rows.map((r: any) => r.SCHEMA_NAME);
 
                 schemas.push('SYS', 'EXA_STATISTICS');
 
                 try {
-                    const vsResult = await this.safeQuery(driver, 'SELECT SCHEMA_NAME FROM SYS.EXA_ALL_VIRTUAL_SCHEMAS ORDER BY SCHEMA_NAME');
+                    const vsResult = await rawQuery(driver, 'SELECT SCHEMA_NAME FROM SYS.EXA_ALL_VIRTUAL_SCHEMAS ORDER BY SCHEMA_NAME');
                     const vsRows = getRowsFromResult(vsResult);
                     for (const row of vsRows) {
                         if (!schemas.includes(row.SCHEMA_NAME)) {
@@ -409,7 +409,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                     ORDER BY 1, 2
                 `;
 
-                const result = await this.safeQuery(driver, tablesQuery);
+                const result = await rawQuery(driver, tablesQuery);
                 const tableRows = getRowsFromResult(result);
 
                 // Fetch ALL columns in one bulk query instead of N per-table queries.
@@ -422,7 +422,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                 `;
                 const columnsByTable = new Map<string, string[]>();
                 try {
-                    const colResult = await this.safeQuery(driver, allColumnsQuery);
+                    const colResult = await rawQuery(driver, allColumnsQuery);
                     const colRows = getRowsFromResult(colResult);
                     for (const row of colRows) {
                         const key = `${row.COLUMN_SCHEMA}.${row.COLUMN_TABLE}`;
@@ -449,7 +449,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                         WHERE SCRIPT_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
                         ORDER BY SCRIPT_SCHEMA, SCRIPT_NAME
                     `;
-                    const scriptResult = await this.safeQuery(driver, scriptsQuery);
+                    const scriptResult = await rawQuery(driver, scriptsQuery);
                     const scriptRows = getRowsFromResult(scriptResult);
                     for (const row of scriptRows) {
                         objects.push({
@@ -469,7 +469,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                         WHERE FUNCTION_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
                         ORDER BY FUNCTION_SCHEMA, FUNCTION_NAME
                     `;
-                    const funcResult = await this.safeQuery(driver, functionsQuery);
+                    const funcResult = await rawQuery(driver, functionsQuery);
                     const funcRows = getRowsFromResult(funcResult);
                     for (const row of funcRows) {
                         objects.push({
@@ -488,7 +488,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                         FROM SYS.EXA_ALL_VIRTUAL_TABLES
                         ORDER BY TABLE_SCHEMA, TABLE_NAME
                     `;
-                    const vtResult = await this.safeQuery(driver, virtualTablesQuery);
+                    const vtResult = await rawQuery(driver, virtualTablesQuery);
                     const vtRows = getRowsFromResult(vtResult);
                     for (const row of vtRows) {
                         objects.push({
@@ -508,7 +508,7 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
                         WHERE SCHEMA_NAME IN ('SYS', 'EXA_STATISTICS')
                         ORDER BY SCHEMA_NAME, OBJECT_NAME
                     `;
-                    const stResult = await this.safeQuery(driver, systemTablesQuery);
+                    const stResult = await rawQuery(driver, systemTablesQuery);
                     const stRows = getRowsFromResult(stResult);
                     for (const row of stRows) {
                         objects.push({
@@ -547,15 +547,4 @@ export class ExasolCompletionProvider implements vscode.CompletionItemProvider {
         }
     }
 
-    private async safeQuery(driver: any, sql: string): Promise<any> {
-        try {
-            return await driver.query(sql);
-        } catch (error) {
-            const message = (error instanceof Error ? error.message : String(error ?? '')).toUpperCase();
-            if (message.includes('INVALID RESULT TYPE') || message.includes('MALFORMED RESULT')) {
-                return await driver.query(sql, undefined, undefined, 'raw');
-            }
-            throw error;
-        }
-    }
 }

--- a/src/providers/objectSearchProvider.ts
+++ b/src/providers/objectSearchProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ConnectionManager, BACKGROUND_QUERY_TIMEOUT_MS } from '../connectionManager';
 import { getOutputChannel } from '../extension';
-import { getRowsFromResult } from '../utils';
+import { getRowsFromResult, rawQuery } from '../utils';
 import { ObjectTreeProvider, ObjectTreeItem, ObjectNode } from './objectTreeProvider';
 import { getNodeTypeConfig, ObjectTreeItemType } from './objectTreeTypes';
 
@@ -73,7 +73,7 @@ export class ObjectSearchProvider {
             const driver = await this.connectionManager.getDriver(connectionId, 'background');
             const objects: SearchableObject[] = [];
 
-            const tablesResult = await driver.query(`
+            const tablesResult = await rawQuery(driver, `
                 SELECT TABLE_SCHEMA, TABLE_NAME, 'table' AS OBJECT_TYPE
                 FROM SYS.EXA_ALL_TABLES
                 WHERE TABLE_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
@@ -92,7 +92,7 @@ export class ObjectSearchProvider {
             }
 
             try {
-                const scriptsResult = await driver.query(`
+                const scriptsResult = await rawQuery(driver, `
                     SELECT SCRIPT_SCHEMA, SCRIPT_NAME
                     FROM SYS.EXA_ALL_SCRIPTS
                     WHERE SCRIPT_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
@@ -110,7 +110,7 @@ export class ObjectSearchProvider {
             }
 
             try {
-                const functionsResult = await driver.query(`
+                const functionsResult = await rawQuery(driver, `
                     SELECT FUNCTION_SCHEMA, FUNCTION_NAME
                     FROM SYS.EXA_ALL_FUNCTIONS
                     WHERE FUNCTION_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')
@@ -128,7 +128,7 @@ export class ObjectSearchProvider {
             }
 
             try {
-                const virtualTablesResult = await driver.query(`
+                const virtualTablesResult = await rawQuery(driver, `
                     SELECT TABLE_SCHEMA, TABLE_NAME
                     FROM SYS.EXA_ALL_VIRTUAL_TABLES
                     ORDER BY TABLE_SCHEMA, TABLE_NAME
@@ -145,7 +145,7 @@ export class ObjectSearchProvider {
             }
 
             try {
-                const systemTablesResult = await driver.query(`
+                const systemTablesResult = await rawQuery(driver, `
                     SELECT SCHEMA_NAME AS TABLE_SCHEMA, OBJECT_NAME AS TABLE_NAME
                     FROM SYS.EXA_SYSCAT
                     WHERE SCHEMA_NAME IN ('SYS', 'EXA_STATISTICS')
@@ -163,7 +163,7 @@ export class ObjectSearchProvider {
             }
 
             try {
-                const columnsResult = await driver.query(`
+                const columnsResult = await rawQuery(driver, `
                     SELECT COLUMN_SCHEMA, COLUMN_TABLE, COLUMN_NAME
                     FROM SYS.EXA_ALL_COLUMNS
                     WHERE COLUMN_SCHEMA NOT IN ('SYS', 'EXA_STATISTICS')

--- a/src/providers/objectTreeProvider.ts
+++ b/src/providers/objectTreeProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ConnectionManager, StoredConnection, BACKGROUND_QUERY_TIMEOUT_MS } from '../connectionManager';
 import { getOutputChannel } from '../extension';
-import { getRowsFromResult, escapeSqlString } from '../utils';
+import { getRowsFromResult, escapeSqlString, rawQuery } from '../utils';
 import { ObjectTreeItemType, getNodeTypeConfig } from './objectTreeTypes';
 
 export type ObjectNode = ObjectTreeItem | ObjectMessageItem;
@@ -634,7 +634,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
 
             // Try to get schema counts in a single query
             try {
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT
                         s.SCHEMA_NAME,
                         COALESCE(t.TABLE_COUNT, 0) AS TABLE_COUNT,
@@ -652,7 +652,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                     ) v ON s.SCHEMA_NAME = v.VIEW_SCHEMA
                     WHERE s.SCHEMA_NAME NOT IN ('SYS', 'EXA_STATISTICS')
                     ORDER BY s.SCHEMA_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 outputChannel?.appendLine(`   Schema query with counts returned ${rows.length} rows`);
                 return rows.map((row: any) => ({
@@ -665,7 +665,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                 outputChannel?.appendLine(`   Falling back to simple schema query without counts...`);
 
                 // Fallback to simple query without counts
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT SCHEMA_NAME
                     FROM SYS.EXA_SCHEMAS
                     WHERE SCHEMA_NAME NOT IN ('SYS', 'EXA_STATISTICS')
@@ -766,7 +766,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
             for (const attempt of attempts) {
                 outputChannel?.appendLine(`   Running tables query (${attempt.description}) for '${schemaName}'`);
                 try {
-                    const result = await driver.query(attempt.sql, undefined, undefined, 'raw');
+                    const result = await rawQuery(driver, attempt.sql);
                     const rows = getRowsFromResult(result);
                     outputChannel?.appendLine(`   ${attempt.description} returned ${rows.length} rows`);
                     return attempt.map(rows);
@@ -859,7 +859,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
             for (const attempt of attempts) {
                 outputChannel?.appendLine(`   Running views query (${attempt.description}) for schema '${schemaName}'`);
                 try {
-                    const rawResult = await driver.query(attempt.sql, undefined, undefined, 'raw');
+                    const rawResult = await rawQuery(driver, attempt.sql);
                     const validated = this.getRawResultOrThrow(rawResult);
                     const rows = getRowsFromResult(validated);
                     outputChannel?.appendLine(`   ${attempt.description} returned ${rows.length} rows`);
@@ -894,7 +894,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT
                         COLUMN_NAME,
                         COLUMN_TYPE,
@@ -924,12 +924,12 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT SCRIPT_TYPE, COUNT(*) AS SCRIPT_COUNT
                     FROM SYS.EXA_ALL_SCRIPTS
                     WHERE SCRIPT_SCHEMA = '${escapeSqlString(schemaName)}'
                     GROUP BY SCRIPT_TYPE
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 const counts = new Map<string, number>();
                 for (const row of rows) {
@@ -955,11 +955,11 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT COUNT(*) AS FUNCTION_COUNT
                     FROM SYS.EXA_ALL_FUNCTIONS
                     WHERE FUNCTION_SCHEMA = '${escapeSqlString(schemaName)}'
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 if (rows.length > 0) {
                     return this.parseRowCount(rows[0].FUNCTION_COUNT) ?? 0;
@@ -981,7 +981,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT
                         SCRIPT_NAME,
                         SCRIPT_LANGUAGE,
@@ -991,7 +991,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                     WHERE SCRIPT_SCHEMA = '${escapeSqlString(schemaName)}'
                     AND SCRIPT_TYPE = '${escapeSqlString(scriptType)}'
                     ORDER BY SCRIPT_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.SCRIPT_NAME,
@@ -1014,12 +1014,12 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT FUNCTION_NAME
                     FROM SYS.EXA_ALL_FUNCTIONS
                     WHERE FUNCTION_SCHEMA = '${escapeSqlString(schemaName)}'
                     ORDER BY FUNCTION_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.FUNCTION_NAME
@@ -1040,12 +1040,12 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT COUNT(*) AS CONSTRAINT_COUNT
                     FROM SYS.EXA_ALL_CONSTRAINTS
                     WHERE CONSTRAINT_SCHEMA = '${escapeSqlString(schemaName)}'
                     AND CONSTRAINT_TABLE = '${escapeSqlString(tableName)}'
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 if (rows.length > 0) {
                     return this.parseRowCount(rows[0].CONSTRAINT_COUNT) ?? 0;
@@ -1067,12 +1067,12 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT COUNT(*) AS INDEX_COUNT
                     FROM SYS.EXA_ALL_INDICES
                     WHERE INDEX_SCHEMA = '${escapeSqlString(schemaName)}'
                     AND INDEX_TABLE = '${escapeSqlString(tableName)}'
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 if (rows.length > 0) {
                     return this.parseRowCount(rows[0].INDEX_COUNT) ?? 0;
@@ -1094,13 +1094,13 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT CONSTRAINT_NAME, CONSTRAINT_TYPE
                     FROM SYS.EXA_ALL_CONSTRAINTS
                     WHERE CONSTRAINT_SCHEMA = '${escapeSqlString(schemaName)}'
                     AND CONSTRAINT_TABLE = '${escapeSqlString(tableName)}'
                     ORDER BY CONSTRAINT_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.CONSTRAINT_NAME,
@@ -1123,14 +1123,14 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT COLUMN_NAME, ORDINAL_POSITION
                     FROM SYS.EXA_ALL_CONSTRAINT_COLUMNS
                     WHERE CONSTRAINT_SCHEMA = '${escapeSqlString(schemaName)}'
                     AND CONSTRAINT_TABLE = '${escapeSqlString(tableName)}'
                     AND CONSTRAINT_NAME = '${escapeSqlString(constraintName)}'
                     ORDER BY ORDINAL_POSITION
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.COLUMN_NAME
@@ -1151,13 +1151,13 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT INDEX_NAME, INDEX_TYPE, INDEX_COLUMNS
                     FROM SYS.EXA_ALL_INDICES
                     WHERE INDEX_SCHEMA = '${escapeSqlString(schemaName)}'
                     AND INDEX_TABLE = '${escapeSqlString(tableName)}'
                     ORDER BY INDEX_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.INDEX_NAME ?? row.INDEX_TYPE ?? 'INDEX',
@@ -1177,7 +1177,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT
                         SCHEMA_NAME,
                         ADAPTER_SCRIPT_SCHEMA,
@@ -1186,7 +1186,7 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
                         LAST_REFRESH_BY
                     FROM SYS.EXA_ALL_VIRTUAL_SCHEMAS
                     ORDER BY SCHEMA_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.SCHEMA_NAME,
@@ -1209,12 +1209,12 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT TABLE_NAME
                     FROM SYS.EXA_ALL_VIRTUAL_TABLES
                     WHERE TABLE_SCHEMA = '${escapeSqlString(virtualSchemaName)}'
                     ORDER BY TABLE_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.TABLE_NAME
@@ -1235,13 +1235,13 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT COLUMN_NAME, COLUMN_TYPE
                     FROM SYS.EXA_ALL_VIRTUAL_COLUMNS
                     WHERE COLUMN_SCHEMA = '${escapeSqlString(virtualSchemaName)}'
                     AND COLUMN_TABLE = '${escapeSqlString(tableName)}'
                     ORDER BY COLUMN_ORDINAL_POSITION
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.COLUMN_NAME,
@@ -1262,12 +1262,12 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     SELECT OBJECT_NAME
                     FROM SYS.EXA_SYSCAT
                     WHERE SCHEMA_NAME = '${escapeSqlString(schemaName)}'
                     ORDER BY OBJECT_NAME
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.OBJECT_NAME
@@ -1288,9 +1288,9 @@ export class ObjectTreeProvider implements vscode.TreeDataProvider<ObjectNode>, 
         try {
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(connection.id, 'background');
-                const result = await driver.query(`
+                const result = await rawQuery(driver, `
                     DESCRIBE "${escapeSqlString(schemaName)}"."${escapeSqlString(tableName)}"
-                `, undefined, undefined, 'raw');
+                `);
                 const rows = getRowsFromResult(result);
                 return rows.map((row: any) => ({
                     name: row.COLUMN_NAME,

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ConnectionManager } from './connectionManager';
-import { executeWithoutResult, getColumnsFromResult, getRowsFromResult } from './utils';
+import { getColumnsFromResult, getRowsFromResult, rawQuery, rawExecute } from './utils';
 
 export interface ColumnMetadata {
     name: string;
@@ -75,21 +75,11 @@ export class QueryExecutor {
 
             if (isResultSet) {
                 // Result-set queries (SELECT, SHOW, DESCRIBE, etc.) - use query()
-                let result: any;
-                let usedExecuteFallback = false;
-
-                try {
-                    result = await driver.query(finalQuery);
-                } catch (queryError: any) {
-                    // E-EDJS-11: Driver says "Invalid result type. Please use method execute instead of query"
-                    // This can happen with certain query patterns - fall back to execute() with raw mode
-                    if (queryError?.message?.includes('E-EDJS-11')) {
-                        result = await driver.execute(finalQuery, undefined, undefined, 'raw');
-                        usedExecuteFallback = true;
-                    } else {
-                        throw queryError;
-                    }
-                }
+                // Use 'raw' response type to avoid a driver bug where error responses
+                // (status:'error', responseData:undefined) crash on `responseData.numResults`
+                // access. Our getColumnsFromResult/getRowsFromResult handle raw responses
+                // correctly and surface proper SQL error messages.
+                const result = await rawQuery(driver, finalQuery);
 
                 const executionTime = Date.now() - startTime;
                 const columnsMeta = getColumnsFromResult(result);
@@ -106,7 +96,7 @@ export class QueryExecutor {
                 };
             } else {
                 // Non-result-set commands (CREATE, ALTER, DROP, RENAME, INSERT, etc.) - use execute()
-                const rawExecuteResult = await driver.execute(finalQuery, undefined, undefined, 'raw');
+                const rawExecuteResult = await rawExecute(driver, finalQuery);
 
                 const executionTime = Date.now() - startTime;
                 const columnsMeta = getColumnsFromResult(rawExecuteResult);
@@ -149,7 +139,7 @@ export class QueryExecutor {
         // Use centralized retry logic from ConnectionManager
         return await this.connectionManager.executeWithRetry(async () => {
             const driver = await this.connectionManager.getDriver();
-            const result = await driver.query(query);
+            const result = await rawQuery(driver, query);
             const executionTime = Date.now() - startTime;
 
             const columnsMeta = getColumnsFromResult(result);

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ConnectionManager, BACKGROUND_QUERY_TIMEOUT_MS } from './connectionManager';
-import { executeWithoutResult, getRowsFromResult } from './utils';
+import { executeWithoutResult, getRowsFromResult, rawQuery } from './utils';
 
 export class SessionManager {
     private currentSchema: string | undefined;
@@ -73,7 +73,7 @@ export class SessionManager {
         try {
             const rows = await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver(undefined, 'background');
-                const result = await driver.query('SELECT CURRENT_SCHEMA');
+                const result = await rawQuery(driver, 'SELECT CURRENT_SCHEMA');
                 return getRowsFromResult(result);
             }, undefined, { timeoutMs: BACKGROUND_QUERY_TIMEOUT_MS, role: 'background' });
             if (rows.length > 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,10 +12,35 @@ export function escapeSqlString(value: string): string {
 }
 
 /**
+ * Run a query via the Exasol driver in 'raw' mode.
+ * Always use these instead of calling driver.query()/driver.execute() directly,
+ * because the driver's default (non-raw) mode crashes with
+ * "Cannot read properties of undefined (reading 'numResults')" when the
+ * database returns an error response (responseData is undefined).
+ */
+export function rawQuery(driver: ExasolDriver, sql: string): Promise<SQLResponse<SQLQueriesResponse>> {
+    return driver.query(sql, undefined, undefined, 'raw');
+}
+
+export function rawExecute(driver: ExasolDriver, sql: string): Promise<SQLResponse<SQLQueriesResponse>> {
+    return driver.execute(sql, undefined, undefined, 'raw');
+}
+
+/**
  * Type guard for raw Exasol driver responses (responseType: 'raw')
  */
 function isRawResponse(result: unknown): result is SQLResponse<SQLQueriesResponse> {
     return typeof result === 'object' && result !== null && 'status' in result && 'responseData' in result;
+}
+
+/**
+ * Throw a descriptive Error from a raw error response.
+ */
+function throwSqlError(response: SQLResponse<SQLQueriesResponse>): never {
+    const sqlCode = response.exception?.sqlCode;
+    const text = response.exception?.text || 'Query execution failed';
+    const message = sqlCode ? `SQL Error [${sqlCode}]: ${text}` : text;
+    throw new Error(message);
 }
 
 /**
@@ -54,30 +79,24 @@ export function getRowsFromResult(result: any): any[] {
         return [];
     }
 
-    try {
-        if (typeof result.getRows === 'function') {
-            return result.getRows();
-        }
-
-        if (isRawResponse(result)) {
-            if (result.status === 'error') {
-                const message = result.exception?.text || 'Query execution failed';
-                throw new Error(message);
-            }
-
-            const firstResult = result.responseData?.results?.[0];
-            if (!firstResult || firstResult.resultType !== 'resultSet') {
-                return [];
-            }
-
-            return convertResultSetToRows(firstResult.resultSet);
-        }
-
-        return result.rows || [];
-    } catch (error) {
-        // If extraction fails, surface the error so callers can handle/fallback appropriately
-        throw error;
+    if (typeof result.getRows === 'function') {
+        return result.getRows();
     }
+
+    if (isRawResponse(result)) {
+        if (result.status === 'error') {
+            throwSqlError(result);
+        }
+
+        const firstResult = result.responseData?.results?.[0];
+        if (!firstResult || firstResult.resultType !== 'resultSet') {
+            return [];
+        }
+
+        return convertResultSetToRows(firstResult.resultSet);
+    }
+
+    return result.rows || [];
 }
 
 /**
@@ -90,48 +109,31 @@ export function getColumnsFromResult(result: any): any[] {
         return [];
     }
 
-    try {
-        if (typeof result.getColumns === 'function') {
-            return result.getColumns();
-        }
-
-        if (isRawResponse(result)) {
-            if (result.status === 'error') {
-                const message = result.exception?.text || 'Query execution failed';
-                throw new Error(message);
-            }
-
-            const firstResult = result.responseData?.results?.[0];
-            if (!firstResult || firstResult.resultType !== 'resultSet') {
-                return [];
-            }
-
-            return firstResult.resultSet?.columns || [];
-        }
-
-        return result.columns || [];
-    } catch (error) {
-        throw error;
+    if (typeof result.getColumns === 'function') {
+        return result.getColumns();
     }
+
+    if (isRawResponse(result)) {
+        if (result.status === 'error') {
+            throwSqlError(result);
+        }
+
+        const firstResult = result.responseData?.results?.[0];
+        if (!firstResult || firstResult.resultType !== 'resultSet') {
+            return [];
+        }
+
+        return firstResult.resultSet?.columns || [];
+    }
+
+    return result.columns || [];
 }
 
-function isNonResultMetadataError(error: unknown): boolean {
-    const message = (error instanceof Error ? error.message : String(error ?? '')).toUpperCase();
-    return message.includes('NUMRESULTS') || message.includes('INVALID RESULT TYPE') || message.includes('E-EDJS-11');
-}
-
-export async function executeWithoutResult(
+export function executeWithoutResult(
     driver: ExasolDriver,
     sql: string
 ): Promise<SQLResponse<SQLQueriesResponse>> {
-    try {
-        return await driver.query(sql, undefined, undefined, 'raw');
-    } catch (error) {
-        if (isNonResultMetadataError(error)) {
-            return await driver.execute(sql, undefined, undefined, 'raw');
-        }
-        throw error;
-    }
+    return rawQuery(driver, sql);
 }
 
 /**


### PR DESCRIPTION
Fixes #41

## Summary

- Add centralized `rawQuery()`/`rawExecute()` wrappers in `utils.ts` that always use the driver's `'raw'` response mode
- Replace all direct `driver.query()`/`driver.execute()` calls across 8 files to go through these wrappers
- Add `throwSqlError()` helper to deduplicate error formatting and include SQL error codes (e.g., `SQL Error [42000]: object not found`)
- Remove dead code: `isNonResultMetadataError`, `E-EDJS-11` fallback, `safeQuery` wrapper, no-op try/catch blocks
- Simplify `executeWithoutResult` to a thin alias over `rawQuery`