### PR TITLE
BI-188: local CSV import + driver update (node:crypto, no node-forge), 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "Exasol" extension will be documented in this file.
 
+## [1.5.1] - 2026-05-29
+
+### Changed
+- Updated the bundled Exasol driver to a fork rebased on upstream exasol-driver-ts 0.4.0, picking up its dependency/security refreshes and the `query()`/`execute()` cancellation fix
+- Kept `node-forge` out of the bundle: the local-CSV-import TLS path that 0.4.0 introduces normally relies on `node-forge`, but it and the login password encryption both use Node's built-in `crypto` instead, so the ~313 KB dependency is not bundled
+
 ## [1.5.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "Exasol" extension will be documented in this file.
 
 ## [1.5.1] - 2026-05-29
 
+### Added
+- Local CSV import from the extension via `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>'`, which streams the local file to Exasol over the driver's TLS tunnel (raw SQL cannot do local imports over the WebSocket protocol)
+
 ### Changed
 - Updated the bundled Exasol driver to a fork rebased on upstream exasol-driver-ts 0.4.0, picking up its dependency/security refreshes and the `query()`/`execute()` cancellation fix
 - Kept `node-forge` out of the bundle: the local-CSV-import TLS path that 0.4.0 introduces normally relies on `node-forge`, but it and the login password encryption both use Node's built-in `crypto` instead, so the ~313 KB dependency is not bundled

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ A third warning, `npm warn skipping integrity check for git dependency ssh://git
 
 ### Forked driver
 
-`@exasol/exasol-driver-ts` is temporarily sourced from a fork at [mikhail-zhadanov/exasol-driver-ts](https://github.com/mikhail-zhadanov/exasol-driver-ts) that swaps `node-forge` for Node's built-in `node:crypto` in the RSA login path. This shrinks the bundled `extension.js` by roughly 280 KB. The pin reverts to the upstream package once the change lands there.
+`@exasol/exasol-driver-ts` is temporarily sourced from a fork at [mikhail-zhadanov/exasol-driver-ts](https://github.com/mikhail-zhadanov/exasol-driver-ts) (v0.4.1, rebased on upstream 0.4.0). The fork replaces `node-forge` with Node's built-in `node:crypto` in both the RSA login path and the local CSV import TLS-certificate path, removing `node-forge` from the bundle entirely (~280 KB of `extension.js`). The pin reverts to the upstream package once the change lands there ([exasol/exasol-driver-ts#59](https://github.com/exasol/exasol-driver-ts/pull/59)).
 
 ## Limitations
 
 - Large result sets (>10,000 rows) may impact rendering performance
 - Query cancellation relies on driver support; some queries may not cancel immediately
-- The [Exasol TypeScript driver](https://github.com/exasol/exasol-driver-ts) only supports cloud file uploads
+- Importing local files is not yet available from the extension; only cloud file imports work. Local CSV import support exists in the driver as of 0.4.1, but the extension UI wiring is tracked separately ([#9](https://github.com/exasol-labs/exasol-vscode/issues/9))
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A third warning, `npm warn skipping integrity check for git dependency ssh://git
 
 - Large result sets (>10,000 rows) may impact rendering performance
 - Query cancellation relies on driver support; some queries may not cancel immediately
-- Local file import from the extension is supported for CSV only, via `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>'`. The extension intercepts the statement and streams the file to Exasol over the driver's TLS tunnel, so the cluster must be able to open a connection back to the client machine for the import tunnel. Other local formats (e.g. FBV) and multi-file local imports are not supported; cloud file imports continue to work via raw SQL
+- Local file import from the extension is supported for CSV only, via `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>'`. The extension intercepts the statement and streams the file to Exasol over the driver's TLS tunnel, so the cluster must be able to open a connection back to the client machine for the import tunnel. Other local formats (e.g. FBV) and multi-file local imports are not supported; cloud file imports continue to work via raw SQL. Cancelling an in-progress local import does not stop the load already streaming to the cluster
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A third warning, `npm warn skipping integrity check for git dependency ssh://git
 
 - Large result sets (>10,000 rows) may impact rendering performance
 - Query cancellation relies on driver support; some queries may not cancel immediately
-- Importing local files is not yet available from the extension; only cloud file imports work. Local CSV import support exists in the driver as of 0.4.1, but the extension UI wiring is tracked separately ([#9](https://github.com/exasol-labs/exasol-vscode/issues/9))
+- Local file import from the extension is supported for CSV only, via `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>'`. The extension intercepts the statement and streams the file to Exasol over the driver's TLS tunnel, so the cluster must be able to open a connection back to the client machine for the import tunnel. Other local formats (e.g. FBV) and multi-file local imports are not supported; cloud file imports continue to work via raw SQL
 
 ## Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "exasol-vscode",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exasol-vscode",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "@exasol/exasol-driver-ts": "github:mikhail-zhadanov/exasol-driver-ts#5bc94315248ae7da9f19c306217f30a69f1ab861",
+        "@exasol/exasol-driver-ts": "github:mikhail-zhadanov/exasol-driver-ts#46d96eff6dd109aa201275b7347a94e9a5f52612",
         "async-mutex": "^0.5.0",
         "sql-formatter": "^15.8.0",
         "ws": "^8.20.1"
