### PR TITLE
feat: system table preview and query toast notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the "Exasol" extension will be documented in this file.
 
+## [1.4.1] - 2026-04-09
+
+### Added
+- Toast notifications after query execution showing duration, row count, and success/failure status (configurable via `exasol.showQueryNotifications`)
+- Double-click on system tables (SYS, EXA_STATISTICS) now opens a data preview instead of column metadata
+
+### Fixed
+- Query execution time displayed as "0.0s" in notifications by switching from `Date.now()` to `performance.now()` for sub-millisecond precision
+
 ## [1.4.0] - 2026-03-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Exasol",
   "icon": "resources/exasol-icon.png",
   "description": "Feature-rich Exasol database extension for Visual Studio Code with IntelliSense, object browser, query execution, and more",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publisher": "exasol",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -423,6 +423,11 @@
           "default": true,
           "description": "Enable SQL auto-completion"
         },
+        "exasol.showQueryNotifications": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show toast notifications after query execution with success/failure status, duration, and row count"
+        },
         "exasol.formatter.keywordCase": {
           "type": "string",
           "enum": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,8 +262,11 @@ export function activate(context: vscode.ExtensionContext) {
 
             try {
                 openObjectExecuting.set(key, true);
-                // Double-click shows table structure only (not preview)
-                await objectActions.describeTable(item.connection, item.schemaName, item.tableInfo.name);
+                if (item.type === 'system-table') {
+                    await objectActions.previewTableData(item.connection, item.schemaName, item.tableInfo.name);
+                } else {
+                    await objectActions.describeTable(item.connection, item.schemaName, item.tableInfo.name);
+                }
             } finally {
                 // Clear after a short delay to allow UI to settle
                 setTimeout(() => openObjectExecuting.delete(key), 500);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { performance } from 'perf_hooks';
 import { ConnectionManager, StoredConnection } from './connectionManager';
 import { ConnectionTreeProvider } from './providers/connectionTreeProvider';
 import { ObjectTreeProvider } from './providers/objectTreeProvider';
@@ -14,7 +15,7 @@ import { ConnectionPanel } from './panels/connectionPanel';
 import { SessionManager } from './sessionManager';
 import { ObjectActions } from './objectActions';
 import { ObjectSearchProvider } from './providers/objectSearchProvider';
-import { findStatementAtCursor, splitIntoStatements } from './utils';
+import { findStatementAtCursor, formatDuration, splitIntoStatements } from './utils';
 import { ExasolNotebookSerializer } from './notebooks/serializer';
 import { ExasolNotebookController } from './notebooks/controller';
 import { formatError } from './connectionTypes';
@@ -23,6 +24,16 @@ import { formatError } from './connectionTypes';
 let outputChannel: vscode.OutputChannel;
 let extensionContext: vscode.ExtensionContext | undefined;
 let extensionConnectionManager: ConnectionManager | undefined;
+
+function showTimedNotification(message: string, timeoutMs: number = 2000): void {
+    vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, cancellable: false },
+        (progress) => {
+            progress.report({ message });
+            return new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
+        }
+    );
+}
 
 export function activate(context: vscode.ExtensionContext) {
     extensionContext = context;
@@ -588,6 +599,10 @@ async function executeQuery(
                 const collector = useTabCollection ? new TabResultCollector() : null;
                 let lastResult = null;
 
+                const batchStartTime = performance.now();
+                let successCount = 0;
+                let failCount = 0;
+
                 for (let i = 0; i < statements.length; i++) {
                     const query = statements[i];
                     const queryNum = i + 1;
@@ -614,6 +629,7 @@ async function executeQuery(
 
                         // Keep track of the last result to show in the panel
                         lastResult = result;
+                        successCount++;
 
                         if (statements.length > 1) {
                             output.appendLine(`   ✅ Query ${queryNum} completed. ${result.rowCount} rows affected.`);
@@ -630,6 +646,7 @@ async function executeQuery(
 
                     } catch (error) {
                         const errorMsg = formatError(error);
+                        failCount++;
 
                         if (statements.length > 1) {
                             output.appendLine(`   ❌ Query ${queryNum} failed: ${errorMsg}`);
@@ -713,10 +730,36 @@ async function executeQuery(
                 if (statements.length > 1) {
                     output.appendLine(`\n🎉 Completed executing ${statements.length} queries`);
                 }
+
+                // Show query notifications
+                const showNotifications = vscode.workspace.getConfiguration('exasol').get<boolean>('showQueryNotifications', true);
+                if (showNotifications) {
+                    const totalDuration = formatDuration(performance.now() - batchStartTime);
+
+                    if (statements.length === 1 && lastResult) {
+                        // Single query success in executeQueries path
+                        showTimedNotification(`Query executed in ${formatDuration(lastResult.executionTime)} — ${lastResult.rowCount} rows returned`);
+                    } else if (statements.length > 1) {
+                        // Batch summary
+                        if (failCount === 0) {
+                            showTimedNotification(`${successCount}/${statements.length} queries executed in ${totalDuration}`);
+                        } else {
+                            vscode.window.showWarningMessage(`${successCount}/${statements.length} queries executed (${failCount} failed) in ${totalDuration}`);
+                        }
+                    }
+                }
             }
         );
     } catch (error) {
-        // Error already handled in the loop
+        // Error already handled in the loop — but show failure notification for single-query case
+        const showNotifications = vscode.workspace.getConfiguration('exasol').get<boolean>('showQueryNotifications', true);
+        if (showNotifications && statements.length === 1) {
+            const errorMsg = formatError(error);
+            const action = await vscode.window.showErrorMessage(`Query failed: ${errorMsg}`, 'Show Details');
+            if (action === 'Show Details') {
+                output.show();
+            }
+        }
     } finally {
         cancellationTokenSource.dispose();
     }
@@ -853,6 +896,12 @@ async function executeStatement(
                 QueryStatsPanel.updateStats(query, result);
 
                 output.appendLine(`✅ Query executed successfully. ${result.rowCount} rows returned.`);
+
+                // Show success notification
+                const showNotifications = vscode.workspace.getConfiguration('exasol').get<boolean>('showQueryNotifications', true);
+                if (showNotifications) {
+                    showTimedNotification(`Query executed in ${formatDuration(result.executionTime)} — ${result.rowCount} rows returned`);
+                }
             }
         );
     } catch (error) {
@@ -863,6 +912,15 @@ async function executeStatement(
         await ResultsPanel.showError(errorMsg);
 
         queryHistoryProvider.addQuery(query, 0, errorMsg);
+
+        // Show failure notification
+        const showNotifications = vscode.workspace.getConfiguration('exasol').get<boolean>('showQueryNotifications', true);
+        if (showNotifications) {
+            const action = await vscode.window.showErrorMessage(`Query failed: ${errorMsg}`, 'Show Details');
+            if (action === 'Show Details') {
+                output.show();
+            }
+        }
     } finally {
         cancellationTokenSource.dispose();
     }

--- a/src/objectActions.ts
+++ b/src/objectActions.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { performance } from 'perf_hooks';
 import { ConnectionManager, StoredConnection } from './connectionManager';
 import { QueryExecutor, QueryResult, ColumnMetadata } from './queryExecutor';
 import { ResultsPanel } from './panels/resultsPanel';
@@ -53,9 +54,9 @@ export class ObjectActions {
                         const query = `SELECT * FROM "${schemaName}"."${tableName}" LIMIT ${limit}`;
                         const driver = await this.connectionManager.getDriver(connection.id);
 
-                        const startTime = Date.now();
+                        const startTime = performance.now();
                         const result = await driver.query(query);
-                        const executionTime = Date.now() - startTime;
+                        const executionTime = performance.now() - startTime;
 
                         const columnsMeta = getColumnsFromResult(result);
                         const rows = getRowsFromResult(result);
@@ -210,9 +211,9 @@ export class ObjectActions {
                     ORDER BY COLUMN_ORDINAL_POSITION
                 `;
 
-                const startTime = Date.now();
+                const startTime = performance.now();
                 const result = await driver.query(query);
-                const executionTime = Date.now() - startTime;
+                const executionTime = performance.now() - startTime;
 
                 const columnsMeta = getColumnsFromResult(result);
                 const rows = getRowsFromResult(result);

--- a/src/providers/objectTreeProvider.ts
+++ b/src/providers/objectTreeProvider.ts
@@ -1453,6 +1453,13 @@ export class ObjectTreeItem extends vscode.TreeItem {
                     arguments: [this]
                 };
                 break;
+            case 'system-table':
+                this.command = {
+                    command: 'exasol.openObject',
+                    title: 'Open System Table',
+                    arguments: [this]
+                };
+                break;
             case 'column':
                 if (this.columnInfo) {
                     this.tooltip = `${this.columnInfo.name}: ${this.columnInfo.type}${this.columnInfo.nullable ? ' (nullable)' : ''}`;

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { performance } from 'perf_hooks';
 import { ConnectionManager } from './connectionManager';
 import { executeWithoutResult, getColumnsFromResult, getRowsFromResult } from './utils';
 
@@ -56,7 +57,7 @@ export class QueryExecutor {
         const maxRows = config.get<number>('maxResultRows', 10000);
         const timeout = config.get<number>('queryTimeout', 300);
 
-        const startTime = Date.now();
+        const startTime = performance.now();
 
         // Clean the query - remove trailing semicolons and trim
         let finalQuery = query.trim().replace(/;+\s*$/, '').trim();
@@ -91,7 +92,7 @@ export class QueryExecutor {
                     }
                 }
 
-                const executionTime = Date.now() - startTime;
+                const executionTime = performance.now() - startTime;
                 const columnsMeta = getColumnsFromResult(result);
                 const rows = getRowsFromResult(result);
                 const columns = columnsMeta.map((col: any) => col.name ?? col.COLUMN_NAME ?? col);
@@ -108,7 +109,7 @@ export class QueryExecutor {
                 // Non-result-set commands (CREATE, ALTER, DROP, RENAME, INSERT, etc.) - use execute()
                 const rawExecuteResult = await driver.execute(finalQuery, undefined, undefined, 'raw');
 
-                const executionTime = Date.now() - startTime;
+                const executionTime = performance.now() - startTime;
                 const columnsMeta = getColumnsFromResult(rawExecuteResult);
                 const rows = getRowsFromResult(rawExecuteResult);
                 const columns = columnsMeta.map((col: any) => col.name ?? col.COLUMN_NAME ?? col);
@@ -144,13 +145,13 @@ export class QueryExecutor {
         const config = vscode.workspace.getConfiguration('exasol');
         const maxRows = limit || config.get<number>('maxResultRows', 10000);
 
-        const startTime = Date.now();
+        const startTime = performance.now();
 
         // Use centralized retry logic from ConnectionManager
         return await this.connectionManager.executeWithRetry(async () => {
             const driver = await this.connectionManager.getDriver();
             const result = await driver.query(query);
-            const executionTime = Date.now() - startTime;
+            const executionTime = performance.now() - startTime;
 
             const columnsMeta = getColumnsFromResult(result);
             const rows = getRowsFromResult(result).slice(0, maxRows);

--- a/src/test/unit/formatDuration.test.ts
+++ b/src/test/unit/formatDuration.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+import { formatDuration } from '../../utils';
+
+suite('formatDuration', () => {
+    test('sub-millisecond returns <1ms', () => {
+        assert.strictEqual(formatDuration(0), '<1ms');
+        assert.strictEqual(formatDuration(0.4), '<1ms');
+    });
+
+    test('milliseconds range (1–999ms)', () => {
+        assert.strictEqual(formatDuration(1), '1ms');
+        assert.strictEqual(formatDuration(45), '45ms');
+        assert.strictEqual(formatDuration(999), '999ms');
+    });
+
+    test('fractional milliseconds round to integer', () => {
+        assert.strictEqual(formatDuration(45.7), '46ms');
+        assert.strictEqual(formatDuration(1.4), '1ms');
+    });
+
+    test('seconds range (1s–59.9s)', () => {
+        assert.strictEqual(formatDuration(1000), '1.0s');
+        assert.strictEqual(formatDuration(1234), '1.2s');
+        assert.strictEqual(formatDuration(59999), '60.0s');
+    });
+
+    test('minutes range (>=60s)', () => {
+        assert.strictEqual(formatDuration(60000), '1m 0s');
+        assert.strictEqual(formatDuration(75000), '1m 15s');
+        assert.strictEqual(formatDuration(125000), '2m 5s');
+    });
+});

--- a/src/test/unit/queryNotifications.test.ts
+++ b/src/test/unit/queryNotifications.test.ts
@@ -1,0 +1,213 @@
+import * as assert from 'assert';
+import { formatDuration } from '../../utils';
+
+// Track calls to mock notification methods
+const windowCalls: { method: string; args: any[] }[] = [];
+let configValues: Record<string, any> = {};
+
+// Lightweight mock for the vscode APIs used by notification logic
+const mockVscode = {
+    window: {
+        showInformationMessage: (...args: any[]) => {
+            windowCalls.push({ method: 'showInformationMessage', args });
+            return Promise.resolve(undefined);
+        },
+        showWarningMessage: (...args: any[]) => {
+            windowCalls.push({ method: 'showWarningMessage', args });
+            return Promise.resolve(undefined);
+        },
+        showErrorMessage: (...args: any[]) => {
+            windowCalls.push({ method: 'showErrorMessage', args });
+            return Promise.resolve(undefined);
+        },
+        withProgress: (options: any, task: (progress: any) => Promise<void>) => {
+            const progress = {
+                report: (value: any) => {
+                    windowCalls.push({ method: 'withProgress', args: [options, value.message] });
+                }
+            };
+            return task(progress);
+        },
+    },
+    workspace: {
+        getConfiguration: (section: string) => ({
+            get: (key: string, defaultValue?: any): any => {
+                const fullKey = `${section}.${key}`;
+                if (fullKey in configValues) {
+                    return configValues[fullKey];
+                }
+                return defaultValue;
+            }
+        })
+    },
+    ProgressLocation: {
+        Notification: 15
+    }
+};
+
+function resetCalls(): void {
+    windowCalls.length = 0;
+    configValues = {};
+}
+
+/**
+ * Mirrors showTimedNotification helper from extension.ts.
+ */
+function showTimedNotification(message: string, timeoutMs: number = 2000): void {
+    mockVscode.window.withProgress(
+        { location: mockVscode.ProgressLocation.Notification, cancellable: false },
+        (progress: any) => {
+            progress.report({ message });
+            return new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
+        }
+    );
+}
+
+/**
+ * Mirrors the notification logic from executeStatement() success path.
+ * Now uses showTimedNotification for auto-dismiss.
+ */
+function showSingleQuerySuccessNotification(executionTimeMs: number, rowCount: number): void {
+    const showNotifications = mockVscode.workspace.getConfiguration('exasol').get('showQueryNotifications', true);
+    if (showNotifications) {
+        showTimedNotification(`Query executed in ${formatDuration(executionTimeMs)} — ${rowCount} rows returned`);
+    }
+}
+
+/**
+ * Mirrors the notification logic from executeStatement() failure path.
+ * Error notifications still persist (no auto-dismiss).
+ */
+async function showSingleQueryFailureNotification(errorMsg: string): Promise<void> {
+    const showNotifications = mockVscode.workspace.getConfiguration('exasol').get('showQueryNotifications', true);
+    if (showNotifications) {
+        await mockVscode.window.showErrorMessage(`Query failed: ${errorMsg}`, 'Show Details');
+    }
+}
+
+/**
+ * Mirrors the notification logic from executeQueries() batch summary path.
+ * Success uses showTimedNotification; partial failure uses showWarningMessage (persistent).
+ */
+function showBatchSummaryNotification(
+    totalStatements: number,
+    successCount: number,
+    failCount: number,
+    batchDurationMs: number
+): void {
+    const showNotifications = mockVscode.workspace.getConfiguration('exasol').get('showQueryNotifications', true);
+    if (showNotifications) {
+        const totalDuration = formatDuration(batchDurationMs);
+        if (failCount === 0) {
+            showTimedNotification(`${successCount}/${totalStatements} queries executed in ${totalDuration}`);
+        } else {
+            mockVscode.window.showWarningMessage(`${successCount}/${totalStatements} queries executed (${failCount} failed) in ${totalDuration}`);
+        }
+    }
+}
+
+suite('Query Execution Notifications', () => {
+
+    setup(() => {
+        resetCalls();
+    });
+
+    suite('single query success notification', () => {
+        test('uses auto-dismiss withProgress notification', () => {
+            showSingleQuerySuccessNotification(1234, 42);
+
+            assert.strictEqual(windowCalls.length, 1);
+            assert.strictEqual(windowCalls[0].method, 'withProgress');
+            assert.strictEqual(windowCalls[0].args[1], 'Query executed in 1.2s — 42 rows returned');
+        });
+
+        test('shows milliseconds for sub-second queries', () => {
+            showSingleQuerySuccessNotification(567, 10);
+
+            assert.strictEqual(windowCalls[0].args[1], 'Query executed in 567ms — 10 rows returned');
+        });
+
+        test('handles zero rows', () => {
+            showSingleQuerySuccessNotification(100, 0);
+
+            assert.strictEqual(windowCalls[0].args[1], 'Query executed in 100ms — 0 rows returned');
+        });
+
+        test('withProgress uses Notification location', () => {
+            showSingleQuerySuccessNotification(1000, 10);
+
+            assert.strictEqual(windowCalls[0].args[0].location, mockVscode.ProgressLocation.Notification);
+        });
+    });
+
+    suite('single query failure notification', () => {
+        test('shows persistent error message with Show Details button', async () => {
+            await showSingleQueryFailureNotification('[42000] syntax error');
+
+            assert.strictEqual(windowCalls.length, 1);
+            assert.strictEqual(windowCalls[0].method, 'showErrorMessage');
+            assert.strictEqual(windowCalls[0].args[0], 'Query failed: [42000] syntax error');
+            assert.strictEqual(windowCalls[0].args[1], 'Show Details');
+        });
+    });
+
+    suite('batch summary notification', () => {
+        test('uses auto-dismiss notification when all queries succeed', () => {
+            showBatchSummaryNotification(5, 5, 0, 3400);
+
+            assert.strictEqual(windowCalls.length, 1);
+            assert.strictEqual(windowCalls[0].method, 'withProgress');
+            assert.strictEqual(windowCalls[0].args[1], '5/5 queries executed in 3.4s');
+        });
+
+        test('shows persistent warning when some queries fail', () => {
+            showBatchSummaryNotification(5, 4, 1, 3400);
+
+            assert.strictEqual(windowCalls.length, 1);
+            assert.strictEqual(windowCalls[0].method, 'showWarningMessage');
+            assert.strictEqual(windowCalls[0].args[0], '4/5 queries executed (1 failed) in 3.4s');
+        });
+
+        test('shows persistent warning with multiple failures', () => {
+            showBatchSummaryNotification(10, 7, 3, 12500);
+
+            assert.strictEqual(windowCalls[0].method, 'showWarningMessage');
+            assert.strictEqual(windowCalls[0].args[0], '7/10 queries executed (3 failed) in 12.5s');
+        });
+    });
+
+    suite('notifications suppressed when setting is false', () => {
+        test('single query success is suppressed', () => {
+            configValues['exasol.showQueryNotifications'] = false;
+
+            showSingleQuerySuccessNotification(1000, 10);
+
+            assert.strictEqual(windowCalls.length, 0);
+        });
+
+        test('single query failure is suppressed', async () => {
+            configValues['exasol.showQueryNotifications'] = false;
+
+            await showSingleQueryFailureNotification('some error');
+
+            assert.strictEqual(windowCalls.length, 0);
+        });
+
+        test('batch summary is suppressed', () => {
+            configValues['exasol.showQueryNotifications'] = false;
+
+            showBatchSummaryNotification(5, 5, 0, 3000);
+
+            assert.strictEqual(windowCalls.length, 0);
+        });
+    });
+
+    suite('setting defaults to true', () => {
+        test('notifications show when setting is not configured', () => {
+            // configValues is empty — no explicit setting
+            showSingleQuerySuccessNotification(1000, 10);
+
+            assert.strictEqual(windowCalls.length, 1, 'Should show notification when setting is unset (defaults to true)');
+        });
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,26 @@
 import type { ExasolDriver, SQLQueriesResponse, SQLQueryColumn, SQLResponse } from '@exasol/exasol-driver-ts';
 
 /**
+ * Format a duration in milliseconds into a human-readable string.
+ * Adapts the unit based on magnitude: ms, seconds, or minutes+seconds.
+ */
+export function formatDuration(ms: number): string {
+    const rounded = Math.round(ms);
+    if (rounded < 1) {
+        return '<1ms';
+    }
+    if (rounded < 1000) {
+        return `${rounded}ms`;
+    }
+    if (ms < 60000) {
+        return `${(ms / 1000).toFixed(1)}s`;
+    }
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.round((ms % 60000) / 1000);
+    return `${minutes}m ${seconds}s`;
+}
+
+/**
  * Escape a string value for safe interpolation into SQL single-quoted literals.
  * Doubles all single-quote characters to prevent SQL injection.
  */


### PR DESCRIPTION
## Summary
- **Double-click preview for system tables**: System tables (SYS, EXA_STATISTICS) now open a `SELECT * LIMIT 100` data preview on double-click instead of column metadata. Regular tables/views are unchanged.
- **Query toast notifications**: Show auto-dismissing toast notifications after query execution with duration, row count, and success/failure status. Configurable via `exasol.showQueryNotifications`.
- **Accurate query timing**: Replaced `Date.now()` with `performance.now()` for sub-millisecond precision. New `formatDuration()` utility adapts units (ms/s/min) based on magnitude.

## Test plan
- [x] Unit tests for `formatDuration()` covering all ranges (sub-ms, ms, seconds, minutes)
- [x] Unit tests for notification logic (success, failure, batch, suppression via setting)
- [x] Manual: double-click a system table in SYS/EXA_STATISTICS → should show data preview
- [x] Manual: double-click a regular table → should still show column metadata
- [x] Manual: run a query → toast notification appears with timing and row count
- [x] Manual: set `exasol.showQueryNotifications: false` → no toast shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)