@@ -1034,10 +1034,10 @@
       }
     },
     "node_modules/@exasol/exasol-driver-ts": {
-      "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/mikhail-zhadanov/exasol-driver-ts.git#5bc94315248ae7da9f19c306217f30a69f1ab861",
-      "integrity": "sha512-V/YOKyOsOZ9wd8SsLd8hSEkGKINWWuTynwT56AgOiDKf20p3LB1v09mQn+4dOdNFuu6fRYafsMCOzvScdyth9Q==",
-      "license": "ISC",
+      "version": "0.4.1",
+      "resolved": "git+ssh://git@github.com/mikhail-zhadanov/exasol-driver-ts.git#46d96eff6dd109aa201275b7347a94e9a5f52612",
+      "integrity": "sha512-ayIkYgqApVxjMOytKWSbtK8cvbwSJLzJ76JOO/1miSrixqoeaKEZxu1Ad5RkHZmUzarwKAtqgPE1/LBSs5dcLQ==",
+      "license": "MIT",
       "dependencies": {
         "generic-pool": "^3.9.0",
         "pako": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Exasol",
   "icon": "resources/exasol-icon.png",
   "description": "Feature-rich Exasol database extension for Visual Studio Code with IntelliSense, object browser, query execution, and more",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "exasol",
   "license": "MIT",
   "repository": {
@@ -590,7 +590,7 @@
     "typescript-eslint": "^8.59.4"
   },
   "dependencies": {
-    "@exasol/exasol-driver-ts": "github:mikhail-zhadanov/exasol-driver-ts#5bc94315248ae7da9f19c306217f30a69f1ab861",
+    "@exasol/exasol-driver-ts": "github:mikhail-zhadanov/exasol-driver-ts#46d96eff6dd109aa201275b7347a94e9a5f52612",
     "async-mutex": "^0.5.0",
     "sql-formatter": "^15.8.0",
     "ws": "^8.20.1"

--- a/src/localCsvImport.ts
+++ b/src/localCsvImport.ts
@@ -1,0 +1,135 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { CsvFormatOptions, RowSeparator, TrimMode } from '@exasol/exasol-driver-ts';
+import { stripCommentsPreservingStrings } from './utils';
+
+/**
+ * A parsed `IMPORT INTO <table> FROM LOCAL [SECURE] CSV FILE '<path>' [options]`
+ * statement. The driver streams the local file to Exasol over its own TLS tunnel,
+ * which raw SQL over the WebSocket protocol cannot do.
+ */
+export interface ParsedLocalCsvImport {
+    /** The import target, captured verbatim (may include a column list, e.g. `t (a, b)`). */
+    table: string;
+    /** The single-quoted file path with doubled quotes unescaped. */
+    filePath: string;
+    /** CSV format options parsed from the trailing clause; unspecified options are omitted. */
+    options: CsvFormatOptions;
+}
+
+// IMPORT INTO <target> FROM LOCAL [SECURE] CSV FILE '<path>' [trailing-options]
+// - target is captured non-greedily up to FROM LOCAL [SECURE] CSV FILE
+// - dotall so multi-line statements match
+const LOCAL_CSV_IMPORT_RE =
+    /^IMPORT\s+INTO\s+(?<target>.+?)\s+FROM\s+LOCAL\s+(?:SECURE\s+)?CSV\s+FILE\s+'(?<path>(?:[^']|'')*)'(?<rest>.*)$/is;
+
+/**
+ * Detects a local CSV import statement and parses it into the shape the driver's
+ * `importFromCsvFile` expects. Returns `null` for anything that is not a local CSV
+ * import (cloud imports without LOCAL, `FROM LOCAL FBV FILE`, plain SELECT, etc.)
+ * so those statements flow through the normal execution path untouched.
+ */
+export function parseLocalCsvImport(sql: string): ParsedLocalCsvImport | null {
+    const cleaned = stripCommentsPreservingStrings(sql)
+        .trim()
+        .replace(/;+\s*$/, '')
+        .trim();
+
+    const match = LOCAL_CSV_IMPORT_RE.exec(cleaned);
+    if (!match || !match.groups) {
+        return null;
+    }
+
+    const table = match.groups.target.trim();
+    // Unescape doubled single-quotes ('' -> ') from the SQL string literal.
+    const filePath = match.groups.path.replace(/''/g, "'");
+    const rest = match.groups.rest;
+
+    // Multiple files are not supported by the single-file driver method.
+    if (/\bFILE\b/i.test(rest)) {
+        throw new Error('Local CSV import supports a single FILE; found multiple. Run one IMPORT per file.');
+    }
+
+    return {
+        table,
+        filePath,
+        options: parseCsvOptions(rest)
+    };
+}
+
+/**
+ * Parses the trailing options clause of a local CSV import into CsvFormatOptions.
+ * Tolerant of arbitrary whitespace and optional spacing around `=`.
+ */
+function parseCsvOptions(rest: string): CsvFormatOptions {
+    const options: CsvFormatOptions = {};
+
+    const skipMatch = /\bSKIP\s*=\s*(\d+)/i.exec(rest);
+    if (skipMatch) {
+        options.skip = Number(skipMatch[1]);
+    }
+
+    const columnSeparatorMatch = /\bCOLUMN\s+SEPARATOR\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
+    if (columnSeparatorMatch) {
+        options.columnSeparator = columnSeparatorMatch[1].replace(/''/g, "'");
+    }
+
+    const columnDelimiterMatch = /\bCOLUMN\s+DELIMITER\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
+    if (columnDelimiterMatch) {
+        options.columnDelimiter = columnDelimiterMatch[1].replace(/''/g, "'");
+    }
+
+    const rowSeparatorMatch = /\bROW\s+SEPARATOR\s*=\s*'(LF|CR|CRLF)'/i.exec(rest);
+    if (rowSeparatorMatch) {
+        const value = rowSeparatorMatch[1].toUpperCase();
+        options.rowSeparator = RowSeparator[value as keyof typeof RowSeparator];
+    }
+
+    const encodingMatch = /\bENCODING\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
+    if (encodingMatch) {
+        options.encoding = encodingMatch[1].replace(/''/g, "'") as CsvFormatOptions['encoding'];
+    }
+
+    // TRIM / LTRIM / RTRIM (match the most specific token first).
+    const trimMatch = /\b(LTRIM|RTRIM|TRIM)\b/i.exec(rest);
+    if (trimMatch) {
+        const value = trimMatch[1].toUpperCase();
+        if (value === 'LTRIM') {
+            options.trim = TrimMode.LEADING;
+        } else if (value === 'RTRIM') {
+            options.trim = TrimMode.TRAILING;
+        } else {
+            options.trim = TrimMode.BOTH;
+        }
+    }
+
+    const nullMatch = /\bNULL\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
+    if (nullMatch) {
+        options.null = nullMatch[1].replace(/''/g, "'");
+    }
+
+    return options;
+}
+
+/**
+ * Resolves a CSV import path to an absolute filesystem path. Absolute paths are
+ * returned unchanged; relative paths resolve against the active SQL document's
+ * directory, falling back to the first workspace folder.
+ */
+export function resolveImportPath(filePath: string): string {
+    if (path.isAbsolute(filePath)) {
+        return filePath;
+    }
+
+    const activeDoc = vscode.window.activeTextEditor?.document?.uri;
+    if (activeDoc && activeDoc.scheme === 'file') {
+        return path.resolve(path.dirname(activeDoc.fsPath), filePath);
+    }
+
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (workspaceFolder) {
+        return path.resolve(workspaceFolder.uri.fsPath, filePath);
+    }
+
+    throw new Error('Relative import path; open the SQL file from a folder or use an absolute path.');
+}

--- a/src/localCsvImport.ts
+++ b/src/localCsvImport.ts
@@ -45,11 +45,6 @@ export function parseLocalCsvImport(sql: string): ParsedLocalCsvImport | null {
     const filePath = match.groups.path.replace(/''/g, "'");
     const rest = match.groups.rest;
 
-    // Multiple files are not supported by the single-file driver method.
-    if (/\bFILE\b/i.test(rest)) {
-        throw new Error('Local CSV import supports a single FILE; found multiple. Run one IMPORT per file.');
-    }
-
     return {
         table,
         filePath,
@@ -58,54 +53,127 @@ export function parseLocalCsvImport(sql: string): ParsedLocalCsvImport | null {
 }
 
 /**
+ * One option token recognized in the trailing clause: a `KEYWORD = 'value'`
+ * pair, a `SKIP = <number>` pair, or a bare `TRIM`/`LTRIM`/`RTRIM` keyword.
+ * The regex is anchored at the current cursor (`y` flag) so matching and
+ * consuming proceed strictly left-to-right; quoted string values are captured
+ * whole and never re-scanned for keywords.
+ */
+interface OptionTokenMatcher {
+    re: RegExp;
+    apply: (options: CsvFormatOptions, m: RegExpExecArray) => void;
+}
+
+const OPTION_TOKEN_MATCHERS: OptionTokenMatcher[] = [
+    {
+        re: /SKIP\s*=\s*(\d+)/iy,
+        apply: (options, m) => { options.skip = Number(m[1]); }
+    },
+    {
+        re: /COLUMN\s+SEPARATOR\s*=\s*'((?:[^']|'')*)'/iy,
+        apply: (options, m) => { options.columnSeparator = m[1].replace(/''/g, "'"); }
+    },
+    {
+        re: /COLUMN\s+DELIMITER\s*=\s*'((?:[^']|'')*)'/iy,
+        apply: (options, m) => { options.columnDelimiter = m[1].replace(/''/g, "'"); }
+    },
+    {
+        re: /ROW\s+SEPARATOR\s*=\s*'(LF|CR|CRLF)'/iy,
+        apply: (options, m) => {
+            const value = m[1].toUpperCase();
+            options.rowSeparator = RowSeparator[value as keyof typeof RowSeparator];
+        }
+    },
+    {
+        re: /ENCODING\s*=\s*'((?:[^']|'')*)'/iy,
+        apply: (options, m) => {
+            options.encoding = m[1].replace(/''/g, "'") as CsvFormatOptions['encoding'];
+        }
+    },
+    {
+        re: /NULL\s*=\s*'((?:[^']|'')*)'/iy,
+        apply: (options, m) => { options.null = m[1].replace(/''/g, "'"); }
+    },
+    {
+        // TRIM / LTRIM / RTRIM as a bare keyword token (no value). The \b after
+        // ensures TRIM is not consumed from the middle of a longer identifier.
+        re: /(LTRIM|RTRIM|TRIM)\b/iy,
+        apply: (options, m) => {
+            const value = m[1].toUpperCase();
+            if (value === 'LTRIM') {
+                options.trim = TrimMode.LEADING;
+            } else if (value === 'RTRIM') {
+                options.trim = TrimMode.TRAILING;
+            } else {
+                options.trim = TrimMode.BOTH;
+            }
+        }
+    }
+];
+
+/** Matches an unconsumed `FILE` keyword token in the option structure. */
+const FILE_TOKEN_RE = /FILE\b/iy;
+/** Matches leading whitespace and optional comma/AND separators between tokens. */
+const SEPARATOR_RE = /[\s,]*(?:AND[\s,]+)?/iy;
+
+/**
  * Parses the trailing options clause of a local CSV import into CsvFormatOptions.
+ *
+ * Walks `rest` left-to-right, matching and consuming one option token at a time.
+ * Because quoted string values are captured whole and the cursor only advances
+ * past matched spans, a keyword that appears INSIDE a quoted value (e.g.
+ * `NULL = 'FILE'`, `COLUMN SEPARATOR = 'SKIP'`) is never re-interpreted as an
+ * option keyword. The multi-file guard likewise only fires on a real `FILE`
+ * token found in the unconsumed structure, not on text inside a quoted value.
  * Tolerant of arbitrary whitespace and optional spacing around `=`.
  */
 function parseCsvOptions(rest: string): CsvFormatOptions {
     const options: CsvFormatOptions = {};
+    let pos = 0;
 
-    const skipMatch = /\bSKIP\s*=\s*(\d+)/i.exec(rest);
-    if (skipMatch) {
-        options.skip = Number(skipMatch[1]);
-    }
-
-    const columnSeparatorMatch = /\bCOLUMN\s+SEPARATOR\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
-    if (columnSeparatorMatch) {
-        options.columnSeparator = columnSeparatorMatch[1].replace(/''/g, "'");
-    }
-
-    const columnDelimiterMatch = /\bCOLUMN\s+DELIMITER\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
-    if (columnDelimiterMatch) {
-        options.columnDelimiter = columnDelimiterMatch[1].replace(/''/g, "'");
-    }
-
-    const rowSeparatorMatch = /\bROW\s+SEPARATOR\s*=\s*'(LF|CR|CRLF)'/i.exec(rest);
-    if (rowSeparatorMatch) {
-        const value = rowSeparatorMatch[1].toUpperCase();
-        options.rowSeparator = RowSeparator[value as keyof typeof RowSeparator];
-    }
-
-    const encodingMatch = /\bENCODING\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
-    if (encodingMatch) {
-        options.encoding = encodingMatch[1].replace(/''/g, "'") as CsvFormatOptions['encoding'];
-    }
-
-    // TRIM / LTRIM / RTRIM (match the most specific token first).
-    const trimMatch = /\b(LTRIM|RTRIM|TRIM)\b/i.exec(rest);
-    if (trimMatch) {
-        const value = trimMatch[1].toUpperCase();
-        if (value === 'LTRIM') {
-            options.trim = TrimMode.LEADING;
-        } else if (value === 'RTRIM') {
-            options.trim = TrimMode.TRAILING;
-        } else {
-            options.trim = TrimMode.BOTH;
+    const skipSeparators = (): void => {
+        SEPARATOR_RE.lastIndex = pos;
+        const sep = SEPARATOR_RE.exec(rest);
+        if (sep) {
+            pos = SEPARATOR_RE.lastIndex;
         }
-    }
+    };
 
-    const nullMatch = /\bNULL\s*=\s*'((?:[^']|'')*)'/i.exec(rest);
-    if (nullMatch) {
-        options.null = nullMatch[1].replace(/''/g, "'");
+    while (pos < rest.length) {
+        skipSeparators();
+        if (pos >= rest.length) {
+            break;
+        }
+
+        // A real FILE token in the unconsumed structure means a second file.
+        FILE_TOKEN_RE.lastIndex = pos;
+        if (FILE_TOKEN_RE.exec(rest)) {
+            throw new Error('Local CSV import supports a single FILE; found multiple. Run one IMPORT per file.');
+        }
+
+        let matched = false;
+        for (const matcher of OPTION_TOKEN_MATCHERS) {
+            matcher.re.lastIndex = pos;
+            const m = matcher.re.exec(rest);
+            if (m) {
+                matcher.apply(options, m);
+                pos = matcher.re.lastIndex;
+                matched = true;
+                break;
+            }
+        }
+
+        if (!matched) {
+            // Unrecognized token: advance past it so a quoted value or stray
+            // token cannot wedge the loop, and keep scanning for a FILE keyword.
+            const advance = /\S+/y;
+            advance.lastIndex = pos;
+            if (advance.exec(rest)) {
+                pos = advance.lastIndex;
+            } else {
+                break;
+            }
+        }
     }
 
     return options;

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ConnectionManager } from './connectionManager';
 import { getColumnsFromResult, getRowsFromResult, rawQuery, rawExecute, extractColumnMetadata, extractColumnName, ColumnMetadata, stripCommentsPreservingStrings } from './utils';
+import { parseLocalCsvImport, resolveImportPath } from './localCsvImport';
 
 export type { ColumnMetadata };
 
@@ -31,6 +32,27 @@ export class QueryExecutor {
 
         // Clean the query - remove trailing semicolons and trim
         let finalQuery = query.trim().replace(/;+\s*$/, '').trim();
+
+        // Intercept local CSV imports: raw SQL cannot stream a local file over the
+        // WebSocket protocol, so route them through the driver's programmatic import.
+        const localImport = parseLocalCsvImport(finalQuery);
+        if (localImport) {
+            return await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver();
+                const absPath = resolveImportPath(localImport.filePath);
+                const rowCount = await driver.importFromCsvFile(localImport.table, absPath, localImport.options);
+
+                const executionTime = Date.now() - startTime;
+
+                return {
+                    columns: [],
+                    columnMetadata: [],
+                    rows: [],
+                    rowCount,
+                    executionTime
+                };
+            }, undefined, cancellationToken ? { cancellationToken } : undefined);
+        }
 
         // Auto-add LIMIT to SELECT queries without explicit LIMIT
         if (finalQuery.toUpperCase().startsWith('SELECT') && !finalQuery.toUpperCase().includes('LIMIT')) {

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -26,7 +26,7 @@ export class QueryExecutor {
 
         const config = vscode.workspace.getConfiguration('exasol');
         const maxRows = config.get<number>('maxResultRows', 10000);
-        const _timeout = config.get<number>('queryTimeout', 300);
+        const queryTimeoutMs = config.get<number>('queryTimeout', 300) * 1000;
 
         const startTime = Date.now();
 
@@ -35,8 +35,18 @@ export class QueryExecutor {
 
         // Intercept local CSV imports: raw SQL cannot stream a local file over the
         // WebSocket protocol, so route them through the driver's programmatic import.
+        //
+        // Cancelling the wrapper here only abandons this promise: it does NOT stop
+        // the in-flight server-side load nor tear down the driver's import tunnel.
+        // Stopping a streaming import cleanly needs a driver-side AbortSignal,
+        // tracked in exasol/exasol-driver-ts#68.
         const localImport = parseLocalCsvImport(finalQuery);
         if (localImport) {
+            // Unlike the SELECT/DDL branches, the import branch passes a timeout:
+            // the cluster connects back to the driver's import tunnel, and an
+            // asymmetric NAT/firewall can stall that handshake with no automatic
+            // recovery, leaving the import hung indefinitely. The timeout rejects
+            // a stalled import instead of hanging forever.
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver();
                 const absPath = resolveImportPath(localImport.filePath);
@@ -51,7 +61,7 @@ export class QueryExecutor {
                     rowCount,
                     executionTime
                 };
-            }, undefined, cancellationToken ? { cancellationToken } : undefined);
+            }, undefined, { timeoutMs: queryTimeoutMs, ...(cancellationToken ? { cancellationToken } : {}) });
         }
 
         // Auto-add LIMIT to SELECT queries without explicit LIMIT

--- a/src/test/unit/localCsvImport.test.ts
+++ b/src/test/unit/localCsvImport.test.ts
@@ -141,3 +141,39 @@ suite('parseLocalCsvImport: multiple files', () => {
         );
     });
 });
+
+suite('parseLocalCsvImport: string-literal-aware option parsing (#3)', () => {
+    test("NULL = 'FILE' parses without a false multi-file error", () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' NULL = 'FILE'");
+        assert.ok(result, 'should detect the import');
+        assert.strictEqual(result.options.null, 'FILE');
+    });
+
+    test("COLUMN SEPARATOR = 'SKIP' sets the separator, not skip", () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' COLUMN SEPARATOR = 'SKIP'");
+        assert.ok(result);
+        assert.strictEqual(result.options.columnSeparator, 'SKIP');
+        assert.strictEqual(result.options.skip, undefined);
+    });
+
+    test('a quoted value containing TRIM is not misread as a trim mode', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' NULL = 'TRIM'");
+        assert.ok(result);
+        assert.strictEqual(result.options.null, 'TRIM');
+        assert.strictEqual(result.options.trim, undefined);
+    });
+
+    test("a quoted value containing ROW SEPARATOR is not misread as a row separator", () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' NULL = 'ROW SEPARATOR'");
+        assert.ok(result);
+        assert.strictEqual(result.options.null, 'ROW SEPARATOR');
+        assert.strictEqual(result.options.rowSeparator, undefined);
+    });
+
+    test('still throws on a genuine second FILE token after a quoted option', () => {
+        assert.throws(
+            () => parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/a.csv' NULL = 'x' FILE '/data/b.csv'"),
+            /single FILE/
+        );
+    });
+});

--- a/src/test/unit/localCsvImport.test.ts
+++ b/src/test/unit/localCsvImport.test.ts
@@ -1,0 +1,143 @@
+import * as assert from 'assert';
+import { registerVscodeMock } from '../helpers/vscodeMock';
+import { RowSeparator, TrimMode } from '@exasol/exasol-driver-ts';
+
+registerVscodeMock();
+
+// Load after the vscode mock is configured, since localCsvImport imports 'vscode'.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { parseLocalCsvImport } = require('../../localCsvImport');
+
+suite('parseLocalCsvImport: detection and extraction', () => {
+    test('detects a basic local CSV import and extracts table and path', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv'");
+        assert.ok(result, 'should detect the import');
+        assert.strictEqual(result.table, 't');
+        assert.strictEqual(result.filePath, '/data/in.csv');
+        assert.deepStrictEqual(result.options, {});
+    });
+
+    test('is case-insensitive and tolerant of extra whitespace', () => {
+        const result = parseLocalCsvImport("import   into   t\n  from local csv file   '/data/in.csv'");
+        assert.ok(result);
+        assert.strictEqual(result.table, 't');
+        assert.strictEqual(result.filePath, '/data/in.csv');
+    });
+
+    test('strips a trailing semicolon', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv';");
+        assert.ok(result);
+        assert.strictEqual(result.filePath, '/data/in.csv');
+    });
+
+    test('parses the SECURE variant', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL SECURE CSV FILE '/data/in.csv'");
+        assert.ok(result);
+        assert.strictEqual(result.table, 't');
+        assert.strictEqual(result.filePath, '/data/in.csv');
+    });
+
+    test('captures a column-list target verbatim', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t (a, b) FROM LOCAL CSV FILE '/data/in.csv'");
+        assert.ok(result);
+        assert.strictEqual(result.table, 't (a, b)');
+        assert.strictEqual(result.filePath, '/data/in.csv');
+    });
+
+    test('captures a schema-qualified target', () => {
+        const result = parseLocalCsvImport("IMPORT INTO myschema.mytable FROM LOCAL CSV FILE '/data/in.csv'");
+        assert.ok(result);
+        assert.strictEqual(result.table, 'myschema.mytable');
+    });
+
+    test('unescapes doubled single-quotes in the path', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/o''brien.csv'");
+        assert.ok(result);
+        assert.strictEqual(result.filePath, "/data/o'brien.csv");
+    });
+});
+
+suite('parseLocalCsvImport: option parsing', () => {
+    test('parses SKIP as a number', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' SKIP = 1");
+        assert.ok(result);
+        assert.strictEqual(result.options.skip, 1);
+    });
+
+    test('parses COLUMN SEPARATOR', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' COLUMN SEPARATOR = ';'");
+        assert.ok(result);
+        assert.strictEqual(result.options.columnSeparator, ';');
+    });
+
+    test('parses COLUMN DELIMITER', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' COLUMN DELIMITER = '\"'");
+        assert.ok(result);
+        assert.strictEqual(result.options.columnDelimiter, '"');
+    });
+
+    test('parses ROW SEPARATOR into the RowSeparator enum', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' ROW SEPARATOR = 'CRLF'");
+        assert.ok(result);
+        assert.strictEqual(result.options.rowSeparator, RowSeparator.CRLF);
+    });
+
+    test('parses ENCODING', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' ENCODING = 'UTF-8'");
+        assert.ok(result);
+        assert.strictEqual(result.options.encoding, 'UTF-8');
+    });
+
+    test('parses NULL', () => {
+        const result = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' NULL = '\\N'");
+        assert.ok(result);
+        assert.strictEqual(result.options.null, '\\N');
+    });
+
+    test('parses TRIM, LTRIM, RTRIM into TrimMode', () => {
+        const trim = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' TRIM");
+        assert.strictEqual(trim.options.trim, TrimMode.BOTH);
+        const ltrim = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' LTRIM");
+        assert.strictEqual(ltrim.options.trim, TrimMode.LEADING);
+        const rtrim = parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' RTRIM");
+        assert.strictEqual(rtrim.options.trim, TrimMode.TRAILING);
+    });
+
+    test('parses multiple options together, tolerant of spacing', () => {
+        const result = parseLocalCsvImport(
+            "IMPORT INTO t FROM LOCAL CSV FILE '/data/in.csv' SKIP=2 COLUMN SEPARATOR='\\t' ROW SEPARATOR = 'LF'"
+        );
+        assert.ok(result);
+        assert.strictEqual(result.options.skip, 2);
+        assert.strictEqual(result.options.columnSeparator, '\\t');
+        assert.strictEqual(result.options.rowSeparator, RowSeparator.LF);
+    });
+});
+
+suite('parseLocalCsvImport: returns null for non-local-CSV statements', () => {
+    test('returns null for a SELECT', () => {
+        assert.strictEqual(parseLocalCsvImport('SELECT * FROM t'), null);
+    });
+
+    test('returns null for a cloud import (FROM CSV AT, no LOCAL)', () => {
+        const sql = "IMPORT INTO t FROM CSV AT 'https://example.com/bucket' FILE '001.csv'";
+        assert.strictEqual(parseLocalCsvImport(sql), null);
+    });
+
+    test('returns null for FROM LOCAL FBV FILE', () => {
+        assert.strictEqual(parseLocalCsvImport("IMPORT INTO t FROM LOCAL FBV FILE '/data/in.fbv'"), null);
+    });
+
+    test('returns null for a comment-only string', () => {
+        assert.strictEqual(parseLocalCsvImport('-- just a comment'), null);
+    });
+});
+
+suite('parseLocalCsvImport: multiple files', () => {
+    test('throws when the options clause contains another FILE token', () => {
+        assert.throws(
+            () => parseLocalCsvImport("IMPORT INTO t FROM LOCAL CSV FILE '/data/a.csv' FILE '/data/b.csv'"),
+            /single FILE/
+        );
+    });
+});

--- a/src/test/unit/queryExecutorRouting.test.ts
+++ b/src/test/unit/queryExecutorRouting.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import { registerVscodeMock, vscodeMock } from '../helpers/vscodeMock';
+
+// QueryExecutor reads exasol config (maxResultRows, queryTimeout) at execute()
+// time; the per-test setup() below installs the config getter it needs.
+registerVscodeMock();
+
+// Load after the vscode mock is configured.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { QueryExecutor } = require('../../queryExecutor');
+
+import { createEmptyRawResult } from '../helpers/mockConnectionManager';
+
+interface DriverCalls {
+    importFromCsvFile: any[][];
+    execute: any[][];
+    query: any[][];
+}
+
+/**
+ * Build a QueryExecutor wired to a fake ConnectionManager whose driver records
+ * every call to importFromCsvFile / execute / query. The fake executeWithRetry
+ * just invokes the supplied fn so routing logic runs unchanged.
+ */
+function makeExecutor(): { qe: any; calls: DriverCalls } {
+    const calls: DriverCalls = { importFromCsvFile: [], execute: [], query: [] };
+
+    const fakeDriver = {
+        importFromCsvFile: async (...args: any[]) => {
+            calls.importFromCsvFile.push(args);
+            return 42;
+        },
+        // rawExecute -> driver.execute(sql, undefined, undefined, 'raw')
+        execute: async (...args: any[]) => {
+            calls.execute.push(args);
+            return createEmptyRawResult([]);
+        },
+        // rawQuery -> driver.query(sql, undefined, undefined, 'raw')
+        query: async (...args: any[]) => {
+            calls.query.push(args);
+            return createEmptyRawResult([]);
+        }
+    };
+
+    const fakeConnectionManager = {
+        getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+        getDriver: async () => fakeDriver,
+        executeWithRetry: async (fn: () => Promise<any>) => fn()
+    };
+
+    return { qe: new QueryExecutor(fakeConnectionManager), calls };
+}
+
+suite('QueryExecutor.execute routing: local CSV import interception', () => {
+    setup(() => {
+        // Other test files share the singleton vscodeMock and may overwrite
+        // workspace; re-establish the config getter QueryExecutor.execute reads.
+        (vscodeMock as any).workspace = {
+            getConfiguration: () => ({
+                get: (_key: string, fallback?: unknown) => fallback
+            })
+        };
+    });
+
+    test('a LOCAL CSV import calls importFromCsvFile and bypasses raw execute/query', async () => {
+        const { qe, calls } = makeExecutor();
+
+        const result = await qe.execute("IMPORT INTO t FROM LOCAL CSV FILE '/abs/x.csv'");
+
+        assert.strictEqual(calls.importFromCsvFile.length, 1, 'should call importFromCsvFile once');
+        const [table, absPath] = calls.importFromCsvFile[0];
+        assert.strictEqual(table, 't');
+        assert.strictEqual(absPath, '/abs/x.csv');
+
+        assert.strictEqual(calls.execute.length, 0, 'must not hit raw execute()');
+        assert.strictEqual(calls.query.length, 0, 'must not hit raw query()');
+
+        assert.strictEqual(result.rowCount, 42);
+    });
+
+    test('a cloud import (FROM CSV AT) does not call importFromCsvFile and goes through execute()', async () => {
+        const { qe, calls } = makeExecutor();
+
+        await qe.execute("IMPORT INTO t FROM CSV AT 'https://h' FILE '001.csv'");
+
+        assert.strictEqual(calls.importFromCsvFile.length, 0, 'must not intercept a cloud import');
+        // IMPORT is classified as a non-result-set command, so it routes to execute().
+        assert.strictEqual(calls.execute.length, 1, 'cloud import should go through raw execute()');
+        assert.strictEqual(calls.query.length, 0);
+    });
+});

--- a/src/test/unit/resolveImportPath.test.ts
+++ b/src/test/unit/resolveImportPath.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { registerVscodeMock, vscodeMock } from '../helpers/vscodeMock';
+
+registerVscodeMock();
+
+// localCsvImport captures the `vscode` namespace at require time, and tsx's CJS
+// interop only live-binds NESTED property mutations on the captured window/
+// workspace objects, not full reassignments. Because other test files share the
+// singleton vscodeMock and reassign window/workspace, we install fresh stable
+// objects in setup() and re-require the module so it re-captures them; per-test
+// helpers then mutate those same objects' nested fields.
+let resolveImportPath: (filePath: string) => string;
+
+function setActiveEditor(fsPath: string | undefined, scheme = 'file'): void {
+    (vscodeMock as any).window.activeTextEditor = fsPath
+        ? { document: { uri: { scheme, fsPath } } }
+        : undefined;
+}
+
+function setWorkspaceFolder(fsPath: string | undefined): void {
+    (vscodeMock as any).workspace.workspaceFolders = fsPath
+        ? [{ uri: { fsPath } }]
+        : undefined;
+}
+
+suite('resolveImportPath', () => {
+    setup(() => {
+        (vscodeMock as any).window = { activeTextEditor: undefined };
+        (vscodeMock as any).workspace = { workspaceFolders: undefined };
+        // Re-require so localCsvImport re-captures the freshly installed objects.
+        delete require.cache[require.resolve('../../localCsvImport')];
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        resolveImportPath = require('../../localCsvImport').resolveImportPath;
+    });
+
+    test('returns an absolute path unchanged', () => {
+        setActiveEditor('/home/user/queries/run.sql');
+        setWorkspaceFolder('/home/user/project');
+        const abs = path.resolve('/abs/data/in.csv');
+        assert.strictEqual(resolveImportPath(abs), abs);
+    });
+
+    test('resolves a relative path against the active file-scheme editor dir', () => {
+        setActiveEditor('/home/user/queries/run.sql');
+        setWorkspaceFolder('/home/user/project');
+        assert.strictEqual(
+            resolveImportPath('data/in.csv'),
+            path.resolve('/home/user/queries', 'data/in.csv')
+        );
+    });
+
+    test('falls back to the workspace folder when the editor is not file-scheme', () => {
+        setActiveEditor('/virtual/notebook', 'untitled');
+        setWorkspaceFolder('/home/user/project');
+        assert.strictEqual(
+            resolveImportPath('data/in.csv'),
+            path.resolve('/home/user/project', 'data/in.csv')
+        );
+    });
+
+    test('resolves against the workspace folder when no active editor', () => {
+        setActiveEditor(undefined);
+        setWorkspaceFolder('/home/user/project');
+        assert.strictEqual(
+            resolveImportPath('data/in.csv'),
+            path.resolve('/home/user/project', 'data/in.csv')
+        );
+    });
+
+    test('throws when neither an active file editor nor a workspace folder is available', () => {
+        setActiveEditor(undefined);
+        setWorkspaceFolder(undefined);
+        assert.throws(() => resolveImportPath('data/in.csv'), /Relative import path/);
+    });
+});


### PR DESCRIPTION
## Summary
- **Local CSV import now works from the extension**: `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>' [options]` is intercepted and streamed to Exasol over the driver's TLS tunnel (raw SQL cannot do local imports over the WebSocket protocol). Closes #9.
- Updates the bundled Exasol driver to `mikhail-zhadanov/exasol-driver-ts@46d96ef` (v0.4.1): replaces `node-forge` with Node's built-in `node:crypto` in both the login and import-TLS paths, plus 0.4.0's local CSV import capability, the `query()`/`execute()` cancellation fix, and dependency/security refreshes. `node-forge` stays out of the bundle (~313 KB).
- Extension 1.5.1.

## How local import works
- `QueryExecutor.execute()` (the single funnel for every statement path) detects `IMPORT ... FROM LOCAL [SECURE] CSV FILE '<path>' [options]`, parses the target, path, and CSV options (`SKIP`, `COLUMN SEPARATOR`/`DELIMITER`, `ROW SEPARATOR`, `ENCODING`, `TRIM`, `NULL`) with string-literal-aware scanning, resolves relative paths against the active document or workspace folder, and calls `driver.importFromCsvFile()`.
- Cloud imports (`FROM CSV AT ...`), FBV, and every other statement are unchanged.

## Review hardening (post whole-project review)
- Import branch applies the `queryTimeout` so a stalled tunnel connect-back rejects instead of hanging indefinitely (the config value was previously read but unused).
- CSV option parsing is string-literal-aware: a quoted value containing an option keyword (e.g. `NULL = 'FILE'`) no longer mis-parses or false-triggers the multi-file guard.
- Added integration routing tests (local -> `importFromCsvFile`; cloud `FROM CSV AT` -> raw path) and `resolveImportPath` tests.

## Verification
- `tsc --noEmit` clean; **457 unit tests pass**; VSIX builds (131 KB, 19 files), zero `node-forge` in bundle.
- Driver CI (PR exasol/exasol-driver-ts#59): build, lint, full unit suite, Node 22/24/26 integration, project-keeper — all green, mergeable.

## Known limitations / follow-ups
- Cancelling an in-progress local import does not stop the in-flight server-side load or tear down the tunnel — needs a driver-side AbortSignal: exasol/exasol-driver-ts#68.
- Local **export** (`EXPORT ... INTO LOCAL CSV FILE`) is not supported (the driver has no local-export path today): exasol/exasol-driver-ts#69.
- The cluster must be able to open a connection back to the client machine for the import tunnel; FBV and multi-file local imports are not supported.

## Note
- The driver is a git-pinned fork until exasol/exasol-driver-ts#59 merges upstream, at which point the pin reverts to the npm release.
