### PR TITLE
feat: SQL execution plan viewer (Plan tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "Exasol" extension will be documented in this file.
 
+## [1.7.0] - 2026-07-23
+
+### Added
+- **Execution plan viewer**: a "Plan" tab alongside single-statement query results showing Exasol's per-operator profile (cost share, duration, rows, CPU/network/disk) with warnings for skew, disk spills, and large redistributions; works for any profiled statement including DDL, DML, IMPORT and EXPORT. Gated by the new `exasol.executionPlan` setting (default on); when enabled, new user connections run `ALTER SESSION SET PROFILE = 'ON'` automatically
+
+### Changed
+- Reported execution time now measures only the statement's own round trip, excluding connection-queue wait and reconnect time
+
 ## [1.6.0] - 2026-06-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A Visual Studio Code extension for working with Exasol databases. Provides datab
 | `maxQueryHistorySize` | 1000 | Queries to keep in history |
 | `autoComplete` | true | Enable IntelliSense |
 | `separateResultTabs` | false | Show each statement result in a separate tab |
+| `executionPlan` | true | Enable execution plan capture and the Plan tab; new user connections automatically enable session profiling |
 | `formatter.*` | — | Keyword case, indent style, tab width, statement spacing |
 
 ## Development
@@ -80,7 +81,7 @@ A third warning, `npm warn skipping integrity check for git dependency ssh://git
 - Large result sets (>10,000 rows) may impact rendering performance
 - Query cancellation relies on driver support; some queries may not cancel immediately
 - Local file import from the extension is supported for CSV only, via `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>'`. The extension intercepts the statement and streams the file to Exasol over the driver's TLS tunnel, so the cluster must be able to open a connection back to the client machine for the import tunnel. Other local formats (e.g. FBV) and multi-file local imports are not supported; cloud file imports continue to work via raw SQL. Cancelling an in-progress local import does not stop the load already streaming to the cluster
-- Execution plan CPU, network, and disk-write metrics require `ALTER SESSION SET PROFILE = 'ON'` before running the query; the Plan tab shows a hint when this wasn't enabled, but doesn't turn profiling on automatically
+- Execution plans require session profiling. When `executionPlan` is enabled, the extension runs `ALTER SESSION SET PROFILE = 'ON'` on new user connections; reconnect after changing the setting or after a profiling setup failure
 - The Plan tab is only available for single-statement results — not yet for the multi-statement "Result 1 / Result 2" tab bar
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A Visual Studio Code extension for working with Exasol databases. Provides datab
 - **Object explorer** — browse schemas, tables, views, columns, scripts, functions, virtual schemas, constraints, indices, and system tables
 - **Object actions** — right-click to preview data, show DDL, generate SELECT, describe table
 - **Results viewer** — sortable, filterable grid with CSV export and cell inspection
+- **Execution plan viewer** — a "Plan" tab alongside every query result, showing a visual per-operator breakdown (cost share, duration, rows, CPU/network/disk) with warnings for skew, disk spills, and large redistributions; available for any profiled statement, not just SELECT — DDL, DML, IMPORT, and EXPORT included
 - **Query history** — automatic tracking with execution time, row counts, and error indicators
 - **SQL Notebooks** — interactive `.exabook` notebooks with SQL cells, inline results, and markdown documentation
 - **SQL formatting** — configurable keyword case, indentation, and statement spacing
@@ -79,6 +80,8 @@ A third warning, `npm warn skipping integrity check for git dependency ssh://git
 - Large result sets (>10,000 rows) may impact rendering performance
 - Query cancellation relies on driver support; some queries may not cancel immediately
 - Local file import from the extension is supported for CSV only, via `IMPORT INTO <table> FROM LOCAL CSV FILE '<path>'`. The extension intercepts the statement and streams the file to Exasol over the driver's TLS tunnel, so the cluster must be able to open a connection back to the client machine for the import tunnel. Other local formats (e.g. FBV) and multi-file local imports are not supported; cloud file imports continue to work via raw SQL. Cancelling an in-progress local import does not stop the load already streaming to the cluster
+- Execution plan CPU, network, and disk-write metrics require `ALTER SESSION SET PROFILE = 'ON'` before running the query; the Plan tab shows a hint when this wasn't enabled, but doesn't turn profiling on automatically
+- The Plan tab is only available for single-statement results — not yet for the multi-statement "Result 1 / Result 2" tab bar
 
 ## Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exasol-vscode",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exasol-vscode",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@exasol/exasol-driver-ts": "github:mikhail-zhadanov/exasol-driver-ts#46d96eff6dd109aa201275b7347a94e9a5f52612",

--- a/package.json
+++ b/package.json
@@ -513,6 +513,11 @@
           "default": false,
           "description": "When enabled, multi-statement executions display each result in a separate tab"
         },
+        "exasol.executionPlan": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable execution plan capture and the Plan tab. When enabled, new user connections run ALTER SESSION SET PROFILE = 'ON'."
+        },
         "exasol.searchIncludesColumns": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Exasol",
   "icon": "resources/exasol-icon.png",
   "description": "Feature-rich Exasol database extension for Visual Studio Code with IntelliSense, object browser, query execution, and more",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "publisher": "exasol",
   "license": "MIT",
   "repository": {

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -3,7 +3,7 @@ import * as crypto from 'crypto';
 import * as tls from 'tls';
 import { Mutex } from 'async-mutex';
 import { ExasolDriver, ExaWebsocket } from '@exasol/exasol-driver-ts';
-import { rawQuery } from './utils';
+import { getRowsFromResult, rawQuery } from './utils';
 import { WebSocket } from 'ws';
 import { getOutputChannel } from './extension';
 import {
@@ -16,6 +16,7 @@ import {
     formatError,
     extractFingerprintError
 } from './connectionTypes';
+import { isExecutionPlanEnabled } from './settings';
 
 // Re-export for existing consumers
 export {
@@ -77,6 +78,8 @@ export class ConnectionManager {
     private backgroundLastUsed: Map<string, number> = new Map();
     /** Interval timer for background driver idle cleanup. */
     private backgroundIdleTimer: ReturnType<typeof setInterval> | undefined;
+    /** User-driver profiling availability per connection. False means ALTER SESSION PROFILE failed. */
+    private executionPlanAvailable: Map<string, boolean> = new Map();
     private readonly connectionsChangedEmitter = new vscode.EventEmitter<void>();
     readonly onDidChangeConnections = this.connectionsChangedEmitter.event;
     private readonly activeConnectionChangedEmitter = new vscode.EventEmitter<StoredConnection | undefined>();
@@ -302,6 +305,9 @@ export class ConnectionManager {
             // Validate the connection is still alive
             const isValid = await this.validateDriver(driver, id, role);
             if (isValid) {
+                if (role === 'user') {
+                    await this.ensureUserProfiling(driver, id, connection);
+                }
                 return driver;
             }
 
@@ -328,6 +334,11 @@ export class ConnectionManager {
         this.connectingPromises.get(id)!.set(role, promise);
         try {
             const driver = await promise;
+            if (role === 'user') {
+                await this.ensureUserProfiling(driver, id, connection);
+            } else {
+                await this.ensureBackgroundAutocommit(driver, connection);
+            }
             if (!this.drivers.has(id)) {
                 this.drivers.set(id, new Map());
             }
@@ -404,6 +415,9 @@ export class ConnectionManager {
             // Reset a specific role only
             this.recentFailures.get(id)?.delete(role);
             this.lastSuccessfulQuery.get(id)?.delete(role);
+            if (role === 'user') {
+                this.executionPlanAvailable.delete(id);
+            }
             const roleMap = this.drivers.get(id);
             const driver = roleMap?.get(role);
             if (driver) {
@@ -415,6 +429,7 @@ export class ConnectionManager {
             this.recentFailures.delete(id);
             this.lastSuccessfulQuery.delete(id);
             this.backgroundLastUsed.delete(id);
+            this.executionPlanAvailable.delete(id);
             const roleMap = this.drivers.get(id);
             if (roleMap) {
                 for (const driver of roleMap.values()) {
@@ -588,6 +603,44 @@ export class ConnectionManager {
     private runExclusive<T>(fn: () => Promise<T>, role: DriverRole = 'user'): Promise<T> {
         const mutex = role === 'background' ? this.backgroundMutex : this.userMutex;
         return mutex.runExclusive(fn);
+    }
+
+    isExecutionPlanAvailable(connectionId?: string): boolean {
+        const id = connectionId || this.activeConnection;
+        return isExecutionPlanEnabled() && (!id || this.executionPlanAvailable.get(id) !== false);
+    }
+
+    private async ensureUserProfiling(driver: ExasolDriver, connectionId: string, connection: StoredConnection): Promise<void> {
+        // Only attempt this once per connection, not once per query: getDriver()
+        // calls this on every reuse of an already-valid driver, and a *remembered
+        // failure* (false) must stick until reconnect (see executionPlanAvailable's
+        // .delete(id) on disconnect) — otherwise a user whose role lacks privilege
+        // to run ALTER SESSION would pay this round-trip, and repeat this log
+        // line, on every single query forever.
+        if (!isExecutionPlanEnabled() || this.executionPlanAvailable.has(connectionId)) {
+            return;
+        }
+        try {
+            const result = await rawQuery(driver, "ALTER SESSION SET PROFILE = 'ON'");
+            getRowsFromResult(result);
+            this.executionPlanAvailable.set(connectionId, true);
+        } catch (error) {
+            this.executionPlanAvailable.set(connectionId, false);
+            getOutputChannel().appendLine(
+                `Execution plan profiling could not be enabled for '${connection.name}': ${formatError(error)}`
+            );
+        }
+    }
+
+    private async ensureBackgroundAutocommit(driver: ExasolDriver, connection: StoredConnection): Promise<void> {
+        try {
+            const result = await rawQuery(driver, "ALTER SESSION SET AUTOCOMMIT = 'ON'");
+            getRowsFromResult(result);
+        } catch (error) {
+            getOutputChannel().appendLine(
+                `Could not confirm autocommit for background connection '${connection.name}': ${formatError(error)}`
+            );
+        }
     }
 
     private async validateDriver(driver: ExasolDriver, connectionId: string, role: DriverRole = 'user'): Promise<boolean> {

--- a/src/connectionManager.ts
+++ b/src/connectionManager.ts
@@ -3,7 +3,7 @@ import * as crypto from 'crypto';
 import * as tls from 'tls';
 import { Mutex } from 'async-mutex';
 import { ExasolDriver, ExaWebsocket } from '@exasol/exasol-driver-ts';
-import { getRowsFromResult, rawQuery } from './utils';
+import { getRowsFromResult, rawExecute, rawQuery } from './utils';
 import { WebSocket } from 'ws';
 import { getOutputChannel } from './extension';
 import {
@@ -315,6 +315,10 @@ export class ConnectionManager {
             const outputChannel = getOutputChannel();
             outputChannel.appendLine(`Connection ${connection.name} (${role}) appears stale, reconnecting...`);
             roleMap.delete(role);
+            if (role === 'user') {
+                // Profiling is session-scoped, so a remembered result is invalid once the session is replaced.
+                this.executionPlanAvailable.delete(id);
+            }
             this.lastSuccessfulQuery.get(id)?.delete(role);
             try { await withTimeout(driver.close(), 2000, 'Driver close timeout'); } catch { /* ignore close errors */ }
             isReconnect = true;
@@ -336,8 +340,6 @@ export class ConnectionManager {
             const driver = await promise;
             if (role === 'user') {
                 await this.ensureUserProfiling(driver, id, connection);
-            } else {
-                await this.ensureBackgroundAutocommit(driver, connection);
             }
             if (!this.drivers.has(id)) {
                 this.drivers.set(id, new Map());
@@ -621,24 +623,13 @@ export class ConnectionManager {
             return;
         }
         try {
-            const result = await rawQuery(driver, "ALTER SESSION SET PROFILE = 'ON'");
+            const result = await rawExecute(driver, "ALTER SESSION SET PROFILE = 'ON'");
             getRowsFromResult(result);
             this.executionPlanAvailable.set(connectionId, true);
         } catch (error) {
             this.executionPlanAvailable.set(connectionId, false);
             getOutputChannel().appendLine(
                 `Execution plan profiling could not be enabled for '${connection.name}': ${formatError(error)}`
-            );
-        }
-    }
-
-    private async ensureBackgroundAutocommit(driver: ExasolDriver, connection: StoredConnection): Promise<void> {
-        try {
-            const result = await rawQuery(driver, "ALTER SESSION SET AUTOCOMMIT = 'ON'");
-            getRowsFromResult(result);
-        } catch (error) {
-            getOutputChannel().appendLine(
-                `Could not confirm autocommit for background connection '${connection.name}': ${formatError(error)}`
             );
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext) {
     const queryHistoryProvider = new QueryHistoryProvider(context);
 
     // Register panel views
-    ResultsPanel.register(context);
+    ResultsPanel.register(context, connectionManager);
 
     // Register notebook support
     const notebookSerializer = vscode.workspace.registerNotebookSerializer(

--- a/src/objectActions.ts
+++ b/src/objectActions.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import { ConnectionManager, StoredConnection } from './connectionManager';
-import { QueryExecutor } from './queryExecutor';
+import { QueryExecutor, captureBaselineStatementIdentity } from './queryExecutor';
 import { ResultsPanel } from './panels/resultsPanel';
 import { getColumnsFromResult, getRowsFromResult, rawQuery, extractColumnMetadata, extractColumnName, escapeSqlString, escapeSqlIdentifier } from './utils';
+import { isExecutionPlanEnabled } from './settings';
 
 export class ObjectActions {
     constructor(
@@ -29,7 +30,12 @@ export class ObjectActions {
                     const query = `SELECT * FROM "${escapeSqlIdentifier(schemaName)}"."${escapeSqlIdentifier(tableName)}" LIMIT ${limit}`;
                     const queryResult = await this.connectionManager.executeWithRetry(async () => {
                         const driver = await this.connectionManager.getDriver(connection.id);
+                        const shouldCapturePlanIdentity = isExecutionPlanEnabled()
+                            && (this.connectionManager.isExecutionPlanAvailable?.(connection.id) ?? true);
 
+                        const identity = shouldCapturePlanIdentity
+                            ? await captureBaselineStatementIdentity(driver)
+                            : {};
                         const startTime = Date.now();
                         const result = await rawQuery(driver, query);
                         const executionTime = Date.now() - startTime;
@@ -44,7 +50,9 @@ export class ObjectActions {
                             columnMetadata,
                             rows,
                             rowCount: rows.length,
-                            executionTime
+                            executionTime,
+                            connectionId: connection.id,
+                            ...identity
                         };
                     }, connection.id);
 

--- a/src/panels/planTabRenderer.ts
+++ b/src/panels/planTabRenderer.ts
@@ -1,0 +1,75 @@
+import { escapeHtml } from '../utils';
+
+/**
+ * Renders the "Results | Plan" tab strip shown above a single-statement
+ * result. Deliberately uses distinct class names (`rv-tab*`, not `tab*`) so
+ * clicks here are never picked up by resultsGrid.tsx's generic
+ * `document.querySelectorAll('.tab')` handler, which is wired for the
+ * unrelated multi-statement Result-N tab bar (tabBarRenderer.ts).
+ */
+export type PlanTabStatus = 'idle' | 'loading' | 'ready' | 'error';
+export type ResultView = 'results' | 'plan';
+
+export function buildResultPlanTabBarHtml(activeView: ResultView, planStatus: PlanTabStatus, nonce: string): string {
+    const planLabel = planStatus === 'loading' ? 'Plan (loading…)' : 'Plan';
+    const planErrorClass = planStatus === 'error' ? ' error' : '';
+
+    return `<div class="rv-tab-bar" id="rv-tab-bar">
+        <div class="rv-tab${activeView === 'results' ? ' active' : ''}" data-view="results"><span class="rv-tab-label">Results</span></div>
+        <div class="rv-tab${activeView === 'plan' ? ' active' : ''}${planErrorClass}" data-view="plan"><span class="rv-tab-label">${escapeHtml(planLabel)}</span></div>
+    </div>
+    <script nonce="${nonce}">
+    (function () {
+        var vscodeApi = window.__vscode || (window.acquireVsCodeApi && window.acquireVsCodeApi());
+        if (vscodeApi) { window.__vscode = vscodeApi; }
+        var bar = document.getElementById('rv-tab-bar');
+        if (!bar || !vscodeApi) { return; }
+        bar.querySelectorAll('.rv-tab').forEach(function (tab) {
+            tab.addEventListener('click', function () {
+                vscodeApi.postMessage({ command: 'switchResultView', view: tab.getAttribute('data-view') });
+            });
+        });
+    })();
+    </script>`;
+}
+
+export function buildResultPlanTabBarCss(): string {
+    return `
+        .rv-tab-bar {
+            display: flex;
+            flex-shrink: 0;
+            border-bottom: 1px solid var(--vscode-panel-border);
+            background-color: var(--vscode-editorGroupHeader-tabsBackground, var(--vscode-editor-background));
+        }
+        .rv-tab {
+            padding: 6px 14px;
+            cursor: pointer;
+            font-size: 12px;
+            white-space: nowrap;
+            border-bottom: 2px solid transparent;
+            color: var(--vscode-tab-inactiveForeground, var(--vscode-foreground));
+            background-color: var(--vscode-tab-inactiveBackground, transparent);
+        }
+        .rv-tab:hover {
+            background-color: var(--vscode-tab-hoverBackground, var(--vscode-list-hoverBackground));
+        }
+        .rv-tab.active {
+            color: var(--vscode-tab-activeForeground, var(--vscode-foreground));
+            background-color: var(--vscode-tab-activeBackground, var(--vscode-editor-background));
+            border-bottom-color: var(--vscode-focusBorder, var(--vscode-charts-blue));
+        }
+        .rv-tab.error {
+            color: var(--vscode-errorForeground, #f44747);
+        }
+        .rv-tab.error::before {
+            content: '';
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: var(--vscode-errorForeground, #f44747);
+            margin-right: 6px;
+            vertical-align: middle;
+        }
+    `;
+}

--- a/src/panels/planTabRenderer.ts
+++ b/src/panels/planTabRenderer.ts
@@ -10,13 +10,16 @@ import { escapeHtml } from '../utils';
 export type PlanTabStatus = 'idle' | 'loading' | 'ready' | 'error';
 export type ResultView = 'results' | 'plan';
 
-export function buildResultPlanTabBarHtml(activeView: ResultView, planStatus: PlanTabStatus, nonce: string): string {
+export function buildResultPlanTabBarHtml(activeView: ResultView, planStatus: PlanTabStatus, nonce: string, showPlanTab = true): string {
     const planLabel = planStatus === 'loading' ? 'Plan (loading…)' : 'Plan';
     const planErrorClass = planStatus === 'error' ? ' error' : '';
+    const planTabHtml = showPlanTab
+        ? `<div class="rv-tab${activeView === 'plan' ? ' active' : ''}${planErrorClass}" data-view="plan"><span class="rv-tab-label">${escapeHtml(planLabel)}</span></div>`
+        : '';
 
     return `<div class="rv-tab-bar" id="rv-tab-bar">
         <div class="rv-tab${activeView === 'results' ? ' active' : ''}" data-view="results"><span class="rv-tab-label">Results</span></div>
-        <div class="rv-tab${activeView === 'plan' ? ' active' : ''}${planErrorClass}" data-view="plan"><span class="rv-tab-label">${escapeHtml(planLabel)}</span></div>
+        ${planTabHtml}
     </div>
     <script nonce="${nonce}">
     (function () {
@@ -27,6 +30,11 @@ export function buildResultPlanTabBarHtml(activeView: ResultView, planStatus: Pl
         bar.querySelectorAll('.rv-tab').forEach(function (tab) {
             tab.addEventListener('click', function () {
                 vscodeApi.postMessage({ command: 'switchResultView', view: tab.getAttribute('data-view') });
+            });
+        });
+        document.querySelectorAll('[data-plan-retry]').forEach(function (button) {
+            button.addEventListener('click', function () {
+                vscodeApi.postMessage({ command: 'switchResultView', view: 'plan' });
             });
         });
     })();

--- a/src/panels/planTabRenderer.ts
+++ b/src/panels/planTabRenderer.ts
@@ -32,10 +32,15 @@ export function buildResultPlanTabBarHtml(activeView: ResultView, planStatus: Pl
                 vscodeApi.postMessage({ command: 'switchResultView', view: tab.getAttribute('data-view') });
             });
         });
-        document.querySelectorAll('[data-plan-retry]').forEach(function (button) {
-            button.addEventListener('click', function () {
+        // The retry button lives in the plan error body, rendered later
+        // inside .plan-view — not yet in the document when this script runs
+        // — so this binds via delegation on the document instead of
+        // querying for the button directly.
+        document.addEventListener('click', function (e) {
+            var target = e.target && e.target.closest && e.target.closest('[data-plan-retry]');
+            if (target) {
                 vscodeApi.postMessage({ command: 'switchResultView', view: 'plan' });
-            });
+            }
         });
     })();
     </script>`;

--- a/src/panels/resultsPanel.ts
+++ b/src/panels/resultsPanel.ts
@@ -1,13 +1,31 @@
 import * as vscode from 'vscode';
 import { QueryResult } from '../queryExecutor';
+import { ConnectionManager } from '../connectionManager';
+import { formatError } from '../connectionTypes';
 import { TabManager, TabResult } from './tabManager';
 import { buildTabBarHtml, buildTabBarCss } from './tabBarRenderer';
+import { buildResultPlanTabBarHtml, buildResultPlanTabBarCss, ResultView } from './planTabRenderer';
+import { PlanProvider } from '../plan/planProvider';
+import { Plan } from '../plan/planModel';
+import {
+    buildPlanContentHtml,
+    buildPlanContentCss,
+    buildPlanErrorHtml,
+    buildPlanLoadingHtml,
+    buildPlanStatusCss
+} from '../plan/planWebview';
 import { escapeHtml, createWebviewRenderContext } from '../utils';
 
 interface ResultViewOptions {
     title: string;
     showExport: boolean;
 }
+
+type PlanViewState =
+    | { status: 'idle' }
+    | { status: 'loading' }
+    | { status: 'ready'; plan: Plan }
+    | { status: 'error'; message: string };
 
 export class ResultsPanel implements vscode.WebviewViewProvider {
     private static instance: ResultsPanel | undefined;
@@ -16,11 +34,16 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
     private static currentError: string | undefined;
     private view: vscode.WebviewView | undefined;
     private tabManager: TabManager = new TabManager();
+    private activeSubTab: ResultView = 'results';
+    private planViewState: PlanViewState = { status: 'idle' };
+    private readonly planProvider: PlanProvider;
 
-    private constructor(private readonly extensionUri: vscode.Uri) {}
+    private constructor(private readonly extensionUri: vscode.Uri, private readonly connectionManager: ConnectionManager) {
+        this.planProvider = new PlanProvider(connectionManager);
+    }
 
-    public static register(context: vscode.ExtensionContext): ResultsPanel {
-        const provider = new ResultsPanel(context.extensionUri);
+    public static register(context: vscode.ExtensionContext, connectionManager: ConnectionManager): ResultsPanel {
+        const provider = new ResultsPanel(context.extensionUri, connectionManager);
         ResultsPanel.instance = provider;
 
         context.subscriptions.push(
@@ -46,6 +69,7 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
         ResultsPanel.currentQuery = query;
         ResultsPanel.currentError = undefined;
         ResultsPanel.instance.tabManager.clearTabs();
+        ResultsPanel.instance.resetPlanView();
         ResultsPanel.instance.updateWebview();
         ResultsPanel.instance.revealWithoutFocus();
     }
@@ -58,6 +82,7 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
         ResultsPanel.currentResult = undefined;
         ResultsPanel.currentQuery = undefined;
         ResultsPanel.instance.tabManager.clearTabs();
+        ResultsPanel.instance.resetPlanView();
         ResultsPanel.instance.updateWebview();
         ResultsPanel.instance.revealWithoutFocus();
     }
@@ -70,6 +95,7 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
         ResultsPanel.currentQuery = undefined;
         ResultsPanel.currentError = undefined;
         ResultsPanel.instance.tabManager.setTabs(tabs);
+        ResultsPanel.instance.resetPlanView();
         ResultsPanel.instance.updateWebview();
         ResultsPanel.instance.revealWithoutFocus();
     }
@@ -105,10 +131,20 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
                     this.tabManager.clearTabs();
                 }
                 this.updateWebview();
+            } else if (message.command === 'switchResultView') {
+                this.activeSubTab = message.view === 'plan' ? 'plan' : 'results';
+                if (this.activeSubTab === 'plan' && this.planViewState.status === 'idle') {
+                    await this.requestPlan();
+                } else {
+                    this.updateWebview();
+                }
             } else if (message.command === 'copy') {
                 // Copy to clipboard
                 await vscode.env.clipboard.writeText(message.text);
                 vscode.window.showInformationMessage(`Copied ${message.text.split('\n').length} cell(s) to clipboard`);
+            } else if (message.command === 'copyPlanText') {
+                await vscode.env.clipboard.writeText(message.text);
+                vscode.window.showInformationMessage('Execution plan copied to clipboard.');
             } else if (message.command === 'openExternal') {
                 this.openExternalLink(message.url);
             }
@@ -153,10 +189,149 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
             return;
         }
 
-        this.view.webview.html = this.getResultHtml(ResultsPanel.currentResult, {
-            title: 'Query Results',
-            showExport: true
-        }, ResultsPanel.currentQuery);
+        this.view.webview.html = this.getSingleResultHtml(ResultsPanel.currentResult, ResultsPanel.currentQuery);
+    }
+
+    private resetPlanView(): void {
+        this.activeSubTab = 'results';
+        this.planViewState = { status: 'idle' };
+    }
+
+    /**
+     * Fetches the execution plan for the currently displayed single-statement
+     * result. Only wired for that path (not the multi-statement Result-N tab
+     * bar) — see planTabRenderer.ts for why.
+     */
+    private async requestPlan(): Promise<void> {
+        this.planViewState = { status: 'loading' };
+        this.updateWebview();
+
+        const result = ResultsPanel.currentResult;
+        if (!result?.sessionId || !result?.baselineStmtId) {
+            this.planViewState = {
+                status: 'error',
+                message: 'No session/statement id was captured for this query, so its execution plan can\'t be looked up.'
+            };
+            this.updateWebview();
+            return;
+        }
+
+        // The plan must be fetched against the connection this query actually
+        // ran on — not whichever connection is active now. If the user switched
+        // the active connection between running the query and opening the Plan
+        // tab, getActiveConnection() would look the profile up in the wrong
+        // session (or a different server entirely), silently returning "no
+        // profiling data" or another session's plan.
+        const connection = result.connectionId
+            ? this.connectionManager.getConnection(result.connectionId)
+            : this.connectionManager.getActiveConnection();
+        if (!connection) {
+            this.planViewState = {
+                status: 'error',
+                message: result.connectionId
+                    ? 'The connection this query ran on is no longer available, so its execution plan can\'t be looked up.'
+                    : 'No active connection.'
+            };
+            this.updateWebview();
+            return;
+        }
+
+        try {
+            const plan = await this.planProvider.getPlan(connection, { sessionId: result.sessionId, afterStmtId: result.baselineStmtId });
+            // A newer query may have completed (and reset the plan view) while
+            // this fetch was in flight — discard the stale outcome rather than
+            // showing one query's plan under another's result tab.
+            if (ResultsPanel.currentResult !== result) {
+                return;
+            }
+            this.planViewState = { status: 'ready', plan };
+        } catch (error) {
+            if (ResultsPanel.currentResult !== result) {
+                return;
+            }
+            this.planViewState = { status: 'error', message: formatError(error) };
+        }
+        this.updateWebview();
+    }
+
+    private getPlanBodyHtml(nonce: string): string {
+        switch (this.planViewState.status) {
+            case 'loading':
+                return buildPlanLoadingHtml();
+            case 'error':
+                return buildPlanErrorHtml({ message: this.planViewState.message });
+            case 'ready':
+                return buildPlanContentHtml(this.planViewState.plan, nonce);
+            case 'idle':
+            default:
+                return buildPlanLoadingHtml();
+        }
+    }
+
+    /**
+     * Renders the single-statement result view: a "Results | Plan" tab strip
+     * above either the results grid (or, for a statement with no result set —
+     * DDL/DML, IMPORT/EXPORT, etc. — the same success summary getSuccessHtml
+     * shows standalone) and the plan timeline. The tab strip always shows:
+     * Exasol profiles any statement that runs through the SQL engine (every
+     * DML/DDL/IMPORT/EXPORT gets at least COMPILE/EXECUTE system steps, often
+     * a real operator too — see operatorTaxonomy.ts's DML rule), and
+     * queryExecutor.ts already captures the session/statement id needed to
+     * look that profile up regardless of whether the statement returned any
+     * columns (see captureBaselineStatementIdentity) — there's no technical
+     * reason to hide the Plan tab just because there's no grid to show next
+     * to it (queryExecutor.ts's local-CSV-import path captures the same
+     * identity too, for the same reason). requestPlan() itself is still the
+     * real gate: a statement that genuinely captured no identity (e.g. the
+     * capture round-trip itself failed) surfaces its own clear error there
+     * instead.
+     */
+    private getSingleResultHtml(result: QueryResult, query: string | undefined): string {
+        const hasResultSet = !!result.columns && result.columns.length > 0;
+
+        const ctx = createWebviewRenderContext(this.view!.webview, this.extensionUri, vscode.Uri.joinPath);
+        const filterId = `filter-${Date.now()}`;
+        const tabBarHtml = buildResultPlanTabBarHtml(this.activeSubTab, this.planViewState.status, ctx.nonce);
+
+        const bodyHtml = this.activeSubTab === 'plan'
+            ? `<div class="plan-view">${this.getPlanBodyHtml(ctx.nonce)}</div>`
+            : hasResultSet
+                ? `<div class="result-content">${ResultsPanel.getGridHtmlStructure(result, filterId, '<button id="export">Export CSV</button>')}</div>`
+                : `<div class="result-content">${getSuccessBodyHtml(result)}</div>`;
+
+        const gridScripts = this.activeSubTab === 'results' && hasResultSet
+            ? `${ctx.dataIsland('result-data', { columns: result.columns, columnMetadata: result.columnMetadata || [], rows: result.rows })}
+               ${ctx.dataIsland('render-state', { filterId, initialSortColumn: null, initialSortDirection: 'asc' })}
+               ${ctx.dataIsland('query-stats', this.buildQueryStats(result, query))}
+               <script nonce="${ctx.nonce}" src="${ctx.mediaUri('results-grid-bundle.js')}"></script>`
+            : '';
+
+        return `<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="Content-Security-Policy" content="${ctx.csp}">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Query Results</title>
+        <link rel="stylesheet" href="${ctx.mediaUri('results-grid-glide.css')}">
+        <link rel="stylesheet" href="${ctx.mediaUri('results-grid.css')}">
+        <style nonce="${ctx.nonce}">
+            html, body { height: 100%; }
+            body { display: flex; flex-direction: column; padding: 0; }
+            .result-content { display: flex; flex-direction: column; flex: 1; min-height: 0; padding: 10px; }
+            .plan-view { flex: 1; min-height: 0; display: flex; flex-direction: column; overflow: hidden; }
+            ${buildResultPlanTabBarCss()}
+            ${buildPlanContentCss()}
+            ${buildPlanStatusCss()}
+            ${getSuccessBodyCss()}
+        </style>
+    </head>
+    <body>
+        ${tabBarHtml}
+        ${bodyHtml}
+        ${gridScripts}
+    </body>
+    </html>`;
     }
 
     private buildQueryStats(result: QueryResult, query: string | undefined) {
@@ -494,71 +669,14 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
     }
 }
 
-function getSuccessHtml(result: QueryResult): string {
+/** Shared with getSingleResultHtml's "Results" tab body for a statement with
+ * no result set (DDL/DML, IMPORT/EXPORT, etc.) — same content, embedded
+ * inside that page's tab strip instead of standing alone. */
+function getSuccessBodyHtml(result: QueryResult): string {
     const executionTimeMs = result.executionTime;
     const executionTimeSec = (executionTimeMs / 1000).toFixed(2);
 
-    return `<!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Query Executed</title>
-        <style>
-            html, body {
-                margin: 0;
-                padding: 0;
-                height: 100%;
-                overflow: hidden;
-                font-family: var(--vscode-font-family);
-                color: var(--vscode-foreground);
-                background-color: var(--vscode-editor-background);
-            }
-            body {
-                padding: 16px;
-                box-sizing: border-box;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-            }
-            .success-container {
-                background-color: var(--vscode-inputValidation-infoBackground);
-                border: 1px solid var(--vscode-inputValidation-infoBorder);
-                border-radius: 4px;
-                padding: 20px 24px;
-                max-width: 500px;
-            }
-            .success-title {
-                color: var(--vscode-charts-green);
-                font-weight: 600;
-                margin-bottom: 12px;
-                display: flex;
-                align-items: center;
-                gap: 8px;
-                font-size: 16px;
-            }
-            .success-icon {
-                font-size: 24px;
-            }
-            .success-details {
-                font-size: 13px;
-                line-height: 1.6;
-                color: var(--vscode-foreground);
-            }
-            .detail-row {
-                display: flex;
-                justify-content: space-between;
-                padding: 4px 0;
-            }
-            .detail-label {
-                color: var(--vscode-descriptionForeground);
-            }
-            .detail-value {
-                font-weight: 500;
-            }
-        </style>
-    </head>
-    <body>
+    return `<div class="success-container-outer">
         <div class="success-container">
             <div class="success-title">
                 <span class="success-icon">&#x2713;</span>
@@ -575,6 +693,84 @@ function getSuccessHtml(result: QueryResult): string {
                 </div>
             </div>
         </div>
+    </div>`;
+}
+
+function getSuccessBodyCss(): string {
+    return `
+        .success-container-outer {
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 16px;
+            box-sizing: border-box;
+        }
+        .success-container {
+            background-color: var(--vscode-inputValidation-infoBackground);
+            border: 1px solid var(--vscode-inputValidation-infoBorder);
+            border-radius: 4px;
+            padding: 20px 24px;
+            max-width: 500px;
+        }
+        .success-title {
+            color: var(--vscode-charts-green);
+            font-weight: 600;
+            margin-bottom: 12px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 16px;
+        }
+        .success-icon {
+            font-size: 24px;
+        }
+        .success-details {
+            font-size: 13px;
+            line-height: 1.6;
+            color: var(--vscode-foreground);
+        }
+        .detail-row {
+            display: flex;
+            justify-content: space-between;
+            padding: 4px 0;
+        }
+        .detail-label {
+            color: var(--vscode-descriptionForeground);
+        }
+        .detail-value {
+            font-weight: 500;
+        }
+    `;
+}
+
+/** Standalone success page for contexts that don't have a Plan tab to offer
+ * — the multi-statement Result-N tab bar (getResultHtml below), which
+ * doesn't support the Plan view at all yet (see planTabRenderer.ts). */
+function getSuccessHtml(result: QueryResult): string {
+    return `<!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Query Executed</title>
+        <style>
+            html, body {
+                margin: 0;
+                padding: 0;
+                height: 100%;
+                overflow: hidden;
+                font-family: var(--vscode-font-family);
+                color: var(--vscode-foreground);
+                background-color: var(--vscode-editor-background);
+            }
+            body { display: flex; flex-direction: column; }
+            ${getSuccessBodyCss()}
+        </style>
+    </head>
+    <body>
+        ${getSuccessBodyHtml(result)}
     </body>
     </html>
     `;

--- a/src/panels/resultsPanel.ts
+++ b/src/panels/resultsPanel.ts
@@ -133,7 +133,14 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
                 this.updateWebview();
             } else if (message.command === 'switchResultView') {
                 this.activeSubTab = message.view === 'plan' ? 'plan' : 'results';
-                if (this.activeSubTab === 'plan' && this.planViewState.status === 'idle') {
+                const currentResult = ResultsPanel.currentResult;
+                if (this.activeSubTab === 'plan' && currentResult && !this.isPlanAvailableForResult(currentResult)) {
+                    this.activeSubTab = 'results';
+                    this.updateWebview();
+                } else if (
+                    this.activeSubTab === 'plan'
+                    && (this.planViewState.status === 'idle' || this.planViewState.status === 'error')
+                ) {
                     await this.requestPlan();
                 } else {
                     this.updateWebview();
@@ -197,6 +204,10 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
         this.planViewState = { status: 'idle' };
     }
 
+    private isPlanAvailableForResult(result: QueryResult): boolean {
+        return this.connectionManager.isExecutionPlanAvailable?.(result.connectionId) ?? true;
+    }
+
     /**
      * Fetches the execution plan for the currently displayed single-statement
      * result. Only wired for that path (not the multi-statement Result-N tab
@@ -212,7 +223,9 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
                 status: 'error',
                 message: 'No session/statement id was captured for this query, so its execution plan can\'t be looked up.'
             };
-            this.updateWebview();
+            if (this.activeSubTab === 'plan') {
+                this.updateWebview();
+            }
             return;
         }
 
@@ -232,7 +245,9 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
                     ? 'The connection this query ran on is no longer available, so its execution plan can\'t be looked up.'
                     : 'No active connection.'
             };
-            this.updateWebview();
+            if (this.activeSubTab === 'plan') {
+                this.updateWebview();
+            }
             return;
         }
 
@@ -251,7 +266,9 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
             }
             this.planViewState = { status: 'error', message: formatError(error) };
         }
-        this.updateWebview();
+        if (this.activeSubTab === 'plan') {
+            this.updateWebview();
+        }
     }
 
     private getPlanBodyHtml(nonce: string): string {
@@ -259,7 +276,7 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
             case 'loading':
                 return buildPlanLoadingHtml();
             case 'error':
-                return buildPlanErrorHtml({ message: this.planViewState.message });
+                return buildPlanErrorHtml({ message: this.planViewState.message, canRetry: true });
             case 'ready':
                 return buildPlanContentHtml(this.planViewState.plan, nonce);
             case 'idle':
@@ -291,7 +308,11 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
 
         const ctx = createWebviewRenderContext(this.view!.webview, this.extensionUri, vscode.Uri.joinPath);
         const filterId = `filter-${Date.now()}`;
-        const tabBarHtml = buildResultPlanTabBarHtml(this.activeSubTab, this.planViewState.status, ctx.nonce);
+        const showPlanTab = this.isPlanAvailableForResult(result);
+        if (!showPlanTab && this.activeSubTab === 'plan') {
+            this.activeSubTab = 'results';
+        }
+        const tabBarHtml = buildResultPlanTabBarHtml(this.activeSubTab, this.planViewState.status, ctx.nonce, showPlanTab);
 
         const bodyHtml = this.activeSubTab === 'plan'
             ? `<div class="plan-view">${this.getPlanBodyHtml(ctx.nonce)}</div>`

--- a/src/panels/resultsPanel.ts
+++ b/src/panels/resultsPanel.ts
@@ -205,7 +205,11 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
     }
 
     private isPlanAvailableForResult(result: QueryResult): boolean {
-        return this.connectionManager.isExecutionPlanAvailable?.(result.connectionId) ?? true;
+        // Results built directly from an object-tree action (preview table,
+        // describe table) never capture a session/statement id, so there's
+        // no profile to look up regardless of connection support.
+        const hasCapturedIdentity = !!result.sessionId && !!result.baselineStmtId;
+        return hasCapturedIdentity && (this.connectionManager.isExecutionPlanAvailable?.(result.connectionId) ?? true);
     }
 
     /**
@@ -289,19 +293,20 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
      * Renders the single-statement result view: a "Results | Plan" tab strip
      * above either the results grid (or, for a statement with no result set —
      * DDL/DML, IMPORT/EXPORT, etc. — the same success summary getSuccessHtml
-     * shows standalone) and the plan timeline. The tab strip always shows:
-     * Exasol profiles any statement that runs through the SQL engine (every
-     * DML/DDL/IMPORT/EXPORT gets at least COMPILE/EXECUTE system steps, often
-     * a real operator too — see operatorTaxonomy.ts's DML rule), and
-     * queryExecutor.ts already captures the session/statement id needed to
-     * look that profile up regardless of whether the statement returned any
-     * columns (see captureBaselineStatementIdentity) — there's no technical
-     * reason to hide the Plan tab just because there's no grid to show next
-     * to it (queryExecutor.ts's local-CSV-import path captures the same
-     * identity too, for the same reason). requestPlan() itself is still the
-     * real gate: a statement that genuinely captured no identity (e.g. the
-     * capture round-trip itself failed) surfaces its own clear error there
-     * instead.
+     * shows standalone) and the plan timeline. The tab strip shows for any
+     * result carrying a captured session/statement id: Exasol profiles any
+     * statement that runs through the SQL engine (every DML/DDL/IMPORT/EXPORT
+     * gets at least COMPILE/EXECUTE system steps, often a real operator too —
+     * see operatorTaxonomy.ts's DML rule), and queryExecutor.ts already
+     * captures that identity regardless of whether the statement returned any
+     * columns (see captureBaselineStatementIdentity; the local-CSV-import
+     * path captures the same identity too, for the same reason) — there's no
+     * technical reason to hide the Plan tab just because there's no grid to
+     * show next to it. Results built by objectActions.ts (preview table,
+     * describe table) never capture that identity, so isPlanAvailableForResult
+     * hides the tab for them instead. requestPlan() remains a backstop for
+     * the rarer case where a queryExecutor.ts result should have captured an
+     * identity but didn't.
      */
     private getSingleResultHtml(result: QueryResult, query: string | undefined): string {
         const hasResultSet = !!result.columns && result.columns.length > 0;

--- a/src/panels/resultsPanel.ts
+++ b/src/panels/resultsPanel.ts
@@ -205,9 +205,10 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
     }
 
     private isPlanAvailableForResult(result: QueryResult): boolean {
-        // Results built directly from an object-tree action (preview table,
-        // describe table) never capture a session/statement id, so there's
-        // no profile to look up regardless of connection support.
+        // describeTable's result (objectActions.ts) never captures a
+        // session/statement id — it's a metadata lookup, not a profiled
+        // statement — so there's no profile to look up regardless of
+        // connection support.
         const hasCapturedIdentity = !!result.sessionId && !!result.baselineStmtId;
         return hasCapturedIdentity && (this.connectionManager.isExecutionPlanAvailable?.(result.connectionId) ?? true);
     }
@@ -300,13 +301,14 @@ export class ResultsPanel implements vscode.WebviewViewProvider {
      * see operatorTaxonomy.ts's DML rule), and queryExecutor.ts already
      * captures that identity regardless of whether the statement returned any
      * columns (see captureBaselineStatementIdentity; the local-CSV-import
-     * path captures the same identity too, for the same reason) — there's no
-     * technical reason to hide the Plan tab just because there's no grid to
-     * show next to it. Results built by objectActions.ts (preview table,
-     * describe table) never capture that identity, so isPlanAvailableForResult
-     * hides the tab for them instead. requestPlan() remains a backstop for
-     * the rarer case where a queryExecutor.ts result should have captured an
-     * identity but didn't.
+     * path captures the same identity too, for the same reason, and
+     * objectActions.ts's previewTableData reuses the same capture on its own
+     * driver) — there's no technical reason to hide the Plan tab just because
+     * there's no grid to show next to it. describeTable's result never
+     * captures that identity — it's a metadata lookup, not a profiled
+     * statement — so isPlanAvailableForResult hides the tab for it instead.
+     * requestPlan() remains a backstop for the rarer case where a result that
+     * should have captured an identity didn't.
      */
     private getSingleResultHtml(result: QueryResult, query: string | undefined): string {
         const hasResultSet = !!result.columns && result.columns.length > 0;

--- a/src/plan/operatorTaxonomy.ts
+++ b/src/plan/operatorTaxonomy.ts
@@ -1,0 +1,91 @@
+/**
+ * Classifies a raw PART_NAME (from EXA_*_PROFILE_* / $EXA_PROFILE_DETAILS_LAST_DAY)
+ * into an OperatorType with fixed traits.
+ *
+ * Exasol's profile views are not documented as an exhaustive, stable enum of
+ * PART_NAME literals — verified real profile output includes names at two
+ * different granularities for the same logical operator (e.g. plain "JOIN"
+ * from EXA_USER_PROFILE_LAST_DAY vs "PIPE JOIN" from
+ * $EXA_PROFILE_DETAILS_LAST_DAY, or "GROUP BY" vs "PIPE AGGREGATOR" +
+ * "GROUPBY POSTPROCESSING" + "GROUPBY INSERT"). Rather than an exact-match
+ * enum that breaks the moment an unseen variant appears, classification is
+ * substring-based with a conservative OTHER fallback — new/unrecognized part
+ * names degrade gracefully instead of throwing or being silently mis-rendered
+ * as something they're not.
+ */
+import { OperatorTraits, OperatorType } from './planModel';
+
+const TRAITS_BY_TYPE: Record<OperatorType, OperatorTraits> = {
+    SCAN: {
+        producesRows: true, consumesRows: false, canSpill: false,
+        movesDataOverNetwork: false, blocking: false, isSystemStep: false
+    },
+    JOIN: {
+        producesRows: true, consumesRows: true, canSpill: true,
+        movesDataOverNetwork: true, blocking: true, isSystemStep: false
+    },
+    GROUP_BY: {
+        producesRows: true, consumesRows: true, canSpill: true,
+        movesDataOverNetwork: true, blocking: true, isSystemStep: false
+    },
+    SORT: {
+        producesRows: true, consumesRows: true, canSpill: true,
+        movesDataOverNetwork: false, blocking: true, isSystemStep: false
+    },
+    NETWORK: {
+        producesRows: true, consumesRows: true, canSpill: false,
+        movesDataOverNetwork: true, blocking: false, isSystemStep: false
+    },
+    DML: {
+        producesRows: false, consumesRows: true, canSpill: false,
+        movesDataOverNetwork: false, blocking: false, isSystemStep: false
+    },
+    SYSTEM: {
+        producesRows: false, consumesRows: false, canSpill: false,
+        movesDataOverNetwork: false, blocking: false, isSystemStep: true
+    },
+    // Conservative default for anything unrecognized: treated as an
+    // ordinary pass-through pipeline step, since we have no basis to
+    // claim it can spill or move data over the network.
+    OTHER: {
+        producesRows: true, consumesRows: true, canSpill: false,
+        movesDataOverNetwork: false, blocking: false, isSystemStep: false
+    }
+};
+
+const TYPE_RULES: Array<{ type: OperatorType; test: (name: string) => boolean }> = [
+    { type: 'SCAN', test: n => n.includes('SCAN') },
+    { type: 'JOIN', test: n => n.includes('JOIN') },
+    { type: 'GROUP_BY', test: n => n.includes('GROUP') || n.includes('AGGREGAT') },
+    { type: 'SORT', test: n => n.includes('SORT') || n.includes('ORDER BY') },
+    {
+        type: 'NETWORK',
+        // Not observed verbatim in a live profile trace during Step 0 research —
+        // included defensively for redistribution-style parts. Falls back to
+        // OTHER (never fabricated data) if the real string differs.
+        test: n => n.includes('NETWORK') || n.includes('DISTRIBUT') || n.includes('BROADCAST') || n.includes('REORGANIZE')
+    },
+    {
+        type: 'DML',
+        test: n => ['INSERT', 'UPDATE', 'DELETE', 'MERGE', 'EXPORT', 'IMPORT'].some(k => n.includes(k))
+    },
+    {
+        type: 'SYSTEM',
+        test: n => [
+            'COMPILE', 'EXECUTE', 'COMMIT', 'ROLLBACK', 'ALTER SESSION',
+            'COLUMN STATISTICS', 'INDEX CREATE', 'TRANSACTION'
+        ].some(k => n.includes(k))
+    }
+];
+
+export interface OperatorClassification {
+    operatorType: OperatorType;
+    traits: OperatorTraits;
+}
+
+export function classifyOperator(partName: string): OperatorClassification {
+    const normalized = (partName || '').toUpperCase();
+    const rule = TYPE_RULES.find(r => r.test(normalized));
+    const operatorType = rule?.type ?? 'OTHER';
+    return { operatorType, traits: TRAITS_BY_TYPE[operatorType] };
+}

--- a/src/plan/operatorTaxonomy.ts
+++ b/src/plan/operatorTaxonomy.ts
@@ -44,6 +44,16 @@ const TRAITS_BY_TYPE: Record<OperatorType, OperatorTraits> = {
         producesRows: false, consumesRows: false, canSpill: false,
         movesDataOverNetwork: false, blocking: false, isSystemStep: true
     },
+    // Inter-node synchronization barrier. Deliberately NOT isSystemStep: it
+    // is real query time (frequently the single hottest node on a real plan)
+    // rather than execution-engine bookkeeping, so it must stay inside the
+    // user/data-flow denominator that costPercent divides by for non-system
+    // nodes (see PlanNode.costPercent in planModel.ts) instead of vanishing
+    // into the system-step total the way COMPILE/EXECUTE do.
+    SYNC: {
+        producesRows: false, consumesRows: false, canSpill: false,
+        movesDataOverNetwork: false, blocking: true, isSystemStep: false
+    },
     // Conservative default for anything unrecognized: treated as an
     // ordinary pass-through pipeline step, since we have no basis to
     // claim it can spill or move data over the network.
@@ -54,15 +64,26 @@ const TRAITS_BY_TYPE: Record<OperatorType, OperatorTraits> = {
 };
 
 const TYPE_RULES: Array<{ type: OperatorType; test: (name: string) => boolean }> = [
+    // Must precede the plain SCAN rule below (and any future SYSTEM keyword
+    // additions further down this list): a SYSTEM TABLE part reads a system
+    // catalog object and produces rows exactly like any other scan — despite
+    // the word SYSTEM in its name it is not execution-engine bookkeeping.
+    // Live census: 11.7% of profile rows were SYSTEM TABLE parts, all
+    // falling through to OTHER before this rule existed.
+    { type: 'SCAN', test: n => n.includes('SYSTEM TABLE') },
     { type: 'SCAN', test: n => n.includes('SCAN') },
     { type: 'JOIN', test: n => n.includes('JOIN') },
     { type: 'GROUP_BY', test: n => n.includes('GROUP') || n.includes('AGGREGAT') },
     { type: 'SORT', test: n => n.includes('SORT') || n.includes('ORDER BY') },
+    // Inter-node synchronization barrier — see the SYNC traits above for why
+    // this is deliberately not classified/traited as a system step.
+    { type: 'SYNC', test: n => n.includes('NODE SYNC') },
     {
         type: 'NETWORK',
         // Included defensively for redistribution-style parts. Falls back to
         // OTHER if the real string differs.
-        test: n => n.includes('NETWORK') || n.includes('DISTRIBUT') || n.includes('BROADCAST') || n.includes('REORGANIZE')
+        test: n => n.includes('NETWORK') || n.includes('DISTRIBUT') || n.includes('BROADCAST') ||
+            n.includes('REORGANIZE') || n.includes('REPLICATE')
     },
     {
         type: 'DML',

--- a/src/plan/operatorTaxonomy.ts
+++ b/src/plan/operatorTaxonomy.ts
@@ -60,9 +60,8 @@ const TYPE_RULES: Array<{ type: OperatorType; test: (name: string) => boolean }>
     { type: 'SORT', test: n => n.includes('SORT') || n.includes('ORDER BY') },
     {
         type: 'NETWORK',
-        // Not observed verbatim in a live profile trace during Step 0 research —
-        // included defensively for redistribution-style parts. Falls back to
-        // OTHER (never fabricated data) if the real string differs.
+        // Included defensively for redistribution-style parts. Falls back to
+        // OTHER if the real string differs.
         test: n => n.includes('NETWORK') || n.includes('DISTRIBUT') || n.includes('BROADCAST') || n.includes('REORGANIZE')
     },
     {

--- a/src/plan/planFormat.ts
+++ b/src/plan/planFormat.ts
@@ -12,7 +12,7 @@ import { OperatorType, Plan } from './planModel';
  * (uncategorized, not an error) were chosen over a bare "·"/"?" after those
  * read as barely-visible and alarming respectively in real screenshots. */
 export const OPERATOR_BADGE: Record<OperatorType, string> = {
-    SCAN: 'S', JOIN: 'J', GROUP_BY: 'G', SORT: 'O', NETWORK: 'N', DML: 'D', SYSTEM: '⚙', OTHER: '⋯'
+    SCAN: 'S', JOIN: 'J', GROUP_BY: 'G', SORT: 'O', NETWORK: 'N', DML: 'D', SYSTEM: '⚙', SYNC: '‖', OTHER: '⋯'
 };
 
 export const OPERATOR_COLOR_VAR: Record<OperatorType, string> = {
@@ -23,12 +23,16 @@ export const OPERATOR_COLOR_VAR: Record<OperatorType, string> = {
     NETWORK: '--vscode-charts-orange',
     DML: '--vscode-charts-red',
     SYSTEM: '--vscode-descriptionForeground',
+    // Every other slot in VS Code's charts palette is already claimed above
+    // (orange: NETWORK, yellow: SORT); charts.pink is the next distinct,
+    // themed color VS Code exposes rather than reusing another type's hue.
+    SYNC: '--vscode-charts-pink',
     OTHER: '--vscode-foreground'
 };
 
 export const OPERATOR_TYPE_LABEL: Record<OperatorType, string> = {
     SCAN: 'Scan', JOIN: 'Join', GROUP_BY: 'Group By', SORT: 'Sort',
-    NETWORK: 'Network', DML: 'DML', SYSTEM: 'System', OTHER: 'Other'
+    NETWORK: 'Network', DML: 'DML', SYSTEM: 'System', SYNC: 'Sync', OTHER: 'Other'
 };
 
 export function fmtMs(seconds: number | undefined): string {
@@ -157,7 +161,14 @@ export function planLacksDetailMetrics(plan: Plan): boolean {
 export function hottestNodeId(plan: Plan): string | undefined {
     let hottest: { id: string; costPercent: number } | undefined;
     for (const node of plan.nodes) {
-        if (node.costPercent === undefined) {
+        // System steps (COMPILE, EXECUTE, ...) carry share-of-total while
+        // user operators carry share-of-query (see PlanNode.costPercent /
+        // finding 2) — mixing the two denominators here would let a system
+        // step outrank an actionable operator on numbers that aren't
+        // comparable. System overhead also isn't an actionable "hot spot" to
+        // chase; it's already visible via its own ring share and the
+        // category rail, so it's excluded from the hot-node race entirely.
+        if (node.traits.isSystemStep || node.costPercent === undefined) {
             continue;
         }
         if (!hottest || node.costPercent > hottest.costPercent) {

--- a/src/plan/planFormat.ts
+++ b/src/plan/planFormat.ts
@@ -49,6 +49,10 @@ export function fmtRows(n: number | undefined): string {
     if (n === undefined) {
         return '—';
     }
+    const roundedMillions = n / 1_000_000;
+    if (n >= 1_000_000_000 || roundedMillions >= 999.5) {
+        return `${(n / 1_000_000_000).toFixed(n >= 99_950_000_000 ? 0 : 1)}B`;
+    }
     const roundedThousands = n / 1_000;
     if (n >= 1_000_000 || roundedThousands >= 999.5) {
         return `${(n / 1_000_000).toFixed(n >= 99_950_000 ? 0 : 1)}M`;

--- a/src/plan/planFormat.ts
+++ b/src/plan/planFormat.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure number/label formatting shared by every Plan renderer (HTML cards in
+ * planWebview.ts, the clipboard text summary in planTextExport.ts). Kept in
+ * one place so a copied plan always shows the exact same numbers as the
+ * on-screen cards it was copied from.
+ */
+import { OperatorType, Plan } from './planModel';
+
+/** SYSTEM/OTHER deliberately get symbols instead of a first-letter initial —
+ * they aren't real data-flow operators, and a symbol makes that legible at a
+ * glance rather than implying a made-up initial. ⚙ (bookkeeping) and ⋯
+ * (uncategorized, not an error) were chosen over a bare "·"/"?" after those
+ * read as barely-visible and alarming respectively in real screenshots. */
+export const OPERATOR_BADGE: Record<OperatorType, string> = {
+    SCAN: 'S', JOIN: 'J', GROUP_BY: 'G', SORT: 'O', NETWORK: 'N', DML: 'D', SYSTEM: '⚙', OTHER: '⋯'
+};
+
+export const OPERATOR_COLOR_VAR: Record<OperatorType, string> = {
+    SCAN: '--vscode-charts-blue',
+    JOIN: '--vscode-charts-purple',
+    GROUP_BY: '--vscode-charts-green',
+    SORT: '--vscode-charts-yellow',
+    NETWORK: '--vscode-charts-orange',
+    DML: '--vscode-charts-red',
+    SYSTEM: '--vscode-descriptionForeground',
+    OTHER: '--vscode-foreground'
+};
+
+export const OPERATOR_TYPE_LABEL: Record<OperatorType, string> = {
+    SCAN: 'Scan', JOIN: 'Join', GROUP_BY: 'Group By', SORT: 'Sort',
+    NETWORK: 'Network', DML: 'DML', SYSTEM: 'System', OTHER: 'Other'
+};
+
+export function fmtMs(seconds: number | undefined): string {
+    if (seconds === undefined) {
+        return '—';
+    }
+    const ms = seconds * 1000;
+    if (ms < 1) {
+        return `${ms.toFixed(3)} ms`;
+    }
+    if (ms < 100) {
+        return `${ms.toFixed(1)} ms`;
+    }
+    return `${ms.toFixed(0)} ms`;
+}
+
+export function fmtRows(n: number | undefined): string {
+    if (n === undefined) {
+        return '—';
+    }
+    if (n >= 1_000_000) {
+        return `${(n / 1_000_000).toFixed(n >= 100_000_000 ? 0 : 1)}M`;
+    }
+    if (n >= 1_000) {
+        return `${(n / 1_000).toFixed(n >= 100_000 ? 0 : 1)}k`;
+    }
+    return String(n);
+}
+
+export function fmtPct(p: number | undefined): string {
+    if (p === undefined) {
+        return '—';
+    }
+    return p < 1 ? '<1%' : `${p.toFixed(0)}%`;
+}
+
+export function fmtMiB(n: number | undefined): string {
+    if (n === undefined) {
+        return '—';
+    }
+    return `${n.toFixed(1)} MiB`;
+}
+
+/** Shared so CPU always renders identically wherever it's shown — previously
+ * inlined separately in planWebview.ts and planTextExport.ts, which is an
+ * easy place for the two to drift apart. */
+export function fmtCpuPct(n: number | undefined): string {
+    if (n === undefined) {
+        return '—';
+    }
+    return `${n}%`;
+}
+
+export function planSourceLabel(source: Plan['source']): string {
+    return source === 'DETAILS' ? 'per-node detail' : source === 'DBA_SUMMARY' ? 'cluster summary (DBA)' : 'cluster summary';
+}
+
+/** The largest per-node cluster size observed across nodes, or undefined if
+ * no node had per-node stats at all (see Plan.perNodeStatsAvailable). */
+export function planClusterSize(plan: Plan): number | undefined {
+    const counts = plan.nodes
+        .map(n => n.perNodeStats?.nodeCount)
+        .filter((n): n is number => n !== undefined);
+    return counts.length > 0 ? Math.max(...counts) : undefined;
+}
+
+export interface CategoryTime {
+    type: OperatorType;
+    label: string;
+    colorVar: string;
+    /** Sum of every node's own duration for this operator type, in seconds. */
+    durationSum: number;
+    /** Share of plan.totalDuration, 0-100. */
+    percent: number;
+}
+
+/**
+ * Buckets every node's real per-node `duration` by its `operatorType`, sorted
+ * by share descending. Never estimated: a node with an undefined duration
+ * simply contributes nothing, rather than being counted as zero or dropped
+ * from totalDuration's denominator.
+ */
+export function planCategoryBreakdown(plan: Plan): CategoryTime[] {
+    if (plan.totalDuration <= 0) {
+        return [];
+    }
+
+    const sums = new Map<OperatorType, number>();
+    for (const node of plan.nodes) {
+        if (node.duration === undefined) {
+            continue;
+        }
+        sums.set(node.operatorType, (sums.get(node.operatorType) ?? 0) + node.duration);
+    }
+
+    return Array.from(sums.entries())
+        .map(([type, durationSum]) => ({
+            type,
+            label: OPERATOR_TYPE_LABEL[type],
+            colorVar: OPERATOR_COLOR_VAR[type],
+            durationSum,
+            percent: (durationSum / plan.totalDuration) * 100
+        }))
+        .sort((a, b) => b.percent - a.percent);
+}
+
+/**
+ * True when NO node in the plan has a defined CPU or Net value — the
+ * signature of a session that ran without `ALTER SESSION SET PROFILE = 'ON'`
+ * first. Confirmed by direct reproduction against a live Exasol instance:
+ * $EXA_PROFILE_DETAILS_LAST_DAY always populates PART_NAME/DURATION/OUT_ROWS
+ * regardless of the PROFILE session parameter, but CPU/NET only ever appear
+ * once PROFILE was explicitly turned on before the query ran — HDD_WRITE is
+ * deliberately excluded from this check since it can legitimately stay
+ * undefined even with profiling on, if nothing ever spilled to disk, so it
+ * isn't a reliable signal either way.
+ */
+export function planLacksDetailMetrics(plan: Plan): boolean {
+    return plan.nodes.length > 0 && plan.nodes.every(n => n.cpu === undefined && n.net === undefined);
+}
+
+/**
+ * The id of the single node with the highest costPercent in the plan, or
+ * undefined if no node has a defined costPercent. A ties-go-to-first rule
+ * (Array.reduce's default) rather than declaring multiple "hot" nodes keeps
+ * the visual signal singular and unambiguous.
+ */
+export function hottestNodeId(plan: Plan): string | undefined {
+    let hottest: { id: string; costPercent: number } | undefined;
+    for (const node of plan.nodes) {
+        if (node.costPercent === undefined) {
+            continue;
+        }
+        if (!hottest || node.costPercent > hottest.costPercent) {
+            hottest = { id: node.id, costPercent: node.costPercent };
+        }
+    }
+    return hottest?.id;
+}

--- a/src/plan/planFormat.ts
+++ b/src/plan/planFormat.ts
@@ -49,8 +49,9 @@ export function fmtRows(n: number | undefined): string {
     if (n === undefined) {
         return '—';
     }
-    if (n >= 1_000_000) {
-        return `${(n / 1_000_000).toFixed(n >= 100_000_000 ? 0 : 1)}M`;
+    const roundedThousands = n / 1_000;
+    if (n >= 1_000_000 || roundedThousands >= 999.5) {
+        return `${(n / 1_000_000).toFixed(n >= 99_950_000 ? 0 : 1)}M`;
     }
     if (n >= 1_000) {
         return `${(n / 1_000).toFixed(n >= 100_000 ? 0 : 1)}k`;
@@ -136,15 +137,8 @@ export function planCategoryBreakdown(plan: Plan): CategoryTime[] {
 }
 
 /**
- * True when NO node in the plan has a defined CPU or Net value — the
- * signature of a session that ran without `ALTER SESSION SET PROFILE = 'ON'`
- * first. Confirmed by direct reproduction against a live Exasol instance:
- * $EXA_PROFILE_DETAILS_LAST_DAY always populates PART_NAME/DURATION/OUT_ROWS
- * regardless of the PROFILE session parameter, but CPU/NET only ever appear
- * once PROFILE was explicitly turned on before the query ran — HDD_WRITE is
- * deliberately excluded from this check since it can legitimately stay
- * undefined even with profiling on, if nothing ever spilled to disk, so it
- * isn't a reliable signal either way.
+ * True when no node has recorded CPU or network data. This usually means
+ * profiling was not active for the session when the statement ran.
  */
 export function planLacksDetailMetrics(plan: Plan): boolean {
     return plan.nodes.length > 0 && plan.nodes.every(n => n.cpu === undefined && n.net === undefined);

--- a/src/plan/planModel.ts
+++ b/src/plan/planModel.ts
@@ -12,7 +12,7 @@
  * types just need a traits declaration (see operatorTaxonomy.ts) and every
  * consumer (warnings, rendering) picks up correct behavior automatically.
  */
-export type OperatorType = 'SCAN' | 'JOIN' | 'GROUP_BY' | 'SORT' | 'NETWORK' | 'DML' | 'SYSTEM' | 'OTHER';
+export type OperatorType = 'SCAN' | 'JOIN' | 'GROUP_BY' | 'SORT' | 'NETWORK' | 'DML' | 'SYSTEM' | 'SYNC' | 'OTHER';
 
 export interface OperatorTraits {
     /** Reads base/temporary table rows into the pipeline (e.g. SCAN). */
@@ -40,14 +40,19 @@ export interface OperatorTraits {
  * not "zero skew".
  */
 export interface PerNodeStat {
-    metric: 'rows';
+    metric: 'rows' | 'duration';
     min: number;
     max: number;
     avg: number;
     nodeCount: number;
 }
 
-export type WarningType = 'HIGH_SKEW' | 'SPILLED_TO_DISK' | 'LARGE_REDISTRIBUTION' | 'ROW_ESTIMATE_MISMATCH';
+export type WarningType =
+    | 'HIGH_SKEW'
+    | 'HIGH_DURATION_SKEW'
+    | 'SPILLED_TO_DISK'
+    | 'LARGE_REDISTRIBUTION'
+    | 'ROW_ESTIMATE_MISMATCH';
 
 export interface PlanWarning {
     type: WarningType;
@@ -68,16 +73,40 @@ export interface PlanNode {
     /** Free-text detail from PART_INFO/REMARKS, shown in the detail panel/tooltip. */
     partInfo: string | undefined;
     remarks: string | undefined;
+    /** OBJECT_ROWS: rows available in the scanned object before this node's
+     * own filtering/output — paired with rowsOut to show scan selectivity. */
+    objectRows: number | undefined;
     rowsOut: number | undefined;
     duration: number | undefined;
     cpu: number | undefined;
     net: number | undefined;
     tempDbRamPeak: number | undefined;
     hddWrite: number | undefined;
-    /** Share of the statement's total duration, derived by the normalizer (not a raw column). */
+    /** HDD_READ, MiB/s — a per-node read RATE, not a volume, per Exasol's
+     * profile view docs. Collapsed as a max across nodes, same as other
+     * per-node rate-like fields. Nonzero in a small minority of real rows
+     * (~5.7%), so it is only ever surfaced when > 0 (see planWebview.ts /
+     * planTextExport.ts) rather than shown as a constant, uninformative 0. */
+    hddRead: number | undefined;
+    /**
+     * Share of duration this node accounts for, but the denominator differs
+     * by node kind: for a system step (traits.isSystemStep) it is share of
+     * Plan.totalDuration (every node, bookkeeping included) — there is no
+     * more meaningful denominator for COMPILE/EXECUTE/etc. For every other
+     * node it is share of totalDuration MINUS the summed duration of all
+     * system steps, so COMPILE/EXECUTE overhead no longer deflates every
+     * real operator's share (see profileRowNormalizer.ts). Plan.totalDuration
+     * itself is unaffected by this and stays wall-time-true for the "Total
+     * time" overview figure.
+     */
     costPercent: number | undefined;
     /** undefined when per-node rows were not available for this plan (see Plan.perNodeStatsAvailable). */
     perNodeStats: PerNodeStat | undefined;
+    /** Per-node distribution of this node's own DURATION, computed under the
+     * same per-node-availability condition as perNodeStats above. A single
+     * straggler node driving up an operator's duration is otherwise invisible
+     * once collapsed to a max (see profileRowNormalizer.ts collapseGroup). */
+    perNodeDurationStats: PerNodeStat | undefined;
     warnings: PlanWarning[];
     /**
      * Operator ids this one consumes from. Left empty in v1: Exasol's profile

--- a/src/plan/planModel.ts
+++ b/src/plan/planModel.ts
@@ -1,0 +1,115 @@
+/**
+ * Normalized execution plan model.
+ *
+ * This is the only shape the webview (or any other consumer) should ever see.
+ * Nothing here encodes Exasol's system table column names directly — that
+ * knowledge is isolated to profileRowNormalizer.ts and planProvider.ts so a
+ * future Exasol schema change only touches those two files.
+ */
+
+/**
+ * A small taxonomy of operator traits rather than a flat enum: new operator
+ * types just need a traits declaration (see operatorTaxonomy.ts) and every
+ * consumer (warnings, rendering) picks up correct behavior automatically.
+ */
+export type OperatorType = 'SCAN' | 'JOIN' | 'GROUP_BY' | 'SORT' | 'NETWORK' | 'DML' | 'SYSTEM' | 'OTHER';
+
+export interface OperatorTraits {
+    /** Reads base/temporary table rows into the pipeline (e.g. SCAN). */
+    producesRows: boolean;
+    /** Consumes rows from a preceding part (e.g. JOIN, GROUP BY, SORT). */
+    consumesRows: boolean;
+    /** Can spill to disk under memory pressure (JOIN, GROUP BY, SORT). */
+    canSpill: boolean;
+    /** Moves data between cluster nodes (redistribution/broadcast). */
+    movesDataOverNetwork: boolean;
+    /** Must fully consume its input before producing output (blocking) vs pipelined. */
+    blocking: boolean;
+    /**
+     * Execution-engine bookkeeping (COMPILE, COLUMN STATISTICS, INDEX CREATE, ...)
+     * rather than a data-flow operator — these exist in real profile traces but
+     * are not what a box-and-arrow query plan should render as an operator box.
+     */
+    isSystemStep: boolean;
+}
+
+/**
+ * Per-node distribution of a single metric across the cluster, computed only
+ * when true per-node rows were available (see planProvider.ts). Never
+ * estimated or synthesized — absence of this field means "not measured",
+ * not "zero skew".
+ */
+export interface PerNodeStat {
+    metric: 'rows';
+    min: number;
+    max: number;
+    avg: number;
+    nodeCount: number;
+}
+
+export type WarningType = 'HIGH_SKEW' | 'SPILLED_TO_DISK' | 'LARGE_REDISTRIBUTION' | 'ROW_ESTIMATE_MISMATCH';
+
+export interface PlanWarning {
+    type: WarningType;
+    message: string;
+    /** The raw values/threshold that triggered this warning, for the detail panel. */
+    detail: Record<string, number | string>;
+}
+
+export interface PlanNode {
+    /** PART_ID from the source profile view, as a string (stable within one plan). */
+    id: string;
+    operatorType: OperatorType;
+    /** Raw PART_NAME, verbatim — always shown alongside the derived operatorType. */
+    operatorLabel: string;
+    traits: OperatorTraits;
+    objectSchema: string | undefined;
+    objectName: string | undefined;
+    /** Free-text detail from PART_INFO/REMARKS, shown in the detail panel/tooltip. */
+    partInfo: string | undefined;
+    remarks: string | undefined;
+    rowsOut: number | undefined;
+    duration: number | undefined;
+    cpu: number | undefined;
+    net: number | undefined;
+    tempDbRamPeak: number | undefined;
+    hddWrite: number | undefined;
+    /** Share of the statement's total duration, derived by the normalizer (not a raw column). */
+    costPercent: number | undefined;
+    /** undefined when per-node rows were not available for this plan (see Plan.perNodeStatsAvailable). */
+    perNodeStats: PerNodeStat | undefined;
+    warnings: PlanWarning[];
+    /**
+     * Operator ids this one consumes from. Left empty in v1: Exasol's profile
+     * views expose PART_ID as a flat chronological sequence with no parent/child
+     * column, so a true data-flow DAG cannot be derived without fabricating
+     * relationships. See Plan.nodes ordering (by PART_ID) for the real signal.
+     */
+    children: string[];
+}
+
+export interface Plan {
+    /**
+     * Exasol SESSION_ID/STMT_ID values (DECIMAL(20,0)/DECIMAL(12,0)) routinely
+     * exceed Number.MAX_SAFE_INTEGER — kept as exact digit strings throughout
+     * this module rather than `number` so identifiers are never silently
+     * rounded. Only ever compared for equality or interpolated into SQL as a
+     * numeric literal, never used arithmetically.
+     */
+    sessionId: string;
+    stmtId: string;
+    queryText: string | undefined;
+    /** Sum of every node's duration — the denominator for each node's costPercent. */
+    totalDuration: number;
+    /** Ordered by PART_ID — the one true ordering signal these views provide. */
+    nodes: PlanNode[];
+    /**
+     * Reserved for a future version that can derive real data-flow edges.
+     * Always empty in v1 — see PlanNode.children.
+     */
+    edges: Array<{ from: string; to: string }>;
+    /** Whether per-node rows were fetched at all for this plan (privilege-gated). */
+    perNodeStatsAvailable: boolean;
+    /** Which profile view ultimately supplied the data, for diagnostics/support. */
+    source: 'DETAILS' | 'DBA_SUMMARY' | 'USER_SUMMARY';
+}

--- a/src/plan/planProvider.ts
+++ b/src/plan/planProvider.ts
@@ -47,7 +47,7 @@ export interface PlanTarget {
     /**
      * Exact digit strings, not `number` — Exasol's SESSION_ID (DECIMAL(20,0))
      * routinely exceeds Number.MAX_SAFE_INTEGER, and converting it to a JS
-	 * number silently rounds it. Validated as a plain
+     * number silently rounds it. Validated as a plain
      * digit string in getPlan() below before being interpolated into SQL.
      */
     sessionId: string;

--- a/src/plan/planProvider.ts
+++ b/src/plan/planProvider.ts
@@ -1,0 +1,279 @@
+/**
+ * Fetches profile rows for a completed statement and normalizes them into a
+ * Plan. This is the only module that knows Exasol's profile *table names* and
+ * privilege model — profileRowNormalizer.ts knows the column shapes, this
+ * file knows which view to query and in what fallback order.
+ *
+ * Fallback order, richest first (mirrors the attempt/fallback convention
+ * already used by src/providers/objectTreeFetchers.ts):
+ *   1. $EXA_PROFILE_DETAILS_LAST_DAY — per-node (IPROC) detail, requires the
+ *      SELECT ANY DICTIONARY privilege. Verified to exist and be gated on
+ *      that privilege against a live Exasol 2026.1.0 instance during Step 0
+ *      research; it is an internal/undocumented object (absent from
+ *      SYS.EXA_SYSCAT) so this fallback chain is what protects v1 from that
+ *      object disappearing or being renamed in a future Exasol version.
+ *   2. EXA_DBA_PROFILE_LAST_DAY — cluster-wide aggregate, any session, same
+ *      privilege requirement as #1.
+ *   3. EXA_USER_PROFILE_LAST_DAY — cluster-wide aggregate, own sessions only,
+ *      no special privilege. Always tried last so v1 always produces a plan
+ *      (without per-node stats) for an unprivileged user profiling their own
+ *      query.
+ *
+ * Identifying the right statement is harder than "STMT_ID equals X": Exasol
+ * has no "give me the id of the statement that just ran" primitive.
+ * CURRENT_STATEMENT returns the id of the statement asking the question, and
+ * every statement (including that one) gets an implicit COMMIT/ROLLBACK
+ * immediately after it, consuming another id. queryExecutor.ts captures a
+ * *baseline* CURRENT_STATEMENT reading before the real query runs; this
+ * module then searches forward from that baseline for the first statement
+ * that isn't transaction bookkeeping — verified against a live instance to
+ * reliably land on the real query regardless of how many implicit
+ * COMMIT/ROLLBACK statements land in between (see afterStmtId below).
+ *
+ * A completed statement's profiling data is also not immediately visible
+ * from a different connection than the one that ran it — measured on a live
+ * instance at ~8-9 seconds before it appeared on its own. An explicit
+ * FLUSH STATISTICS (from any connection, not necessarily the one that ran
+ * the query) forces it to become visible in well under a second, so getPlan()
+ * always issues one before attempting the fetch, with only a short retry
+ * budget afterward as a safety margin rather than a multi-second poll.
+ */
+import { ConnectionManager, StoredConnection, BACKGROUND_QUERY_TIMEOUT_MS } from '../connectionManager';
+import { getRowsFromResult, rawExecute, rawQuery } from '../utils';
+import { getOutputChannel } from '../extension';
+import { Plan } from './planModel';
+import { normalizeProfileRows, ProfileSource } from './profileRowNormalizer';
+import { WarningThresholds, DEFAULT_WARNING_THRESHOLDS } from './planWarnings';
+
+export interface PlanTarget {
+    /**
+     * Exact digit strings, not `number` — Exasol's SESSION_ID (DECIMAL(20,0))
+     * routinely exceeds Number.MAX_SAFE_INTEGER, and converting it to a JS
+     * number silently rounds it (verified: a real session id's last three
+     * digits were lost this way during Step 0 testing). Validated as a plain
+     * digit string in getPlan() below before being interpolated into SQL.
+     */
+    sessionId: string;
+    /**
+     * CURRENT_STATEMENT read *before* the real query ran (see file header).
+     * Not the real query's own STMT_ID — the fetch below searches forward
+     * from this baseline for the first non-transaction statement.
+     */
+    afterStmtId: string;
+}
+
+interface FetchAttempt {
+    source: ProfileSource;
+    table: string;
+    /** Only $EXA_PROFILE_DETAILS_LAST_DAY has an IPROC (per-node) column —
+     * EXA_DBA_PROFILE_LAST_DAY/EXA_USER_PROFILE_LAST_DAY don't (confirmed via
+     * DESCRIBE against a live instance). Ordering by it on those tiers fails
+     * with "object IPROC not found", verified live on a second instance. */
+    hasIproc: boolean;
+}
+
+const DIGITS_ONLY = /^\d+$/;
+
+// Safety-margin pauses between full fallback-chain passes (not per-tier).
+//
+// Two schedules, chosen by whether the best-effort FLUSH STATISTICS succeeded:
+//
+//   * FLUSH succeeded — profiling data is forced visible in well under a
+//     second, so a short window only covers the odd under-load straggler.
+//     (~1.5s total.)
+//
+//   * FLUSH failed (e.g. the user lacks the flush privilege but can still read
+//     the profile views) — the data only becomes visible from this background
+//     session after Exasol's own cross-connection propagation, measured at
+//     ~8-9s on a live instance (see file header). A 1.5s window here reported a
+//     false "no profiling data found" for a user who would have seen the plan a
+//     few seconds later, so this schedule polls out to comfortably past that
+//     window (~13.5s total) before giving up.
+//
+// A genuine "no data" error only surfaces after the chosen schedule is
+// exhausted. The privilege-denied-on-every-tier case never waits through
+// either schedule: it throws on the first round (see getPlan()).
+export const RETRY_DELAYS_MS = [0, 500, 1000];
+export const RETRY_DELAYS_AFTER_FLUSH_FAILURE_MS = [0, 1000, 2000, 3000, 3500, 4000];
+
+export interface PlanProviderRetryOptions {
+    /** Overrides the post-flush-success retry schedule (testing seam). */
+    retryDelaysMs?: number[];
+    /** Overrides the post-flush-failure retry schedule (testing seam). */
+    retryDelaysAfterFlushFailureMs?: number[];
+}
+
+const ATTEMPTS: FetchAttempt[] = [
+    { source: 'DETAILS', table: '"$EXA_PROFILE_DETAILS_LAST_DAY"', hasIproc: true },
+    { source: 'DBA_SUMMARY', table: 'EXA_DBA_PROFILE_LAST_DAY', hasIproc: false },
+    { source: 'USER_SUMMARY', table: 'EXA_USER_PROFILE_LAST_DAY', hasIproc: false }
+];
+
+/**
+ * Finds the STMT_ID of the first non-transaction statement after the given
+ * baseline, then returns every row for that exact statement — a single
+ * round trip via a correlated subquery, not two separate queries.
+ */
+function buildSql(attempt: FetchAttempt, target: PlanTarget): string {
+    const { table } = attempt;
+    const scope = `SESSION_ID = ${target.sessionId}`;
+    const orderBy = attempt.hasIproc ? 'ORDER BY PART_ID, IPROC' : 'ORDER BY PART_ID';
+    return `
+        SELECT * FROM ${table}
+        WHERE ${scope} AND STMT_ID = (
+            SELECT MIN(STMT_ID) FROM ${table}
+            WHERE ${scope} AND STMT_ID > ${target.afterStmtId} AND COMMAND_NAME NOT IN ('COMMIT', 'ROLLBACK')
+        )
+        ${orderBy}
+    `;
+}
+
+/**
+ * An insufficient-privilege response — the expected case for a non-DBA user
+ * hitting tiers 1/2. Distinguished from isObjectNotFoundError below because
+ * "every tier denied by privilege" gets its own, more accurate error message
+ * (see getPlan()) instead of the generic "no profiling data" one.
+ */
+function isPrivilegeError(error: unknown): boolean {
+    const message = (error instanceof Error ? error.message : String(error ?? '')).toUpperCase();
+    return message.includes('INSUFFICIENT PRIVILEGE');
+}
+
+/** Defends against a future Exasol version renaming/removing the
+ * undocumented detail table — falls back rather than failing outright. */
+function isObjectNotFoundError(error: unknown): boolean {
+    const message = (error instanceof Error ? error.message : String(error ?? '')).toUpperCase();
+    return message.includes('NOT FOUND') && message.includes('OBJECT');
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export class PlanProvider {
+    private readonly retryDelaysMs: number[];
+    private readonly retryDelaysAfterFlushFailureMs: number[];
+
+    constructor(private connectionManager: ConnectionManager, retryOptions: PlanProviderRetryOptions = {}) {
+        this.retryDelaysMs = retryOptions.retryDelaysMs ?? RETRY_DELAYS_MS;
+        this.retryDelaysAfterFlushFailureMs =
+            retryOptions.retryDelaysAfterFlushFailureMs ?? RETRY_DELAYS_AFTER_FLUSH_FAILURE_MS;
+    }
+
+    async getPlan(
+        connection: StoredConnection,
+        target: PlanTarget,
+        thresholds: WarningThresholds = DEFAULT_WARNING_THRESHOLDS
+    ): Promise<Plan> {
+        if (!DIGITS_ONLY.test(target.sessionId) || !DIGITS_ONLY.test(target.afterStmtId)) {
+            throw new Error('getPlan requires sessionId/afterStmtId to be plain digit strings');
+        }
+
+        const outputChannel = getOutputChannel();
+
+        // Best-effort: force pending profiling data to become queryable now
+        // rather than waiting out Exasol's natural flush interval. A failure
+        // here (e.g. insufficient privilege in some deployments) just means
+        // falling back to the retry loop's own margin below.
+        let flushSucceeded = false;
+        try {
+            await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id, 'background');
+                const flushResult = await rawExecute(driver, 'FLUSH STATISTICS');
+                // rawExecute() requests responseType: 'raw', and the driver only
+                // throws on a SQL-level error (e.g. insufficient privilege) for its
+                // default response type — 'raw' responses are handed back as-is,
+                // error status included, with no throw. getRowsFromResult() is what
+                // actually inspects that status and throws; FLUSH STATISTICS has no
+                // rows to return on success, so this only ever surfaces a genuine
+                // failure, never a false one.
+                getRowsFromResult(flushResult);
+            }, connection.id, { timeoutMs: BACKGROUND_QUERY_TIMEOUT_MS, role: 'background' });
+            flushSucceeded = true;
+        } catch (error) {
+            outputChannel?.appendLine(`   FLUSH STATISTICS before plan fetch failed (continuing anyway): ${error}`);
+        }
+
+        // With a successful flush the data is visible almost immediately; without
+        // one we must poll long enough to outlast Exasol's cross-connection
+        // propagation delay (see RETRY_DELAYS_AFTER_FLUSH_FAILURE_MS).
+        const retryDelays = flushSucceeded ? this.retryDelaysMs : this.retryDelaysAfterFlushFailureMs;
+
+        let lastError: unknown;
+
+        for (let round = 0; round < retryDelays.length; round++) {
+            if (retryDelays[round] > 0) {
+                await sleep(retryDelays[round]);
+            }
+
+            const plan = await this.connectionManager.executeWithRetry(async () => {
+                const driver = await this.connectionManager.getDriver(connection.id, 'background');
+
+                // True only if every tier this round was denied specifically by
+                // privilege — as opposed to reaching a tier and finding it empty,
+                // which just means "not ready yet" and is worth retrying. If every
+                // tier is a hard permission wall, no amount of retrying will help,
+                // so getPlan() fails fast with a distinct, accurate message below
+                // instead of the generic "no profiling data" one.
+                let allDeniedByPrivilege = true;
+
+                for (const attempt of ATTEMPTS) {
+                    try {
+                        const result = await rawQuery(driver, buildSql(attempt, target));
+                        const rows = getRowsFromResult(result);
+                        if (rows.length === 0) {
+                            // Reached this tier — not a privilege wall. Not
+                            // necessarily a privilege problem either — just no
+                            // data yet (or the query hasn't propagated there at
+                            // all). Keep going down the fallback chain.
+                            allDeniedByPrivilege = false;
+                            outputChannel?.appendLine(
+                                `   Plan fetch (${attempt.source}): 0 rows for session ${target.sessionId} after stmt ${target.afterStmtId}`
+                            );
+                            continue;
+                        }
+                        const resolvedStmtId = String(rows[0].STMT_ID);
+                        outputChannel?.appendLine(`   Plan fetch (${attempt.source}): ${rows.length} rows for resolved stmt ${resolvedStmtId}`);
+                        return normalizeProfileRows(
+                            rows,
+                            { sessionId: target.sessionId, stmtId: resolvedStmtId, source: attempt.source },
+                            thresholds
+                        );
+                    } catch (error) {
+                        lastError = error;
+                        if (isPrivilegeError(error)) {
+                            outputChannel?.appendLine(`   Plan fetch (${attempt.source}) denied by privilege, falling back: ${error}`);
+                            continue;
+                        }
+                        if (isObjectNotFoundError(error)) {
+                            allDeniedByPrivilege = false;
+                            outputChannel?.appendLine(`   Plan fetch (${attempt.source}) unavailable, falling back: ${error}`);
+                            continue;
+                        }
+                        throw error;
+                    }
+                }
+
+                if (allDeniedByPrivilege) {
+                    throw new Error(
+                        `Your database user doesn't have permission to view query profiling data — access was denied ` +
+                        `on every available profile view. Ask a DBA to grant SELECT on EXA_USER_PROFILE_LAST_DAY ` +
+                        `(available to all users by default in a standard Exasol setup), or SELECT ANY DICTIONARY for full per-node detail.`
+                    );
+                }
+                return null;
+            }, connection.id, { timeoutMs: BACKGROUND_QUERY_TIMEOUT_MS, role: 'background' });
+
+            if (plan) {
+                return plan;
+            }
+        }
+
+        throw new Error(
+            `No profiling data found for session ${target.sessionId} after statement ${target.afterStmtId}. ` +
+            `Make sure profiling was enabled (ALTER SESSION SET PROFILE = 'ON') before the query ran, ` +
+            `and that FLUSH STATISTICS has run since.` +
+            (lastError ? ` Last error: ${lastError}` : '')
+        );
+    }
+}

--- a/src/plan/planProvider.ts
+++ b/src/plan/planProvider.ts
@@ -7,11 +7,9 @@
  * Fallback order, richest first (mirrors the attempt/fallback convention
  * already used by src/providers/objectTreeFetchers.ts):
  *   1. $EXA_PROFILE_DETAILS_LAST_DAY — per-node (IPROC) detail, requires the
- *      SELECT ANY DICTIONARY privilege. Verified to exist and be gated on
- *      that privilege against a live Exasol 2026.1.0 instance during Step 0
- *      research; it is an internal/undocumented object (absent from
- *      SYS.EXA_SYSCAT) so this fallback chain is what protects v1 from that
- *      object disappearing or being renamed in a future Exasol version.
+ *      SELECT ANY DICTIONARY privilege. It is an internal/undocumented object,
+ *      so this fallback chain protects v1 from that object disappearing or
+ *      being renamed in a future Exasol version.
  *   2. EXA_DBA_PROFILE_LAST_DAY — cluster-wide aggregate, any session, same
  *      privilege requirement as #1.
  *   3. EXA_USER_PROFILE_LAST_DAY — cluster-wide aggregate, own sessions only,
@@ -49,8 +47,7 @@ export interface PlanTarget {
     /**
      * Exact digit strings, not `number` — Exasol's SESSION_ID (DECIMAL(20,0))
      * routinely exceeds Number.MAX_SAFE_INTEGER, and converting it to a JS
-     * number silently rounds it (verified: a real session id's last three
-     * digits were lost this way during Step 0 testing). Validated as a plain
+	 * number silently rounds it. Validated as a plain
      * digit string in getPlan() below before being interpolated into SQL.
      */
     sessionId: string;
@@ -65,10 +62,8 @@ export interface PlanTarget {
 interface FetchAttempt {
     source: ProfileSource;
     table: string;
-    /** Only $EXA_PROFILE_DETAILS_LAST_DAY has an IPROC (per-node) column —
-     * EXA_DBA_PROFILE_LAST_DAY/EXA_USER_PROFILE_LAST_DAY don't (confirmed via
-     * DESCRIBE against a live instance). Ordering by it on those tiers fails
-     * with "object IPROC not found", verified live on a second instance. */
+    /** Only $EXA_PROFILE_DETAILS_LAST_DAY has an IPROC (per-node) column.
+     * Ordering by it on the aggregate views fails because they do not expose it. */
     hasIproc: boolean;
 }
 
@@ -271,8 +266,8 @@ export class PlanProvider {
 
         throw new Error(
             `No profiling data found for session ${target.sessionId} after statement ${target.afterStmtId}. ` +
-            `Make sure profiling was enabled (ALTER SESSION SET PROFILE = 'ON') before the query ran, ` +
-            `and that FLUSH STATISTICS has run since.` +
+            `Make sure execution plans are enabled, reconnect so session profiling is configured, ` +
+            `then run the query again.` +
             (lastError ? ` Last error: ${lastError}` : '')
         );
     }

--- a/src/plan/planTextExport.ts
+++ b/src/plan/planTextExport.ts
@@ -1,0 +1,75 @@
+/**
+ * Renders a normalized Plan as a plain-text summary for clipboard export.
+ *
+ * Deliberately block-formatted rather than column-aligned: a fixed-width
+ * table only looks right in a monospace-rendering destination, and a copied
+ * plan is just as likely to land in a proportional-font target (a Jira/
+ * support-ticket comment box, a Slack message, an email) where misaligned
+ * columns read worse than no alignment at all.
+ *
+ * Deliberately full parity with the on-screen detail panel (nodeDetailHtml
+ * in planWebview.ts), not just the compact card face: CPU, Net, HDD write,
+ * Temp DB RAM peak, and per-node skew all show up here too, whenever Exasol
+ * actually reported a value for them — undefined means "not measured" and
+ * is omitted, never shown as a fake zero.
+ */
+import { Plan, PlanNode } from './planModel';
+import { fmtMs, fmtPct, fmtRows, fmtMiB, fmtCpuPct, planSourceLabel, planClusterSize } from './planFormat';
+
+function joinDefinedFields(fields: Array<string | undefined>): string | undefined {
+    const defined = fields.filter((f): f is string => f !== undefined);
+    return defined.length > 0 ? defined.join('  ') : undefined;
+}
+
+function perNodeRowsLine(node: PlanNode): string {
+    if (!node.perNodeStats) {
+        return 'Per-node rows: not available';
+    }
+    const s = node.perNodeStats;
+    return `Per-node rows: min ${s.min} / max ${s.max} / avg ${s.avg.toFixed(0)} / nodes ${s.nodeCount}`;
+}
+
+function operatorBlock(node: PlanNode, index: number): string {
+    const objectSuffix = node.objectName
+        ? ` — ${node.objectSchema ? `${node.objectSchema}.` : ''}${node.objectName}`
+        : '';
+    const title = `${index + 1}. ${node.operatorLabel} [part ${node.id}]${objectSuffix}`;
+
+    const primaryMetrics = `   Duration: ${fmtMs(node.duration)}  CPU: ${fmtCpuPct(node.cpu)}  ` +
+        `Cost: ${fmtPct(node.costPercent)}  Rows out: ${fmtRows(node.rowsOut)}`;
+
+    const secondaryMetrics = joinDefinedFields([
+        node.net !== undefined ? `Net: ${fmtMiB(node.net)}` : undefined,
+        node.hddWrite !== undefined ? `HDD write: ${fmtMiB(node.hddWrite)}` : undefined,
+        node.tempDbRamPeak !== undefined ? `Temp DB RAM peak: ${fmtMiB(node.tempDbRamPeak)}` : undefined
+    ]);
+
+    const lines = [
+        title,
+        primaryMetrics,
+        secondaryMetrics !== undefined ? `   ${secondaryMetrics}` : undefined,
+        `   ${perNodeRowsLine(node)}`,
+        node.partInfo ? `   Part info: ${node.partInfo}` : undefined,
+        node.remarks ? `   Remarks: ${node.remarks}` : undefined,
+        ...node.warnings.map(w => `   ⚠ ${w.message}`)
+    ].filter((line): line is string => line !== undefined);
+
+    return lines.join('\n');
+}
+
+export function buildPlanTextSummary(plan: Plan): string {
+    const clusterSize = planClusterSize(plan);
+    const header = [
+        `Execution plan — session ${plan.sessionId}, statement ${plan.stmtId}`,
+        `Source: ${planSourceLabel(plan.source)}`,
+        `Total time: ${fmtMs(plan.totalDuration)}`,
+        `Nodes: ${clusterSize !== undefined ? clusterSize : 'not available'}`
+    ].join('\n');
+
+    if (plan.nodes.length === 0) {
+        return `${header}\n\nThis statement produced no profiled operators.\n`;
+    }
+
+    const body = plan.nodes.map((node, i) => operatorBlock(node, i)).join('\n\n');
+    return `${header}\n\n${body}\n`;
+}

--- a/src/plan/planTextExport.ts
+++ b/src/plan/planTextExport.ts
@@ -29,26 +29,78 @@ function perNodeRowsLine(node: PlanNode): string {
     return `Per-node rows: min ${s.min} / max ${s.max} / avg ${s.avg.toFixed(0)} / nodes ${s.nodeCount}`;
 }
 
-function operatorBlock(node: PlanNode, index: number): string {
+/** Same "not available" convention as perNodeRowsLine — but only when
+ * per-node rows were fetched at all; when they weren't, per-node durations
+ * were never computable either, and repeating "not available" for both
+ * lines every single time (the common no-detail case) is pure noise. Also
+ * omitted below the 1ms noise floor — see the identical check in
+ * nodePopoverHtml (planWebview.ts). */
+function perNodeDurationLine(node: PlanNode): string | undefined {
+    if (!node.perNodeDurationStats || node.perNodeDurationStats.max < 0.001) {
+        return undefined;
+    }
+    const s = node.perNodeDurationStats;
+    return `Per-node durations: min ${fmtMs(s.min)} / max ${fmtMs(s.max)} / avg ${fmtMs(s.avg)} / nodes ${s.nodeCount}`;
+}
+
+/** "N rows -> M (P%)" scan selectivity — see scannedSelectivity() in
+ * planWebview.ts for the identical computation shown there. */
+function scannedLine(node: PlanNode): string | undefined {
+    if (node.objectRows === undefined || node.objectRows === 0 || node.rowsOut === undefined) {
+        return undefined;
+    }
+    const rowsPart = `Scanned: ${node.objectRows.toLocaleString()} rows → ${node.rowsOut.toLocaleString()}`;
+    // rowsOut > objectRows means the two numbers are inconsistent — still
+    // show the raw counts, but never render a selectivity percentage over
+    // 100%, which would read as a real signal rather than a data problem.
+    if (node.rowsOut > node.objectRows) {
+        return rowsPart;
+    }
+    const pct = (node.rowsOut / node.objectRows) * 100;
+    return `${rowsPart} (${pct.toFixed(1)}%)`;
+}
+
+/** Renders one node's full block exactly as it appears inside
+ * buildPlanTextSummary()'s output — also the text behind the popover's
+ * per-node "Copy" button (see nodePopoverHtml in planWebview.ts), so a
+ * single-node copy and the matching block inside a full-plan copy are
+ * always character-for-character identical. */
+export function operatorBlock(node: PlanNode, index: number): string {
     const objectSuffix = node.objectName
         ? ` — ${node.objectSchema ? `${node.objectSchema}.` : ''}${node.objectName}`
         : '';
     const title = `${index + 1}. ${node.operatorLabel} [part ${node.id}]${objectSuffix}`;
 
-    const primaryMetrics = `   Duration: ${fmtMs(node.duration)}  CPU: ${fmtCpuPct(node.cpu)}  ` +
-        `Cost: ${fmtPct(node.costPercent)}  Rows out: ${fmtRows(node.rowsOut)}`;
+    // Metrics first, in the same order as the popover (planWebview.ts):
+    // Duration, Duration share ("Share" — F12 renamed this from "Cost"),
+    // CPU (max node), Rows out, then Scanned on its own line below. The
+    // share's denominator differs by node kind (see PlanNode.costPercent in
+    // planModel.ts) — spelled out here too, or the same operator reads as
+    // two contradictory percentages between this export and the side rail's
+    // always-of-total category breakdown with no hint why.
+    const shareLabel = node.traits.isSystemStep ? 'Share (of total)' : 'Share (of query)';
+    const primaryMetrics = `   Duration: ${fmtMs(node.duration)}  ${shareLabel}: ${fmtPct(node.costPercent)}  ` +
+        `CPU (max node): ${fmtCpuPct(node.cpu)}  Rows out: ${fmtRows(node.rowsOut)}`;
 
     const secondaryMetrics = joinDefinedFields([
         node.net !== undefined ? `Net: ${fmtMiB(node.net)}` : undefined,
+        node.tempDbRamPeak !== undefined ? `Temp DB RAM peak: ${fmtMiB(node.tempDbRamPeak)}` : undefined,
         node.hddWrite !== undefined ? `HDD write: ${fmtMiB(node.hddWrite)}` : undefined,
-        node.tempDbRamPeak !== undefined ? `Temp DB RAM peak: ${fmtMiB(node.tempDbRamPeak)}` : undefined
+        // Deliberately shown only when > 0 — see PlanNode.hddRead in
+        // planModel.ts (it's a rate, and 0 is the overwhelming common case).
+        node.hddRead !== undefined && node.hddRead > 0 ? `HDD read: ${node.hddRead.toFixed(1)} MiB/s` : undefined
     ]);
+
+    const scanned = scannedLine(node);
+    const perNodeDurations = perNodeDurationLine(node);
 
     const lines = [
         title,
         primaryMetrics,
+        scanned !== undefined ? `   ${scanned}` : undefined,
         secondaryMetrics !== undefined ? `   ${secondaryMetrics}` : undefined,
         `   ${perNodeRowsLine(node)}`,
+        perNodeDurations !== undefined ? `   ${perNodeDurations}` : undefined,
         node.partInfo ? `   Part info: ${node.partInfo}` : undefined,
         node.remarks ? `   Remarks: ${node.remarks}` : undefined,
         ...node.warnings.map(w => `   ⚠ ${w.message}`)

--- a/src/plan/planTextExport.ts
+++ b/src/plan/planTextExport.ts
@@ -63,7 +63,7 @@ export function buildPlanTextSummary(plan: Plan): string {
         `Execution plan — session ${plan.sessionId}, statement ${plan.stmtId}`,
         `Source: ${planSourceLabel(plan.source)}`,
         `Total time: ${fmtMs(plan.totalDuration)}`,
-        `Nodes: ${clusterSize !== undefined ? clusterSize : 'not available'}`
+        `Nodes observed: ${clusterSize !== undefined ? clusterSize : 'not available'}`
     ].join('\n');
 
     if (plan.nodes.length === 0) {

--- a/src/plan/planWarnings.ts
+++ b/src/plan/planWarnings.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure warning computation over an already-normalized node's metrics.
+ *
+ * Every threshold here is a v1 heuristic, not a value Exasol itself defines —
+ * documented per-warning below. None of these ever run against a fabricated
+ * or estimated number: HIGH_SKEW only fires when real per-node rows were
+ * fetched (see planProvider.ts), and ROW_ESTIMATE_MISMATCH can never fire at
+ * all in v1 because these profile views expose no pre-execution row estimate
+ * (OBJECT_ROWS/OUT_ROWS are both post-execution actuals) — see honesty
+ * constraint in the project brief.
+ *
+ * LARGE_REDISTRIBUTION deliberately flags by *share of total query time*,
+ * not a fixed byte cutoff. Researched this before picking it: Snowflake's
+ * Query Profile, BigQuery's query-plan docs, and Databricks' skew guidance
+ * all flag operators by relative cost (% of total duration, or vs. other
+ * stages/runs) — none use an absolute byte threshold in their plan UI. A
+ * fixed MiB number can't scale across wildly different query/cluster sizes
+ * (20 MiB is nothing in an hour-long query, everything in a 50ms one);
+ * relative cost share does. Redshift is the one vendor with a fixed
+ * constant for this (1,000,000 rows), and it lives in a separate
+ * monitoring/alerting layer, not its plan viewer.
+ */
+import { OperatorTraits, PerNodeStat, PlanWarning } from './planModel';
+
+export interface WarningThresholds {
+    /** (max - avg) / avg across nodes, above which HIGH_SKEW fires. */
+    skewRatio: number;
+    /** Share of the query's total duration (0-100) an operator must both
+     * exceed and move real network data over, to get LARGE_REDISTRIBUTION. */
+    redistributionCostSharePercent: number;
+}
+
+export const DEFAULT_WARNING_THRESHOLDS: WarningThresholds = {
+    skewRatio: 0.3,
+    redistributionCostSharePercent: 20
+};
+
+export interface WarningInputs {
+    traits: OperatorTraits;
+    hddWrite: number | undefined;
+    net: number | undefined;
+    perNodeStats: PerNodeStat | undefined;
+    /** Share of the query's total duration this node accounts for — the
+     * same number shown on its card. Undefined only when totalDuration
+     * itself is 0 (see profileRowNormalizer.ts), in which case
+     * LARGE_REDISTRIBUTION cannot be evaluated and never fires. */
+    costPercent: number | undefined;
+}
+
+export function computeWarnings(
+    node: WarningInputs,
+    thresholds: WarningThresholds = DEFAULT_WARNING_THRESHOLDS
+): PlanWarning[] {
+    const warnings: PlanWarning[] = [];
+
+    // Heuristic: nonzero disk write on an operator capable of spilling (JOIN/
+    // GROUP BY/SORT). Exasol's profile views have no explicit "spilled" flag,
+    // so this infers it from HDD_WRITE > 0 rather than claiming certainty.
+    if (node.traits.canSpill && node.hddWrite !== undefined && node.hddWrite > 0) {
+        warnings.push({
+            type: 'SPILLED_TO_DISK',
+            message: `Wrote ${node.hddWrite.toFixed(1)} MiB to disk during execution`,
+            detail: { hddWriteMiB: node.hddWrite }
+        });
+    }
+
+    if (
+        node.traits.movesDataOverNetwork &&
+        node.net !== undefined &&
+        node.net > 0 &&
+        node.costPercent !== undefined &&
+        node.costPercent > thresholds.redistributionCostSharePercent
+    ) {
+        warnings.push({
+            type: 'LARGE_REDISTRIBUTION',
+            // One decimal place here, not zero: with costPercent just over the
+            // threshold (e.g. 20.4% vs. a 20% threshold), toFixed(0) rounded
+            // both to the same displayed number ("20% ... threshold 20%"),
+            // reading as if the warning had fired for no reason.
+            message: `Moved ${node.net.toFixed(1)} MiB across the network — this step alone accounted for ` +
+                `${node.costPercent.toFixed(1)}% of the query's total time (threshold ${thresholds.redistributionCostSharePercent}%)`,
+            detail: { netMiB: node.net, costPercent: node.costPercent, thresholdPercent: thresholds.redistributionCostSharePercent }
+        });
+    }
+
+    if (node.perNodeStats && node.perNodeStats.nodeCount > 1 && node.perNodeStats.avg > 0) {
+        const ratio = (node.perNodeStats.max - node.perNodeStats.avg) / node.perNodeStats.avg;
+        if (ratio > thresholds.skewRatio) {
+            warnings.push({
+                type: 'HIGH_SKEW',
+                message: `Rows per node ranged ${node.perNodeStats.min}-${node.perNodeStats.max} ` +
+                    `(avg ${node.perNodeStats.avg.toFixed(0)}) across ${node.perNodeStats.nodeCount} nodes`,
+                detail: {
+                    min: node.perNodeStats.min,
+                    max: node.perNodeStats.max,
+                    avg: node.perNodeStats.avg,
+                    nodeCount: node.perNodeStats.nodeCount,
+                    ratio
+                }
+            });
+        }
+    }
+
+    // ROW_ESTIMATE_MISMATCH intentionally never fires in v1: see file header.
+
+    return warnings;
+}

--- a/src/plan/planWarnings.ts
+++ b/src/plan/planWarnings.ts
@@ -9,16 +9,9 @@
  * (OBJECT_ROWS/OUT_ROWS are both post-execution actuals) — see honesty
  * constraint in the project brief.
  *
- * LARGE_REDISTRIBUTION deliberately flags by *share of total query time*,
- * not a fixed byte cutoff. Researched this before picking it: Snowflake's
- * Query Profile, BigQuery's query-plan docs, and Databricks' skew guidance
- * all flag operators by relative cost (% of total duration, or vs. other
- * stages/runs) — none use an absolute byte threshold in their plan UI. A
- * fixed MiB number can't scale across wildly different query/cluster sizes
- * (20 MiB is nothing in an hour-long query, everything in a 50ms one);
- * relative cost share does. Redshift is the one vendor with a fixed
- * constant for this (1,000,000 rows), and it lives in a separate
- * monitoring/alerting layer, not its plan viewer.
+ * LARGE_REDISTRIBUTION deliberately flags by share of total query time, not a
+ * fixed byte cutoff. A fixed MiB threshold would not scale across very
+ * different query sizes or cluster sizes.
  */
 import { OperatorTraits, PerNodeStat, PlanWarning } from './planModel';
 

--- a/src/plan/planWarnings.ts
+++ b/src/plan/planWarnings.ts
@@ -16,16 +16,29 @@
 import { OperatorTraits, PerNodeStat, PlanWarning } from './planModel';
 
 export interface WarningThresholds {
-    /** (max - avg) / avg across nodes, above which HIGH_SKEW fires. */
+    /** (max - avg) / avg across nodes, above which HIGH_SKEW/HIGH_DURATION_SKEW fire. */
     skewRatio: number;
     /** Share of the query's total duration (0-100) an operator must both
      * exceed and move real network data over, to get LARGE_REDISTRIBUTION. */
     redistributionCostSharePercent: number;
+    /** Noise floor for HIGH_SKEW: real per-node ROWS distributions are only
+     * worth flagging once the busiest node handled at least this many rows.
+     * Live data showed the median part outputs 1 row and 38.6% output under
+     * 10 — without this floor, HIGH_SKEW fired constantly on statistically
+     * meaningless row counts (e.g. "0-1 rows across 4 nodes"), training users
+     * to ignore the warnings rail entirely. */
+    skewMinRows: number;
+    /** Noise floor for HIGH_DURATION_SKEW, in seconds: the busiest node must
+     * have taken at least this long, so a skewed-but-trivial (sub-50ms)
+     * duration spread doesn't fire alongside the real row-skew floor above. */
+    durationSkewMinSeconds: number;
 }
 
 export const DEFAULT_WARNING_THRESHOLDS: WarningThresholds = {
     skewRatio: 0.3,
-    redistributionCostSharePercent: 20
+    redistributionCostSharePercent: 20,
+    skewMinRows: 1000,
+    durationSkewMinSeconds: 0.05
 };
 
 export interface WarningInputs {
@@ -33,6 +46,8 @@ export interface WarningInputs {
     hddWrite: number | undefined;
     net: number | undefined;
     perNodeStats: PerNodeStat | undefined;
+    /** Per-node DURATION distribution — see PlanNode.perNodeDurationStats. */
+    perNodeDurationStats: PerNodeStat | undefined;
     /** Share of the query's total duration this node accounts for — the
      * same number shown on its card. Undefined only when totalDuration
      * itself is 0 (see profileRowNormalizer.ts), in which case
@@ -78,7 +93,11 @@ export function computeWarnings(
 
     if (node.perNodeStats && node.perNodeStats.nodeCount > 1 && node.perNodeStats.avg > 0) {
         const ratio = (node.perNodeStats.max - node.perNodeStats.avg) / node.perNodeStats.avg;
-        if (ratio > thresholds.skewRatio) {
+        // skewMinRows: see WarningThresholds doc — without this floor, a
+        // handful of rows split unevenly across nodes (statistically
+        // meaningless) fired the same warning as a genuine multi-million-row
+        // skew.
+        if (ratio > thresholds.skewRatio && node.perNodeStats.max >= thresholds.skewMinRows) {
             warnings.push({
                 type: 'HIGH_SKEW',
                 message: `Rows per node ranged ${node.perNodeStats.min}-${node.perNodeStats.max} ` +
@@ -88,6 +107,40 @@ export function computeWarnings(
                     max: node.perNodeStats.max,
                     avg: node.perNodeStats.avg,
                     nodeCount: node.perNodeStats.nodeCount,
+                    ratio
+                }
+            });
+        }
+    }
+
+    // Duration skew: restricted to blocking, non-system data-flow operators.
+    // Non-blocking (pipelined) operators don't wait on their slowest node the
+    // same way, and system steps are excluded on the same basis as HIGH_SKEW.
+    // Sync barriers (SYNC: producesRows/consumesRows both false) are also
+    // excluded even though they're blocking and non-system: a sync barrier's
+    // own per-node duration spread just mirrors whatever skew already exists
+    // upstream (already warned on the real data-flow operator that caused
+    // it), so flagging it too is redundant noise, not a second finding.
+    if (
+        node.traits.blocking &&
+        !node.traits.isSystemStep &&
+        (node.traits.producesRows || node.traits.consumesRows) &&
+        node.perNodeDurationStats &&
+        node.perNodeDurationStats.nodeCount > 1 &&
+        node.perNodeDurationStats.avg > 0
+    ) {
+        const stats = node.perNodeDurationStats;
+        const ratio = (stats.max - stats.avg) / stats.avg;
+        if (ratio > thresholds.skewRatio && stats.max >= thresholds.durationSkewMinSeconds) {
+            warnings.push({
+                type: 'HIGH_DURATION_SKEW',
+                message: `Slowest node took ${(stats.max * 1000).toFixed(0)}ms vs ` +
+                    `${(stats.avg * 1000).toFixed(0)}ms average across ${stats.nodeCount} nodes`,
+                detail: {
+                    minSeconds: stats.min,
+                    maxSeconds: stats.max,
+                    avgSeconds: stats.avg,
+                    nodeCount: stats.nodeCount,
                     ratio
                 }
             });

--- a/src/plan/planWebview.ts
+++ b/src/plan/planWebview.ts
@@ -30,17 +30,18 @@
  * the opposite direction, continuing directly below where the previous row
  * ended instead of restarting at the far left across a large gap.
  */
-import { Plan, PlanNode, PlanWarning } from './planModel';
+import { OperatorType, Plan, PlanNode, PlanWarning } from './planModel';
 import { escapeHtml } from '../utils';
 import {
     fmtMs, fmtPct, fmtRows, fmtMiB, fmtCpuPct,
     planSourceLabel, planClusterSize, planCategoryBreakdown, hottestNodeId, planLacksDetailMetrics,
-    OPERATOR_BADGE, OPERATOR_COLOR_VAR
+    OPERATOR_BADGE, OPERATOR_COLOR_VAR, OPERATOR_TYPE_LABEL
 } from './planFormat';
-import { buildPlanTextSummary } from './planTextExport';
+import { buildPlanTextSummary, operatorBlock } from './planTextExport';
 
 const WARNING_LABEL: Record<PlanWarning['type'], string> = {
     HIGH_SKEW: 'skew',
+    HIGH_DURATION_SKEW: 'duration skew',
     SPILLED_TO_DISK: 'spilled to disk',
     LARGE_REDISTRIBUTION: 'large redistribution',
     ROW_ESTIMATE_MISMATCH: 'row estimate mismatch'
@@ -53,32 +54,100 @@ function detailRow(label: string, value: string | undefined): string {
     return `<div class="plan-detail-row"><span class="plan-detail-k">${escapeHtml(label)}</span><span class="plan-detail-v">${escapeHtml(value)}</span></div>`;
 }
 
+/** "N rows -> M (P%)" scan selectivity, or undefined when either side of the
+ * ratio isn't available (see PlanNode.objectRows in planModel.ts) or the
+ * object reported zero rows (division by zero rather than a signal). */
+function scannedSelectivity(node: PlanNode): string | undefined {
+    if (node.objectRows === undefined || node.objectRows === 0 || node.rowsOut === undefined) {
+        return undefined;
+    }
+    const rowsPart = `${node.objectRows.toLocaleString()} rows → ${node.rowsOut.toLocaleString()}`;
+    // rowsOut > objectRows means the two numbers are inconsistent (e.g. a
+    // stale/partial collapse) — still show the raw counts, but never render
+    // a selectivity percentage over 100%, which would read as a real signal
+    // rather than a data problem.
+    if (node.rowsOut > node.objectRows) {
+        return rowsPart;
+    }
+    const pct = (node.rowsOut / node.objectRows) * 100;
+    return `${rowsPart} (${pct.toFixed(1)}%)`;
+}
+
+/** Duration share is two different denominators depending on node kind (see
+ * PlanNode.costPercent in planModel.ts) — the same operator otherwise reads
+ * as two contradictory numbers with no hint why (a screenshot showed one
+ * node at 45% on its ring, 31% in the side rail's category breakdown, with
+ * nothing distinguishing which total each was a share of). Spelling out the
+ * denominator in the label itself removes the ambiguity without adding a
+ * second, dual-display row. */
+function durationShareLabel(node: PlanNode): string {
+    return node.traits.isSystemStep ? 'Duration share (of total)' : 'Duration share (of query)';
+}
+
+/** Inserts a zero-width space (U+200B) after every '.' and '_' so a long
+ * schema-qualified name (e.g. "SNAP_SALESFORCE.CONTRACT_DOCUMENTS") gets a
+ * natural break at the schema/table boundary instead of wrapping mid-word.
+ * MUST run on the already-escaped string, not the raw one: escapeHtml()
+ * never touches '.' or '_' either way, but doing this last removes any need
+ * to reason about whether it might. */
+const ZERO_WIDTH_SPACE = String.fromCharCode(0x200b);
+function withBreakOpportunities(escaped: string): string {
+    return escaped.replace(/[._]/g, `$&${ZERO_WIDTH_SPACE}`);
+}
+
 /** Full detail for one node, shown in its popover on click — identical
- * field set regardless of how it's displayed. */
-function nodePopoverHtml(node: PlanNode): string {
+ * field set regardless of how it's displayed. `index` is the node's 0-based
+ * position in plan.nodes, needed only to number the embedded per-node copy
+ * text (finding 11) identically to its numbering in the full "Copy as text"
+ * export (see operatorBlock in planTextExport.ts). */
+function nodePopoverHtml(node: PlanNode, index: number): string {
     const titleText = node.objectName
         ? `${node.operatorLabel} — ${node.objectSchema ? `${node.objectSchema}.` : ''}${node.objectName}`
         : node.operatorLabel;
 
+    // Metrics first (the numbers a click here is almost always chasing),
+    // then Part info/Remarks — scan popovers carry filter columns in
+    // Remarks, worth a glance without scrolling past the rest of the
+    // identity block first — then the remaining identity/free-text fields,
+    // warnings last (see warningDetails below). Every NUMERIC metric row
+    // always renders, using the shared formatters' own "—" for an undefined
+    // value, so a field never silently vanishes depending on what this
+    // particular node happened to report (identity/text fields — Object,
+    // Part info, Remarks — are the exception: omitting them when absent is
+    // correct, they're not measurements). HDD read is the one deliberate
+    // exception even among numeric fields: shown only when > 0 (see
+    // planModel.ts).
     const rows = [
-        detailRow('Part id', node.id),
-        detailRow('Operator', `${node.operatorLabel} (${node.operatorType})`),
-        detailRow('Object', node.objectSchema ? `${node.objectSchema}.${node.objectName ?? ''}` : node.objectName),
-        detailRow('Part info', node.partInfo),
-        detailRow('Remarks', node.remarks),
-        detailRow('Rows out', node.rowsOut !== undefined ? node.rowsOut.toLocaleString() : undefined),
         detailRow('Duration', fmtMs(node.duration)),
-        detailRow('CPU', node.cpu !== undefined ? fmtCpuPct(node.cpu) : undefined),
+        detailRow(durationShareLabel(node), fmtPct(node.costPercent)),
+        detailRow('CPU (max node)', fmtCpuPct(node.cpu)),
+        detailRow('Rows out', node.rowsOut !== undefined ? node.rowsOut.toLocaleString() : '—'),
+        detailRow('Scanned', scannedSelectivity(node)),
         detailRow('Net', fmtMiB(node.net)),
-        detailRow('Temp DB RAM peak', node.tempDbRamPeak !== undefined ? fmtMiB(node.tempDbRamPeak) : undefined),
+        detailRow('Temp DB RAM peak', fmtMiB(node.tempDbRamPeak)),
         detailRow('HDD write', fmtMiB(node.hddWrite)),
-        detailRow('Cost share', fmtPct(node.costPercent)),
+        detailRow('HDD read', node.hddRead !== undefined && node.hddRead > 0 ? `${node.hddRead.toFixed(1)} MiB/s` : undefined),
         detailRow(
             'Per-node rows',
             node.perNodeStats
                 ? `min ${node.perNodeStats.min} / max ${node.perNodeStats.max} / avg ${node.perNodeStats.avg.toFixed(0)} / nodes ${node.perNodeStats.nodeCount}`
                 : 'not available'
         ),
+        detailRow(
+            'Per-node durations',
+            // Below the 1ms noise floor, a per-node duration spread is
+            // measurement granularity, not a real straggler — see the
+            // identical floor in planTextExport.ts's perNodeDurationLine().
+            node.perNodeDurationStats && node.perNodeDurationStats.max >= 0.001
+                ? `min ${fmtMs(node.perNodeDurationStats.min)} / max ${fmtMs(node.perNodeDurationStats.max)} / ` +
+                  `avg ${fmtMs(node.perNodeDurationStats.avg)} / nodes ${node.perNodeDurationStats.nodeCount}`
+                : undefined
+        ),
+        detailRow('Part info', node.partInfo),
+        detailRow('Remarks', node.remarks),
+        detailRow('Part id', node.id),
+        detailRow('Operator', `${node.operatorLabel} (${node.operatorType})`),
+        detailRow('Object', node.objectSchema ? `${node.objectSchema}.${node.objectName ?? ''}` : node.objectName),
         detailRow(
             'Traits',
             Object.entries(node.traits).filter(([, v]) => v).map(([k]) => k).join(', ') || 'none'
@@ -89,10 +158,38 @@ function nodePopoverHtml(node: PlanNode): string {
         `<div class="plan-detail-row"><span class="plan-detail-k">Warning</span><span class="plan-detail-v">${escapeHtml(w.message)}</span></div>`
     ).join('');
 
+    // Per-node copy (finding 11): the exact same text operatorBlock() would
+    // render for this node inside the full "Copy as text" export, embedded
+    // in a hidden textarea (same CSP-safe pattern as #plan-text-data below)
+    // so the click handler has no DOM to build or escape at runtime — it
+    // only ever reads a value that was already escaped once, here.
+    const copyText = operatorBlock(node, index);
+
     return `<div class="plan-popover" data-popover hidden>
-        <div class="plan-popover-title">${escapeHtml(titleText)}</div>
+        <div class="plan-popover-title-row">
+            <div class="plan-popover-title">${withBreakOpportunities(escapeHtml(titleText))}</div>
+            <button type="button" class="plan-node-copy" data-copy-node="${escapeHtml(node.id)}">⧉ Copy</button>
+        </div>
         ${rows}${warningDetails}
+        <textarea class="plan-node-copy-data" hidden>${escapeHtml(copyText)}</textarea>
     </div>`;
+}
+
+/** Middle-truncates a long object caption (finding 19): keeps the
+ * distinguishing tail (e.g. the actual table name after a shared schema/
+ * prefix) instead of a leading-only truncation, which made a row of
+ * "PIPE FILTERSCAN / SYS.EXA_SESSION_ROL…"-style captions indistinguishable
+ * at a glance. Deterministic string slicing, not JS measuring against the
+ * rendered font — the popover shows the untruncated name regardless, so
+ * nothing is actually lost, only the compact caption is shortened. The CSS
+ * text-overflow: ellipsis on .hnode-sub stays as a backstop for whatever
+ * this fixed 18-character budget still doesn't cover at an unusual zoom
+ * level, not as the primary mechanism. */
+function middleTruncateCaption(s: string): string {
+    if (s.length <= 18) {
+        return s;
+    }
+    return `${s.slice(0, 8)}…${s.slice(-9)}`;
 }
 
 /**
@@ -102,48 +199,117 @@ function nodePopoverHtml(node: PlanNode): string {
  * real <button> (data-node-toggle/data-node-id, aria-expanded reflecting
  * whether its popover is open) so activating it — click, Enter, or Space —
  * opens that popover. The popover is a sibling in the same .hnode-wrap, not
- * nested inside the button.
+ * nested inside the button. `index` is the node's 0-based position in
+ * plan.nodes — see nodePopoverHtml.
  */
-function hnodeHtml(node: PlanNode, isHot: boolean): string {
+function hnodeHtml(node: PlanNode, isHot: boolean, index: number): string {
     const badge = OPERATOR_BADGE[node.operatorType] ?? '?';
     const colorVar = isHot ? '--vscode-charts-red' : (OPERATOR_COLOR_VAR[node.operatorType] ?? '--vscode-descriptionForeground');
     const pct = Math.max(0, Math.min(100, node.costPercent ?? 0));
     const hasWarnings = node.warnings.length > 0;
     const warnTitle = hasWarnings ? node.warnings.map(w => WARNING_LABEL[w.type] ?? w.type).join(', ') : '';
 
-    const subLines = [
-        node.duration !== undefined ? fmtMs(node.duration) : undefined,
-        node.objectName ? `${node.objectSchema ? node.objectSchema + '.' : ''}${node.objectName}` : undefined
-    ].filter((v): v is string => v !== undefined);
+    const durationLine = node.duration !== undefined ? fmtMs(node.duration) : undefined;
+    const objectLineRaw = node.objectName ? `${node.objectSchema ? node.objectSchema + '.' : ''}${node.objectName}` : undefined;
+    const objectLine = objectLineRaw !== undefined ? middleTruncateCaption(objectLineRaw) : undefined;
+    // Dims/italicizes a temp-object caption (finding 20) — PART_INFO already
+    // says "on TEMPORARY table"; a novice reading a bare "tmp_subselect3" in
+    // the caption has no way to know that without clicking through, and this
+    // survives even the truncation above since it's a class on the whole
+    // line, not text content.
+    const isTempObject = node.partInfo !== undefined && node.partInfo.toUpperCase().includes('TEMPORARY');
+    const subLineHtml = [
+        durationLine !== undefined ? `<span class="hnode-sub">${escapeHtml(durationLine)}</span>` : undefined,
+        objectLine !== undefined
+            ? `<span class="hnode-sub${isTempObject ? ' hnode-sub-temp' : ''}">${escapeHtml(objectLine)}</span>`
+            : undefined
+    ].filter((v): v is string => v !== undefined).join('');
 
     const typeWords = node.operatorType.replace('_', ' ').toLowerCase();
     const warningSuffix = hasWarnings ? `, ${node.warnings.length} warning${node.warnings.length === 1 ? '' : 's'}` : '';
     const ariaLabel = `${node.operatorLabel}, ${typeWords}, ${fmtPct(node.costPercent)} of total time${warningSuffix}`;
 
+    // Cheap hover peek (finding 9): a one-line title on the button itself —
+    // distinct from the ring's own title (the operator type, finding 5) so
+    // hovering the ring still names the type while hovering the rest of the
+    // card shows the numbers. Only defined parts are included, so a node
+    // with no recorded duration/cost doesn't show a dangling "— · —".
+    const hoverParts = [
+        durationLine,
+        node.costPercent !== undefined ? fmtPct(node.costPercent) : undefined,
+        hasWarnings ? `${node.warnings.length} warning${node.warnings.length === 1 ? '' : 's'}` : undefined
+    ].filter((v): v is string => v !== undefined);
+    const titleAttr = hoverParts.length > 0 ? ` title="${escapeHtml(hoverParts.join(' · '))}"` : '';
+
     return `<div class="hnode-wrap">
         <button type="button" class="hnode${isHot ? ' hnode-hot' : ''}${node.traits.isSystemStep ? ' hnode-system' : ''}"
-            data-node-toggle data-node-id="${escapeHtml(node.id)}" aria-label="${escapeHtml(ariaLabel)}" aria-expanded="false">
+            data-node-toggle data-node-id="${escapeHtml(node.id)}" aria-label="${escapeHtml(ariaLabel)}" aria-expanded="false"${titleAttr}>
             <span class="hnode-pct">${fmtPct(node.costPercent)}</span>
-            <span class="hnode-ring" data-ring-color="${colorVar}" data-ring-pct="${pct}">
+            <span class="hnode-ring" title="${escapeHtml(OPERATOR_TYPE_LABEL[node.operatorType])}" data-ring-color="${colorVar}" data-ring-pct="${pct}">
                 <span class="hnode-badge">${escapeHtml(badge)}</span>
                 ${hasWarnings ? `<span class="hnode-warn" title="${escapeHtml(warnTitle)}" aria-hidden="true">⚠</span>` : ''}
             </span>
             <span class="hnode-name">${escapeHtml(node.operatorLabel)}</span>
             <span class="hnode-type">${escapeHtml(node.operatorType.replace('_', ' '))}</span>
-            ${subLines.map(l => `<span class="hnode-sub">${escapeHtml(l)}</span>`).join('')}
+            ${subLineHtml}
         </button>
-        ${nodePopoverHtml(node)}
+        ${nodePopoverHtml(node, index)}
     </div>`;
 }
 
 /** The connector between one node and the next, labeled with the row count
  * actually flowing across it (the preceding node's real rowsOut) whenever
- * that value was reported. */
+ * that value was reported. Always built left-to-right ('→', finding 21) —
+ * this markup has no idea yet whether the browser will end up wrapping its
+ * row and reversing it; layoutFlowRows() below corrects the glyph (never
+ * the count text) once it knows. */
 function hconnHtml(prevNode: PlanNode): string {
     const label = prevNode.rowsOut !== undefined
-        ? `<span class="hconn-label">${escapeHtml(fmtRows(prevNode.rowsOut))} rows</span>`
+        ? `<span class="hconn-label">→ ${escapeHtml(fmtRows(prevNode.rowsOut))} row${prevNode.rowsOut === 1 ? '' : 's'}</span>`
         : '';
     return `<div class="hconn"><div class="hconn-line"></div>${label}</div>`;
+}
+
+/** Rail order, most actionable first (finding 16): a real spill or a
+ * dominant network move is always worth looking at; row/duration skew is
+ * only as worth looking at as how far it strayed from the average, so
+ * those two tiers order by impact rather than plan position. */
+const WARNING_PRIORITY: Record<PlanWarning['type'], number> = {
+    SPILLED_TO_DISK: 0,
+    LARGE_REDISTRIBUTION: 1,
+    HIGH_DURATION_SKEW: 2,
+    HIGH_SKEW: 3,
+    ROW_ESTIMATE_MISMATCH: 4
+};
+
+/** (max - avg) / avg * max — the same ratio computeWarnings() itself used to
+ * decide whether a skew warning fires at all, times the busiest node's raw
+ * value, so a wildly skewed but tiny count doesn't outrank a merely
+ * moderately skewed but enormous one. Both fields travel in `detail` already
+ * (see planWarnings.ts); non-skew warning types have no notion of impact and
+ * sort purely by WARNING_PRIORITY above. */
+function warningImpact(warning: PlanWarning): number {
+    const ratio = typeof warning.detail.ratio === 'number' ? warning.detail.ratio : 0;
+    if (warning.type === 'HIGH_SKEW') {
+        const max = typeof warning.detail.max === 'number' ? warning.detail.max : 0;
+        return ratio * max;
+    }
+    if (warning.type === 'HIGH_DURATION_SKEW') {
+        const max = typeof warning.detail.maxSeconds === 'number' ? warning.detail.maxSeconds : 0;
+        return ratio * max;
+    }
+    return 0;
+}
+
+/** Severity-sorted, not document order — see WARNING_PRIORITY/warningImpact
+ * above. Array.prototype.sort is spec-stable (ES2019+), so two warnings
+ * tied on both keys keep their original plan order rather than shuffling. */
+function sortedWarningItems(plan: Plan): Array<{ node: PlanNode; warning: PlanWarning }> {
+    const items = plan.nodes.flatMap(node => node.warnings.map(warning => ({ node, warning })));
+    return items.slice().sort((a, b) => {
+        const priorityDiff = WARNING_PRIORITY[a.warning.type] - WARNING_PRIORITY[b.warning.type];
+        return priorityDiff !== 0 ? priorityDiff : warningImpact(b.warning) - warningImpact(a.warning);
+    });
 }
 
 /** Every warning across the whole plan, listed once up front so they read as
@@ -152,7 +318,7 @@ function hconnHtml(prevNode: PlanNode): string {
  * for exactly the thing a plan viewer exists to surface. Each item is a
  * button that opens (and scrolls to) the popover for the node it came from. */
 function warningsSummaryHtml(plan: Plan): string {
-    const items = plan.nodes.flatMap(node => node.warnings.map(warning => ({ node, warning })));
+    const items = sortedWarningItems(plan);
     if (items.length === 0) {
         return '';
     }
@@ -175,16 +341,33 @@ function warningsSummaryHtml(plan: Plan): string {
  * orientation stats, then the category breakdown, then — only when
  * relevant — the PROFILE hint. Per-node detail lives in each node's own
  * popover, not here, so there's exactly one place to look for it. */
+/** Fixed reading order for the badge legend card below — not OperatorType's
+ * own declaration order in planModel.ts (which groups SYSTEM before SYNC);
+ * this instead groups the real data-flow operators first and the two
+ * non-operator kinds (Sync, System) last, ending on the deliberate
+ * catch-all Other. */
+const LEGEND_ORDER: OperatorType[] = ['SCAN', 'JOIN', 'GROUP_BY', 'SORT', 'NETWORK', 'DML', 'SYNC', 'SYSTEM', 'OTHER'];
+
 function sideRailHtml(plan: Plan): string {
     const clusterSize = planClusterSize(plan);
     const breakdown = planCategoryBreakdown(plan);
+    const opCount = plan.nodes.length;
+
+    // No new data: exactly the OPERATOR_BADGE/OPERATOR_TYPE_LABEL pairs
+    // every node already renders on its ring (see hnodeHtml) and its
+    // title-attribute hover legend (finding 5) — this just lists all nine
+    // in one place instead of requiring a click (or a hover) per operator
+    // type to learn what a badge glyph means.
+    const legendHtml = LEGEND_ORDER.map(type =>
+        `<div class="plan-legend-item"><span class="plan-legend-badge">${escapeHtml(OPERATOR_BADGE[type])}</span><span>${escapeHtml(OPERATOR_TYPE_LABEL[type])}</span></div>`
+    ).join('');
 
     const categoryHtml = breakdown.length > 0
         ? `<div class="hcat-bar">${breakdown.map(b =>
             `<span data-width="${b.percent}" data-color-var="${b.colorVar}" title="${escapeHtml(b.label)} ${b.percent.toFixed(0)}%"></span>`
         ).join('')}</div>
         <div class="hcat-legend">${breakdown.map(b =>
-            `<div><span><i data-color-var="${b.colorVar}"></i>${escapeHtml(b.label)}</span><span>${fmtPct(b.percent)}</span></div>`
+            `<div><span><i data-color-var="${b.colorVar}"></i>${escapeHtml(b.label)}</span><span>${fmtMs(b.durationSum)}</span><span>${fmtPct(b.percent)}</span></div>`
         ).join('')}</div>`
         : `<div class="hcat-empty">not available</div>`;
 
@@ -202,15 +385,36 @@ function sideRailHtml(plan: Plan): string {
         ${warningsSummaryHtml(plan)}
         <div class="plan-side-card">
             <h4>Profile overview</h4>
-            <div class="plan-side-row"><span>Source</span><span>${escapeHtml(planSourceLabel(plan.source))}</span></div>
+            <!-- Session/Statement first — together they're the composite
+                 key copied verbatim into a EXA_*_PROFILE_LAST_DAY /
+                 EXA_SQL_LAST_DAY cross-check (WHERE SESSION_ID = ... AND
+                 STMT_ID = ...), and that pair's own order follows those
+                 views' own column order (SESSION_ID precedes STMT_ID) —
+                 Session also being the wider of the two keys. Facts about
+                 the plan itself come next; Source, a provenance caveat
+                 rather than something about the query, comes last. -->
+            <div class="plan-side-row"><span>Session</span><span>${escapeHtml(plan.sessionId)}</span></div>
+            <div class="plan-side-row" title="Serial number of the statement within its session"><span>Statement</span><span>${escapeHtml(plan.stmtId)}</span></div>
             <div class="plan-side-row"><span>Total time</span><span>${fmtMs(plan.totalDuration)}</span></div>
+            <div class="plan-side-row"><span>Operators</span><span>${opCount} operator${opCount === 1 ? '' : 's'}</span></div>
             <div class="plan-side-row"><span>Nodes observed</span><span>${clusterSize !== undefined ? clusterSize : 'not available'}</span></div>
+            <div class="plan-side-row"><span>Source</span><span>${escapeHtml(planSourceLabel(plan.source))}</span></div>
         </div>
         <div class="plan-side-card">
-            <h4>Time by category</h4>
+            <!-- This breakdown is always share-of-total (every node,
+                 bookkeeping included) — unlike a non-system node's own ring,
+                 whose share excludes system-step time (see costPercent in
+                 planModel.ts). The suffix says so directly instead of
+                 leaving the same operator reading as two silently
+                 contradictory percentages. -->
+            <h4>Time by category (of total)</h4>
             ${categoryHtml}
         </div>
         ${profileHintHtml}
+        <div class="plan-side-card">
+            <h4>Legend</h4>
+            <div class="plan-legend">${legendHtml}</div>
+        </div>
     </div>`;
 }
 
@@ -224,22 +428,26 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
     const flowInner = plan.nodes.length > 0
         ? `<div class="hflow-track">${plan.nodes.map((node, i) =>
             i === 0
-                ? hnodeHtml(node, node.id === hotId)
-                : `<div class="hstep">${hconnHtml(plan.nodes[i - 1])}${hnodeHtml(node, node.id === hotId)}</div>`
+                ? hnodeHtml(node, node.id === hotId, i)
+                : `<div class="hstep">${hconnHtml(plan.nodes[i - 1])}${hnodeHtml(node, node.id === hotId, i)}</div>`
         ).join('')}</div>`
         : '<p class="plan-empty">This statement produced no profiled operators.</p>';
 
     const textSummary = buildPlanTextSummary(plan);
-    const opCount = plan.nodes.length;
 
+    // No statement/total/operator-count summary here any more — it duplicated
+    // the Profile overview rail (see sideRailHtml), which is now the single
+    // source for all of it. This strip is just the toolbar row: the
+    // Query-text toggle (when there's query text to toggle) on the left,
+    // Copy-as-text on the right, sharing one row instead of two near-empty
+    // ones. The .plan-sql pre itself stays outside this row, directly below
+    // it, so toggling it doesn't disturb the toolbar's own height.
     return `
     <div class="plan-flow-caption">
-        <span>Statement ${escapeHtml(plan.stmtId)} · ${fmtMs(plan.totalDuration)} total · ${opCount} operator${opCount === 1 ? '' : 's'}</span>
+        ${plan.queryText ? '<button type="button" class="plan-sql-toggle" data-sql-toggle aria-expanded="false">▸ Query text</button>' : ''}
         <button type="button" class="plan-copy-btn" data-copy-plan>⧉ Copy as text</button>
     </div>
-    ${plan.queryText ? `
-    <button type="button" class="plan-sql-toggle" data-sql-toggle aria-expanded="false">▸ Query text</button>
-    <pre class="plan-sql" hidden>${escapeHtml(plan.queryText)}</pre>` : ''}
+    ${plan.queryText ? `<pre class="plan-sql" hidden>${escapeHtml(plan.queryText)}</pre>` : ''}
     <div class="plan-body">
         <div class="plan-flow-h">${flowInner}</div>
         ${sideRailHtml(plan)}
@@ -283,6 +491,15 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
             Array.prototype.slice.call(flowTrack.querySelectorAll('.hflow-drop')).forEach(function (drop) { drop.remove(); });
             Array.prototype.slice.call(flowTrack.querySelectorAll('.hconn.hconn-hidden')).forEach(function (conn) {
                 conn.classList.remove('hconn-hidden');
+            });
+            // A previous relayout may have flipped some of these to '←' for
+            // a reversed row (finding 21) — every real .hconn-label survives
+            // a reset (only the .hflow-drop ones just removed above were
+            // ever destroyed), so each one needs its arrow put back to the
+            // build-time default before the next measurement pass decides
+            // fresh which rows, if any, are reversed this time.
+            Array.prototype.slice.call(flowTrack.querySelectorAll('.hconn-label')).forEach(function (label) {
+                label.textContent = (label.textContent || '').replace(/^[→←]/, '→');
             });
             flowTrack.classList.remove('hflow-track-snaked');
         }
@@ -372,7 +589,16 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
                     if (labelText) {
                         var labelSpan = document.createElement('span');
                         labelSpan.className = 'hconn-label';
-                        labelSpan.textContent = labelText;
+                        // The drop is already a vertical connector — '↓',
+                        // not the carried-over '→' (finding 21), and never
+                        // the count text itself, which is untouched either
+                        // way. A literal space here, not \s — this whole
+                        // script is itself the body of an outer TS template
+                        // literal (see buildPlanContentHtml), which silently
+                        // drops the backslash off unrecognized string
+                        // escapes like \s before this regex source ever
+                        // reaches the browser.
+                        labelSpan.textContent = '↓ ' + labelText.replace(/^[→←] /, '');
                         dropConn.appendChild(labelSpan);
                     }
                     dropWrap.appendChild(dropConn);
@@ -382,6 +608,15 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
                 var rowEl = document.createElement('div');
                 rowEl.className = 'hflow-row' + (reversed ? ' hflow-row-reverse' : '');
                 rowItems.forEach(function (item) { rowEl.appendChild(item); });
+                if (reversed) {
+                    // Visual order reversed, so the connector's arrow has to
+                    // follow (finding 21) — only the glyph, never the count
+                    // text (see the regex, which touches only a leading
+                    // arrow character).
+                    Array.prototype.slice.call(rowEl.querySelectorAll('.hconn-label')).forEach(function (label) {
+                        label.textContent = (label.textContent || '').replace(/^→/, '←');
+                    });
+                }
                 flowTrack.appendChild(rowEl);
 
                 if (rowIndex > 0) {
@@ -425,21 +660,28 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
             document.querySelectorAll('[data-node-toggle]').forEach(function (n) { n.setAttribute('aria-expanded', 'false'); });
         }
 
-        // Vertical: flips to open *above* the node instead of below when
-        // there isn't enough room left in the visible flow area — but only
-        // when there's actually MORE room above than below. Blindly flipping
-        // whenever below didn't fit (the original logic) missed that
-        // scrollArea's getBoundingClientRect() is relative to the currently
-        // visible, scrolled viewport, not the whole flow: a node near the
-        // top of what's currently in view has just as little room above it,
-        // so flipping there ran the popover off the top of the scroll
-        // container and got clipped to a barely-visible sliver — confirmed
-        // against a real screenshot. Whichever side is picked, its height is
-        // also capped to what's actually available there (with its own
-        // scrollbar) so a popover that still doesn't fully fit is at least
-        // fully reachable, never silently clipped away by the container's
-        // own overflow. Horizontal: same edge-aware clamp as before, against
-        // the scroll viewport.
+        // Vertical: opens below by default, flipping above (.flip-up) only
+        // when below genuinely doesn't fit AND flipping is actually the
+        // better move — either above fits outright, or above simply has
+        // more room to work with than below (finding 18). The earlier
+        // "flip whenever spaceAbove > spaceBelow" rule flipped (and clamped
+        // with an internal scrollbar) even when the popover fit fully
+        // above outright, on plans where the two sides happened to be
+        // close — screenshots of a tall snaked plan showed bottom-row
+        // popovers scrolling internally with ample space sitting unused
+        // above them. Both spaceAbove/spaceBelow are already relative to
+        // the visible, scrolled slice of the flow (scrollArea's own
+        // getBoundingClientRect()), not the whole flow — a node near the
+        // top of what's in view has just as little room above it as below,
+        // so this still won't flip a popover off the top of the scroll
+        // container the way blindly flipping on "below didn't fit" alone
+        // used to. Whichever side is picked, its height is capped to what's
+        // actually available there, with its own scrollbar, and that cap is
+        // floored to a whole multiple of the popover's own line-height
+        // (finding 15) so the clamp never lands mid-line — a real
+        // screenshot showed the title row itself half-clipped right above
+        // the scrollbar it triggered. Horizontal: same edge-aware clamp as
+        // before, against the scroll viewport.
         function positionPopover(pop, node) {
             resetPopover(pop);
             if (!scrollArea) { return; }
@@ -452,7 +694,8 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
             var spaceBelow = areaRect.bottom - nodeRect.bottom;
             var spaceAbove = nodeRect.top - areaRect.top;
             var fitsBelow = popHeight + verticalGap <= spaceBelow;
-            var flip = !fitsBelow && spaceAbove > spaceBelow;
+            var fitsAbove = popHeight + verticalGap <= spaceAbove;
+            var flip = !fitsBelow && (fitsAbove || spaceAbove > spaceBelow);
 
             if (flip) {
                 pop.classList.add('flip-up');
@@ -460,7 +703,14 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
 
             var available = (flip ? spaceAbove : spaceBelow) - verticalGap;
             if (popHeight > available) {
-                pop.style.maxHeight = Math.max(available, 60) + 'px';
+                // 16px (VS Code's own default body line-height) is the
+                // fallback for when a real computed line-height isn't
+                // resolvable (e.g. this JSDOM test environment, which never
+                // loads the actual stylesheet).
+                var lineHeight = parseFloat(window.getComputedStyle(pop).lineHeight) || 16;
+                var cappedAvailable = Math.max(available, 60);
+                var flooredHeight = Math.floor(cappedAvailable / lineHeight) * lineHeight;
+                pop.style.maxHeight = Math.max(flooredHeight, 60) + 'px';
                 pop.style.overflowY = 'auto';
             }
 
@@ -499,15 +749,33 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
             return e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar';
         }
 
+        // Arrow-key walk between node buttons (finding 9): DOM order is
+        // logical flow order regardless of a snaked row's visual reversal
+        // (see layoutFlowRows above), so this needs no awareness of which
+        // row anything ended up on — the same index math works before and
+        // after a relayout.
+        function focusAdjacentNode(current, delta) {
+            var all = Array.prototype.slice.call(document.querySelectorAll('[data-node-toggle]'));
+            var idx = all.indexOf(current);
+            var target = all[idx + delta];
+            if (target && target.focus) { target.focus(); }
+        }
+
         document.querySelectorAll('[data-node-toggle]').forEach(function (node) {
             node.addEventListener('click', function (e) {
                 e.stopPropagation();
                 openPopoverFor(node);
             });
             node.addEventListener('keydown', function (e) {
-                if (!isActivationKey(e)) { return; }
-                e.preventDefault();
-                openPopoverFor(node);
+                if (isActivationKey(e)) {
+                    e.preventDefault();
+                    openPopoverFor(node);
+                    return;
+                }
+                if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                    e.preventDefault();
+                    focusAdjacentNode(node, e.key === 'ArrowRight' ? 1 : -1);
+                }
             });
         });
 
@@ -523,6 +791,23 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
             if (e.key === 'Escape') { closeAllPopovers(); }
         });
 
+        // Transient ring highlight on the node a warning jump lands on
+        // (finding 8) — the jump itself scrolls to and opens the node's
+        // popover, but once that's dismissed nothing marked which node it
+        // was. Clears any previous highlight first so only ever one node
+        // carries it, then times its own removal out so it reads as a
+        // pointer, not a permanent state change.
+        var highlightTimer;
+        function jumpHighlight(target) {
+            // Clears any pending removal first — jumping to the same node
+            // twice within the timeout window must not let the first timer
+            // remove the second jump's fresh highlight early.
+            clearTimeout(highlightTimer);
+            document.querySelectorAll('.hnode-jumped').forEach(function (n) { n.classList.remove('hnode-jumped'); });
+            target.classList.add('hnode-jumped');
+            highlightTimer = setTimeout(function () { target.classList.remove('hnode-jumped'); }, 1600);
+        }
+
         document.querySelectorAll('.plan-warning-item').forEach(function (item) {
             function activate() {
                 var id = item.getAttribute('data-jump-to');
@@ -530,6 +815,7 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
                 if (!target) { return; }
                 if (target.scrollIntoView) { target.scrollIntoView({ block: 'nearest', inline: 'nearest' }); }
                 openPopoverFor(target);
+                jumpHighlight(target);
                 if (target.focus) { target.focus(); }
             }
             item.addEventListener('click', function (e) { e.stopPropagation(); activate(); });
@@ -543,7 +829,12 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
         var sqlToggle = document.querySelector('[data-sql-toggle]');
         if (sqlToggle) {
             sqlToggle.addEventListener('click', function () {
-                var sql = sqlToggle.nextElementSibling;
+                // .plan-sql is no longer the toggle's own next sibling — the
+                // toggle now shares .plan-flow-caption with the copy button
+                // (the merged toolbar row) — but it's still the next sibling
+                // of that whole row, one level up.
+                var captionRow = sqlToggle.closest('.plan-flow-caption');
+                var sql = captionRow && captionRow.nextElementSibling;
                 if (!sql) { return; }
                 sql.hidden = !sql.hidden;
                 sqlToggle.textContent = (sql.hidden ? '▸' : '▾') + ' Query text';
@@ -560,12 +851,38 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
                 vscodeApi.postMessage({ command: 'copyPlanText', text: data.value });
             });
         }
+
+        // Per-node copy (finding 11): each popover carries its own hidden
+        // textarea (see nodePopoverHtml above) with exactly the text this
+        // button should post — no per-click DOM building or escaping, just
+        // reading a value that was already escaped once at render time.
+        // stopPropagation keeps the click from reaching the document-level
+        // "click anywhere closes the popover" handler, same as every other
+        // interactive element already inside the popover.
+        document.querySelectorAll('.plan-node-copy').forEach(function (btn) {
+            btn.addEventListener('click', function (e) {
+                e.stopPropagation();
+                var pop = btn.closest('[data-popover]');
+                var data = pop ? pop.querySelector('.plan-node-copy-data') : null;
+                var vscodeApi = window.__vscode || (window.acquireVsCodeApi && window.acquireVsCodeApi());
+                if (vscodeApi) { window.__vscode = vscodeApi; }
+                if (!vscodeApi || !data) { return; }
+                vscodeApi.postMessage({ command: 'copyPlanText', text: data.value });
+            });
+        });
     })();
     </script>`;
 }
 
 export function buildPlanContentCss(): string {
     return `
+        /* Query-text toggle (left, only when there's query text) and
+           Copy-as-text (right) share this one row now — used to be two
+           near-empty lines. space-between is enough to place both when the
+           toggle renders; .plan-copy-btn's own margin-left: auto below is
+           what keeps it pinned right even when the toggle doesn't (a lone
+           flex child under space-between has nothing to "space between"
+           and sits at the LEFT edge instead). */
         .plan-flow-caption {
             display: flex;
             justify-content: space-between;
@@ -578,7 +895,14 @@ export function buildPlanContentCss(): string {
             font-family: var(--vscode-editor-font-family);
         }
         .plan-copy-btn {
+            /* margin-left: auto, not just flex: none — this is what actually
+               guarantees the button sits flush right in BOTH cases (query
+               text present or not), since an auto margin claims all free
+               space on its side regardless of sibling count, where
+               justify-content: space-between alone only works once there
+               are two children to space apart. */
             flex: none;
+            margin-left: auto;
             font-size: 11px;
             padding: 3px 8px;
             border-radius: 4px;
@@ -594,8 +918,6 @@ export function buildPlanContentCss(): string {
             outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px;
         }
         .plan-sql-toggle {
-            display: inline-block;
-            margin: 6px 0 0 14px;
             font-size: 11px;
             font-family: inherit;
             background: none;
@@ -626,7 +948,12 @@ export function buildPlanContentCss(): string {
         }
 
         .plan-body { display: flex; flex: 1; min-height: 0; overflow: hidden; }
-        .plan-flow-h { flex: 1; min-width: 0; overflow: auto; padding: 30px 22px 200px; }
+        /* Bottom padding only needs to clear a popover on a bare one-row
+           plan now (finding 10) — the flip-up condition (see positionPopover
+           below) and its own internal scroll already guarantee a popover
+           stays reachable regardless of where it opens, so this no longer
+           has to reserve enough empty space to fit one below every node. */
+        .plan-flow-h { flex: 1; min-width: 0; overflow: auto; padding: 30px 22px 56px; }
         .plan-empty { color: var(--vscode-descriptionForeground); padding: 4px; }
         /* Wraps onto additional rows instead of forcing a long horizontal
            scroll for plans with many operators — each connector travels
@@ -707,6 +1034,18 @@ export function buildPlanContentCss(): string {
             content: ''; position: absolute; inset: 5px; border-radius: 50%;
             background-color: var(--vscode-editor-background);
         }
+        /* Transient marker for the node a warning-rail jump landed on
+           (finding 8) — class-based and removed by the script after ~1600ms
+           (see planWebview.ts), not a CSS animation/keyframe: the script
+           already owns the timing (it has to, to clear a *previous*
+           highlight first), so a keyframe here would just be a second clock
+           to keep in sync with the first. */
+        .hnode-jumped .hnode-ring {
+            outline: 2px solid var(--vscode-editorWarning-foreground, var(--vscode-charts-orange));
+            outline-offset: 3px;
+            border-radius: 50%;
+            transition: outline-color 0.3s;
+        }
         .hnode-badge {
             position: relative; z-index: 1; font-family: var(--vscode-editor-font-family);
             font-weight: 700; font-size: 12px; color: var(--vscode-foreground);
@@ -728,6 +1067,10 @@ export function buildPlanContentCss(): string {
             text-align: center; margin-top: 2px; max-width: 112px; overflow: hidden;
             text-overflow: ellipsis; white-space: nowrap;
         }
+        /* Temp-object caption, dimmed (finding 20) — see middleTruncateCaption's
+           isTempObject check above; PART_INFO already says "on TEMPORARY
+           table" for these, this just makes that legible without a click. */
+        .hnode-sub-temp { opacity: 0.65; font-style: italic; }
 
         .hconn { display: flex; flex-direction: column; align-items: center; flex: none; width: 44px; margin-top: 27px; }
         .hconn-line { width: 100%; height: 2px; background-color: var(--vscode-panel-border); position: relative; }
@@ -755,7 +1098,7 @@ export function buildPlanContentCss(): string {
         .plan-popover {
             position: absolute; left: 50%; transform: translateX(-50%);
             top: calc(100% + 12px);
-            width: 220px; background-color: var(--vscode-editorWidget-background);
+            width: 280px; background-color: var(--vscode-editorWidget-background);
             border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
             border-radius: 6px; padding: 8px 10px; box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
             z-index: 30; text-align: left; cursor: default;
@@ -779,11 +1122,28 @@ export function buildPlanContentCss(): string {
         .plan-popover[hidden] {
             display: none;
         }
-        .plan-popover-title { font-size: 12px; font-weight: 600; margin-bottom: 4px; word-break: break-word; }
+        .plan-popover-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+        .plan-popover-title { font-size: 12px; font-weight: 600; word-break: break-word; }
+        /* Per-node copy (finding 11) — same secondary-button look as the
+           whole-plan .plan-copy-btn up in the caption row, scaled down to
+           fit a 280px popover's title row. */
+        .plan-node-copy {
+            flex: none; font-size: 9.5px; font-family: inherit; padding: 2px 6px; border-radius: 4px;
+            border: 1px solid var(--vscode-button-border, var(--vscode-panel-border));
+            background-color: var(--vscode-button-secondaryBackground, transparent);
+            color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+            cursor: pointer;
+        }
+        .plan-node-copy:hover {
+            background-color: var(--vscode-button-secondaryHoverBackground, var(--vscode-list-hoverBackground));
+        }
+        .plan-node-copy:focus-visible {
+            outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px;
+        }
         /* Label stacked above value, not side-by-side: a long label (e.g.
            "Per-node rows") next to a long value (e.g. a Traits list, or the
            "not available" fallback) left almost no room for the value
-           column when squeezed side-by-side in a 220px popover, and
+           column when squeezed side-by-side in a 280px popover, and
            word-break: break-word chopped it mid-word ("not avai / labl / e")
            to fit — confirmed via a real screenshot. Full-width, top-aligned
            text wraps at normal word boundaries instead. */
@@ -808,17 +1168,42 @@ export function buildPlanContentCss(): string {
             margin: 0 0 8px; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em;
             color: var(--vscode-descriptionForeground); font-weight: 700;
         }
-        .plan-side-row { display: flex; justify-content: space-between; align-items: baseline; padding: 4px 0; font-size: 11.5px; }
+        /* flex-wrap: wrap is a no-op for every short value here (Source,
+           Total time, Nodes observed) — space-between still lands them on
+           one line same as before. It only matters for a full-length
+           SESSION_ID (up to 20 digits), which drops to its own line rather
+           than clipping against the rail's 208px width. */
+        .plan-side-row { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: baseline; padding: 4px 0; font-size: 11.5px; }
         .plan-side-row + .plan-side-row { border-top: 1px solid var(--vscode-panel-border); }
         .plan-side-row span:first-child { color: var(--vscode-descriptionForeground); }
-        .plan-side-row span:last-child { font-family: var(--vscode-editor-font-family); font-weight: 600; }
+        .plan-side-row span:last-child {
+            font-family: var(--vscode-editor-font-family); font-weight: 600; text-align: right;
+            /* A 20-digit SESSION_ID has no word boundary to break at —
+               overflow-wrap lets the browser break it as a last resort, once
+               the wrap above has already dropped it to its own line, instead
+               of it overflowing/clipping against the card edge. Same
+               word-boundary-first choice already made for .plan-detail-v in
+               the popover. min-width: 0 overrides the flex-item default of
+               auto, which would otherwise refuse to shrink below the
+               value's un-wrapped intrinsic width and defeat both of these. */
+            min-width: 0; overflow-wrap: break-word;
+        }
         .hcat-bar {
             display: flex; width: 100%; height: 7px; border-radius: 4px; overflow: hidden;
             margin: 2px 0 8px; background-color: var(--vscode-panel-border);
         }
         .hcat-bar span { display: block; height: 100%; }
         .hcat-legend { display: flex; flex-direction: column; gap: 4px; font-size: 10px; font-family: var(--vscode-editor-font-family); }
-        .hcat-legend div { display: flex; justify-content: space-between; }
+        /* Three spans per row now (label, absolute duration, percent) — a
+           plain justify-content: space-between would spread the duration
+           span across the middle of the row's free space instead of next to
+           the percent it belongs with. The label grows to fill whatever
+           room is left; duration/percent stay fixed-width and hug the right
+           edge together, with a small gap between the two of them. */
+        .hcat-legend div { display: flex; align-items: baseline; gap: 6px; }
+        .hcat-legend div span:first-child { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .hcat-legend div span:not(:first-child) { flex: none; }
+        .hcat-legend div span:nth-child(2) { color: var(--vscode-descriptionForeground); }
         .hcat-legend i { display: inline-block; width: 7px; height: 7px; border-radius: 2px; margin-right: 6px; vertical-align: -1px; }
         .hcat-empty { color: var(--vscode-descriptionForeground); font-size: 11px; }
         .plan-side-hint {
@@ -832,6 +1217,21 @@ export function buildPlanContentCss(): string {
             font-family: var(--vscode-editor-font-family);
             background-color: var(--vscode-textCodeBlock-background, var(--vscode-editorWidget-background));
             border-radius: 3px; padding: 1px 4px;
+        }
+
+        /* Badge legend: two columns read better than one long list in a
+           208px rail (see LEGEND_ORDER above) — grid, not flex-wrap, so a
+           short final row (9 items, an odd count) doesn't stretch its lone
+           item across the full width. */
+        .plan-legend { display: grid; grid-template-columns: 1fr 1fr; gap: 5px 10px; font-size: 10px; }
+        .plan-legend-item { display: flex; align-items: center; gap: 5px; color: var(--vscode-descriptionForeground); }
+        .plan-legend-badge {
+            display: inline-flex; align-items: center; justify-content: center; flex: none;
+            width: 14px; height: 14px; border-radius: 50%;
+            font-family: var(--vscode-editor-font-family); font-weight: 700; font-size: 9px;
+            color: var(--vscode-foreground);
+            background-color: var(--vscode-editorWidget-background);
+            border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
         }
 
         /* -- warnings summary: leads the rail, reads as fast as the hot node -- */

--- a/src/plan/planWebview.ts
+++ b/src/plan/planWebview.ts
@@ -289,7 +289,7 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
 
         // The x-center of an item's ring (its actual visual anchor), not the
         // item box as a whole — measured relative to the track, so it stays
-        // valid across whatever transform-shifting layoutFlowRows() below
+        // valid across whatever position-shifting layoutFlowRows() below
         // applies to earlier rows.
         function ringCenterX(item, trackRect) {
             var ring = item.querySelector('.hnode-ring') || item;
@@ -392,7 +392,15 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
                     dropConn.style.marginLeft = (targetX - dropWidth / 2) + 'px';
 
                     var currentX = ringCenterX(rowItems[0], trackRect);
-                    rowEl.style.transform = 'translateX(' + (targetX - currentX) + 'px)';
+                    // Must not be a CSS transform: a transform creates a new
+                    // stacking context on this row, which traps the open
+                    // popover's z-index inside that row's own context —
+                    // later sibling rows (also stacking contexts, painted
+                    // later in DOM order) then draw over a popover that's
+                    // supposed to be on top. position: relative + left
+                    // shifts the row the same way without creating one.
+                    rowEl.style.position = 'relative';
+                    rowEl.style.left = (targetX - currentX) + 'px';
                 }
 
                 prevLastItem = rowItems[rowItems.length - 1];
@@ -653,10 +661,11 @@ export function buildPlanContentCss(): string {
            of the next no longer means anything spatially (see hconn-hidden
            below) — this vertical stub replaces it. Both its horizontal
            position (margin-left) and the following row's own position
-           (transform: translateX, on .hflow-row/.hflow-row-reverse above)
-           are computed in script from the actual measured position of the
-           ring the previous row ended on, not packed against the track's
-           edge. */
+           (position: relative + left, on .hflow-row/.hflow-row-reverse
+           above — NOT transform, which would create a stacking context
+           and trap a popover's z-index inside this row) are computed in
+           script from the actual measured position of the ring the
+           previous row ended on, not packed against the track's edge. */
         .hflow-drop { display: flex; width: 100%; margin: 2px 0; }
         .hflow-drop-connector {
             width: 118px; flex: none; display: flex; flex-direction: column; align-items: center; padding: 2px 0 6px;

--- a/src/plan/planWebview.ts
+++ b/src/plan/planWebview.ts
@@ -188,16 +188,13 @@ function sideRailHtml(plan: Plan): string {
         ).join('')}</div>`
         : `<div class="hcat-empty">not available</div>`;
 
-    // Shown only when nothing in the plan has CPU/Net at all — that's the
-    // signature of a session that ran without PROFILE turned on first (see
-    // planLacksDetailMetrics). Educates the user on how to get that detail
-    // next time, rather than silently leaving every CPU/Net/HDD write row
-    // looking broken with no explanation.
+    // Shown only when nothing in the plan has CPU/Net at all, which usually
+    // means profiling was not active for the session when this statement ran.
     const profileHintHtml = planLacksDetailMetrics(plan)
         ? `<div class="plan-side-card plan-side-hint">
             <h4>Want more detail?</h4>
-            <p>CPU, network, and disk metrics weren't captured for this run. Run
-            <code>ALTER SESSION SET PROFILE = 'ON'</code> before your query to see them next time.</p>
+            <p>CPU, network, and disk metrics weren't captured for this run. Reconnect with
+            execution plans enabled, then run the query again.</p>
         </div>`
         : '';
 
@@ -207,7 +204,7 @@ function sideRailHtml(plan: Plan): string {
             <h4>Profile overview</h4>
             <div class="plan-side-row"><span>Source</span><span>${escapeHtml(planSourceLabel(plan.source))}</span></div>
             <div class="plan-side-row"><span>Total time</span><span>${fmtMs(plan.totalDuration)}</span></div>
-            <div class="plan-side-row"><span>Nodes</span><span>${clusterSize !== undefined ? clusterSize : 'not available'}</span></div>
+            <div class="plan-side-row"><span>Nodes observed</span><span>${clusterSize !== undefined ? clusterSize : 'not available'}</span></div>
         </div>
         <div class="plan-side-card">
             <h4>Time by category</h4>
@@ -321,9 +318,7 @@ export function buildPlanContentHtml(plan: Plan, nonce: string): string {
         // edge-packing only lines up with the previous row by coincidence,
         // since a row's real content width is whatever fit before it
         // wrapped, which is essentially never exactly the track's full
-        // width (confirmed against a real screenshot: the drop arrow and
-        // the next row's node both landed visibly off-center from the ring
-        // above them).
+        // width.
         function layoutFlowRows() {
             if (!flowTrack) { return; }
             resetFlowRows();
@@ -647,12 +642,8 @@ export function buildPlanContentCss(): string {
            on the wrong side of it once the row reads right-to-left. -- */
         .hflow-row { display: flex; align-items: flex-start; width: 100%; }
         /* No justify-content here: row-reverse already swaps which edge is
-           "main-start" to the right, so the default flex-start packs this
-           row's content flush against the right edge on its own. Adding an
-           explicit flex-end would target "main-end", which row-reverse has
-           just swapped to mean the LEFT edge — undoing the whole point of
-           reversing the row (confirmed against a real screenshot: it sent
-           the row's lone item straight back to the far left). */
+           "main-start" to the right, so default flex-start packs this row's
+           content flush against the right edge on its own. */
         .hflow-row-reverse { flex-direction: row-reverse; }
         .hflow-row-reverse .hstep { flex-direction: row-reverse; }
         .hflow-row-reverse .hconn-line::after {
@@ -663,11 +654,9 @@ export function buildPlanContentCss(): string {
            below) — this vertical stub replaces it. Both its horizontal
            position (margin-left) and the following row's own position
            (transform: translateX, on .hflow-row/.hflow-row-reverse above)
-           are computed in script, from the actual measured position of the
-           ring the previous row ended on — not packed against the track's
-           edge, which only lines up by coincidence (confirmed against a
-           real screenshot: edge-packing left both the arrow and the next
-           row's node visibly off-center from the ring above them). */
+           are computed in script from the actual measured position of the
+           ring the previous row ended on, not packed against the track's
+           edge. */
         .hflow-drop { display: flex; width: 100%; margin: 2px 0; }
         .hflow-drop-connector {
             width: 118px; flex: none; display: flex; flex-direction: column; align-items: center; padding: 2px 0 6px;
@@ -855,12 +844,17 @@ export function buildPlanContentCss(): string {
 
 export interface PlanErrorViewOptions {
     message: string;
+    canRetry?: boolean;
 }
 
 export function buildPlanErrorHtml(options: PlanErrorViewOptions): string {
+    const retryHtml = options.canRetry
+        ? '<button type="button" class="plan-retry-btn" data-plan-retry>Retry</button>'
+        : '';
     return `<div class="plan-status-container">
         <div class="plan-status-title">⚠ Couldn't load the execution plan</div>
         <div class="plan-status-message">${escapeHtml(options.message)}</div>
+        ${retryHtml}
     </div>`;
 }
 
@@ -879,6 +873,22 @@ export function buildPlanStatusCss(): string {
             font-size: 12px;
             white-space: pre-wrap;
             color: var(--vscode-descriptionForeground);
+        }
+        .plan-retry-btn {
+            margin-top: 12px;
+            font-size: 12px;
+            padding: 4px 10px;
+            border-radius: 4px;
+            border: 1px solid var(--vscode-button-border, var(--vscode-panel-border));
+            background-color: var(--vscode-button-secondaryBackground, transparent);
+            color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+            cursor: pointer;
+        }
+        .plan-retry-btn:hover {
+            background-color: var(--vscode-button-secondaryHoverBackground, var(--vscode-list-hoverBackground));
+        }
+        .plan-retry-btn:focus-visible {
+            outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px;
         }
     `;
 }

--- a/src/plan/planWebview.ts
+++ b/src/plan/planWebview.ts
@@ -1,0 +1,884 @@
+/**
+ * Renders a normalized Plan as static HTML: a horizontal, left-to-right flow
+ * of operator nodes ordered by PART_ID (the one real ordering signal these
+ * profile views provide — see planModel.ts). No animation, no live updates;
+ * this is regenerated once per plan fetch, matching every other view in
+ * ResultsPanel. Horizontal rather than a vertical card stack because the
+ * Plan tab lives in VS Code's bottom panel container (wide, short), not a
+ * sidebar — see package.json's `panel` viewsContainers entry.
+ *
+ * Every free-text field on the model (query text, object names, remarks,
+ * part info) originates from the database and is escaped via escapeHtml()
+ * before being placed in the document — none of it is trusted input.
+ *
+ * Each node is a real <button>, and clicking it reveals a floating popover
+ * with its full detail — anchored right next to the node you clicked, not
+ * routed to a persistent panel elsewhere on screen (tried that; it worked,
+ * but lost the "detail appears right where I'm looking" immediacy of a
+ * popout, which is what this feature is actually for). The popover measures
+ * how much room is left below the node before it opens and flips to open
+ * *above* instead when there isn't enough (the same trick VS Code's own
+ * hover tooltips use) — that, not moving detail to a side panel, is the fix
+ * for a popover clipping against the bottom of the panel on a wrapped row.
+ * The popover is a sibling of the button (not nested inside it) so it never
+ * raises an interactive-content-inside-a-button question.
+ *
+ * When the flow has enough operators to wrap onto more than one row, the
+ * inline <script> below measures where the browser actually broke the rows
+ * (this depends on the panel's current width, so it can't be decided up
+ * front in this static markup) and restructures alternating rows to read in
+ * the opposite direction, continuing directly below where the previous row
+ * ended instead of restarting at the far left across a large gap.
+ */
+import { Plan, PlanNode, PlanWarning } from './planModel';
+import { escapeHtml } from '../utils';
+import {
+    fmtMs, fmtPct, fmtRows, fmtMiB, fmtCpuPct,
+    planSourceLabel, planClusterSize, planCategoryBreakdown, hottestNodeId, planLacksDetailMetrics,
+    OPERATOR_BADGE, OPERATOR_COLOR_VAR
+} from './planFormat';
+import { buildPlanTextSummary } from './planTextExport';
+
+const WARNING_LABEL: Record<PlanWarning['type'], string> = {
+    HIGH_SKEW: 'skew',
+    SPILLED_TO_DISK: 'spilled to disk',
+    LARGE_REDISTRIBUTION: 'large redistribution',
+    ROW_ESTIMATE_MISMATCH: 'row estimate mismatch'
+};
+
+function detailRow(label: string, value: string | undefined): string {
+    if (value === undefined) {
+        return '';
+    }
+    return `<div class="plan-detail-row"><span class="plan-detail-k">${escapeHtml(label)}</span><span class="plan-detail-v">${escapeHtml(value)}</span></div>`;
+}
+
+/** Full detail for one node, shown in its popover on click — identical
+ * field set regardless of how it's displayed. */
+function nodePopoverHtml(node: PlanNode): string {
+    const titleText = node.objectName
+        ? `${node.operatorLabel} — ${node.objectSchema ? `${node.objectSchema}.` : ''}${node.objectName}`
+        : node.operatorLabel;
+
+    const rows = [
+        detailRow('Part id', node.id),
+        detailRow('Operator', `${node.operatorLabel} (${node.operatorType})`),
+        detailRow('Object', node.objectSchema ? `${node.objectSchema}.${node.objectName ?? ''}` : node.objectName),
+        detailRow('Part info', node.partInfo),
+        detailRow('Remarks', node.remarks),
+        detailRow('Rows out', node.rowsOut !== undefined ? node.rowsOut.toLocaleString() : undefined),
+        detailRow('Duration', fmtMs(node.duration)),
+        detailRow('CPU', node.cpu !== undefined ? fmtCpuPct(node.cpu) : undefined),
+        detailRow('Net', fmtMiB(node.net)),
+        detailRow('Temp DB RAM peak', node.tempDbRamPeak !== undefined ? fmtMiB(node.tempDbRamPeak) : undefined),
+        detailRow('HDD write', fmtMiB(node.hddWrite)),
+        detailRow('Cost share', fmtPct(node.costPercent)),
+        detailRow(
+            'Per-node rows',
+            node.perNodeStats
+                ? `min ${node.perNodeStats.min} / max ${node.perNodeStats.max} / avg ${node.perNodeStats.avg.toFixed(0)} / nodes ${node.perNodeStats.nodeCount}`
+                : 'not available'
+        ),
+        detailRow(
+            'Traits',
+            Object.entries(node.traits).filter(([, v]) => v).map(([k]) => k).join(', ') || 'none'
+        )
+    ].filter(Boolean).join('');
+
+    const warningDetails = node.warnings.map(w =>
+        `<div class="plan-detail-row"><span class="plan-detail-k">Warning</span><span class="plan-detail-v">${escapeHtml(w.message)}</span></div>`
+    ).join('');
+
+    return `<div class="plan-popover" data-popover hidden>
+        <div class="plan-popover-title">${escapeHtml(titleText)}</div>
+        ${rows}${warningDetails}
+    </div>`;
+}
+
+/**
+ * One node in the horizontal flow: a ring (fill share = costPercent, red
+ * instead of the operator-type color when this is the plan's single
+ * highest-cost node), badge letter, name/type, and a short sub-caption. A
+ * real <button> (data-node-toggle/data-node-id, aria-expanded reflecting
+ * whether its popover is open) so activating it — click, Enter, or Space —
+ * opens that popover. The popover is a sibling in the same .hnode-wrap, not
+ * nested inside the button.
+ */
+function hnodeHtml(node: PlanNode, isHot: boolean): string {
+    const badge = OPERATOR_BADGE[node.operatorType] ?? '?';
+    const colorVar = isHot ? '--vscode-charts-red' : (OPERATOR_COLOR_VAR[node.operatorType] ?? '--vscode-descriptionForeground');
+    const pct = Math.max(0, Math.min(100, node.costPercent ?? 0));
+    const hasWarnings = node.warnings.length > 0;
+    const warnTitle = hasWarnings ? node.warnings.map(w => WARNING_LABEL[w.type] ?? w.type).join(', ') : '';
+
+    const subLines = [
+        node.duration !== undefined ? fmtMs(node.duration) : undefined,
+        node.objectName ? `${node.objectSchema ? node.objectSchema + '.' : ''}${node.objectName}` : undefined
+    ].filter((v): v is string => v !== undefined);
+
+    const typeWords = node.operatorType.replace('_', ' ').toLowerCase();
+    const warningSuffix = hasWarnings ? `, ${node.warnings.length} warning${node.warnings.length === 1 ? '' : 's'}` : '';
+    const ariaLabel = `${node.operatorLabel}, ${typeWords}, ${fmtPct(node.costPercent)} of total time${warningSuffix}`;
+
+    return `<div class="hnode-wrap">
+        <button type="button" class="hnode${isHot ? ' hnode-hot' : ''}${node.traits.isSystemStep ? ' hnode-system' : ''}"
+            data-node-toggle data-node-id="${escapeHtml(node.id)}" aria-label="${escapeHtml(ariaLabel)}" aria-expanded="false">
+            <span class="hnode-pct">${fmtPct(node.costPercent)}</span>
+            <span class="hnode-ring" data-ring-color="${colorVar}" data-ring-pct="${pct}">
+                <span class="hnode-badge">${escapeHtml(badge)}</span>
+                ${hasWarnings ? `<span class="hnode-warn" title="${escapeHtml(warnTitle)}" aria-hidden="true">⚠</span>` : ''}
+            </span>
+            <span class="hnode-name">${escapeHtml(node.operatorLabel)}</span>
+            <span class="hnode-type">${escapeHtml(node.operatorType.replace('_', ' '))}</span>
+            ${subLines.map(l => `<span class="hnode-sub">${escapeHtml(l)}</span>`).join('')}
+        </button>
+        ${nodePopoverHtml(node)}
+    </div>`;
+}
+
+/** The connector between one node and the next, labeled with the row count
+ * actually flowing across it (the preceding node's real rowsOut) whenever
+ * that value was reported. */
+function hconnHtml(prevNode: PlanNode): string {
+    const label = prevNode.rowsOut !== undefined
+        ? `<span class="hconn-label">${escapeHtml(fmtRows(prevNode.rowsOut))} rows</span>`
+        : '';
+    return `<div class="hconn"><div class="hconn-line"></div>${label}</div>`;
+}
+
+/** Every warning across the whole plan, listed once up front so they read as
+ * fast as the "hot" node does — a small ⚠ badge on a 46px ring, reachable
+ * only by opening each node's popover in turn, wasn't a fast enough signal
+ * for exactly the thing a plan viewer exists to surface. Each item is a
+ * button that opens (and scrolls to) the popover for the node it came from. */
+function warningsSummaryHtml(plan: Plan): string {
+    const items = plan.nodes.flatMap(node => node.warnings.map(warning => ({ node, warning })));
+    if (items.length === 0) {
+        return '';
+    }
+
+    const itemsHtml = items.map(({ node, warning }) =>
+        `<button type="button" class="plan-warning-item" data-jump-to="${escapeHtml(node.id)}">
+            <span class="plan-warning-part">${escapeHtml(node.operatorLabel)} · part ${escapeHtml(node.id)}</span>
+            <span class="plan-warning-msg">${escapeHtml(warning.message)}</span>
+        </button>`
+    ).join('');
+
+    return `<div class="plan-side-card plan-side-warnings">
+        <h4>⚠ Warnings (${items.length})</h4>
+        ${itemsHtml}
+    </div>`;
+}
+
+/** Persistent right rail: stays fixed while the flow above scrolls/wraps.
+ * Plan-level summaries only — Warnings lead (most actionable), then
+ * orientation stats, then the category breakdown, then — only when
+ * relevant — the PROFILE hint. Per-node detail lives in each node's own
+ * popover, not here, so there's exactly one place to look for it. */
+function sideRailHtml(plan: Plan): string {
+    const clusterSize = planClusterSize(plan);
+    const breakdown = planCategoryBreakdown(plan);
+
+    const categoryHtml = breakdown.length > 0
+        ? `<div class="hcat-bar">${breakdown.map(b =>
+            `<span data-width="${b.percent}" data-color-var="${b.colorVar}" title="${escapeHtml(b.label)} ${b.percent.toFixed(0)}%"></span>`
+        ).join('')}</div>
+        <div class="hcat-legend">${breakdown.map(b =>
+            `<div><span><i data-color-var="${b.colorVar}"></i>${escapeHtml(b.label)}</span><span>${fmtPct(b.percent)}</span></div>`
+        ).join('')}</div>`
+        : `<div class="hcat-empty">not available</div>`;
+
+    // Shown only when nothing in the plan has CPU/Net at all — that's the
+    // signature of a session that ran without PROFILE turned on first (see
+    // planLacksDetailMetrics). Educates the user on how to get that detail
+    // next time, rather than silently leaving every CPU/Net/HDD write row
+    // looking broken with no explanation.
+    const profileHintHtml = planLacksDetailMetrics(plan)
+        ? `<div class="plan-side-card plan-side-hint">
+            <h4>Want more detail?</h4>
+            <p>CPU, network, and disk metrics weren't captured for this run. Run
+            <code>ALTER SESSION SET PROFILE = 'ON'</code> before your query to see them next time.</p>
+        </div>`
+        : '';
+
+    return `<div class="plan-side">
+        ${warningsSummaryHtml(plan)}
+        <div class="plan-side-card">
+            <h4>Profile overview</h4>
+            <div class="plan-side-row"><span>Source</span><span>${escapeHtml(planSourceLabel(plan.source))}</span></div>
+            <div class="plan-side-row"><span>Total time</span><span>${fmtMs(plan.totalDuration)}</span></div>
+            <div class="plan-side-row"><span>Nodes</span><span>${clusterSize !== undefined ? clusterSize : 'not available'}</span></div>
+        </div>
+        <div class="plan-side-card">
+            <h4>Time by category</h4>
+            ${categoryHtml}
+        </div>
+        ${profileHintHtml}
+    </div>`;
+}
+
+export function buildPlanContentHtml(plan: Plan, nonce: string): string {
+    const hotId = hottestNodeId(plan);
+
+    // Each non-first node is grouped with its incoming connector in one
+    // .hstep so they wrap onto the next row together — otherwise flex-wrap
+    // can leave a connector arrow stranded at the end of a row pointing at
+    // a node that wrapped to the row below it.
+    const flowInner = plan.nodes.length > 0
+        ? `<div class="hflow-track">${plan.nodes.map((node, i) =>
+            i === 0
+                ? hnodeHtml(node, node.id === hotId)
+                : `<div class="hstep">${hconnHtml(plan.nodes[i - 1])}${hnodeHtml(node, node.id === hotId)}</div>`
+        ).join('')}</div>`
+        : '<p class="plan-empty">This statement produced no profiled operators.</p>';
+
+    const textSummary = buildPlanTextSummary(plan);
+    const opCount = plan.nodes.length;
+
+    return `
+    <div class="plan-flow-caption">
+        <span>Statement ${escapeHtml(plan.stmtId)} · ${fmtMs(plan.totalDuration)} total · ${opCount} operator${opCount === 1 ? '' : 's'}</span>
+        <button type="button" class="plan-copy-btn" data-copy-plan>⧉ Copy as text</button>
+    </div>
+    ${plan.queryText ? `
+    <button type="button" class="plan-sql-toggle" data-sql-toggle aria-expanded="false">▸ Query text</button>
+    <pre class="plan-sql" hidden>${escapeHtml(plan.queryText)}</pre>` : ''}
+    <div class="plan-body">
+        <div class="plan-flow-h">${flowInner}</div>
+        ${sideRailHtml(plan)}
+    </div>
+    <textarea id="plan-text-data" hidden>${escapeHtml(textSummary)}</textarea>
+    <script nonce="${nonce}">
+    (function () {
+        // The CSP here has no 'unsafe-hashes'/'unsafe-inline' on style-src, and a
+        // nonce on style-src only permits nonce'd <style> ELEMENTS, never inline
+        // style="" ATTRIBUTES on arbitrary markup — the browser silently drops
+        // them. So every per-node/per-segment color and percentage below is
+        // carried as data-* attributes and painted here via the CSSOM instead,
+        // which this already-nonce'd script is allowed to do.
+        document.querySelectorAll('.hnode-ring[data-ring-pct]').forEach(function (ring) {
+            var pct = ring.getAttribute('data-ring-pct');
+            var colorVar = ring.getAttribute('data-ring-color');
+            ring.style.background = 'conic-gradient(var(' + colorVar + ') 0% ' + pct + '%, var(--vscode-panel-border) ' + pct + '% 100%)';
+        });
+        document.querySelectorAll('.hcat-bar span[data-width]').forEach(function (segment) {
+            segment.style.width = segment.getAttribute('data-width') + '%';
+            segment.style.backgroundColor = 'var(' + segment.getAttribute('data-color-var') + ')';
+        });
+        document.querySelectorAll('.hcat-legend i[data-color-var]').forEach(function (swatch) {
+            swatch.style.backgroundColor = 'var(' + swatch.getAttribute('data-color-var') + ')';
+        });
+
+        var flowTrack = document.querySelector('.hflow-track');
+
+        // Pure CSS can't do this: where a row actually breaks depends on the
+        // panel's current width, which changes whenever the user resizes it,
+        // so row membership has to be measured after layout, not assumed up
+        // front. resetFlowRows() is idempotent so every relayout — the
+        // initial one and every later resize — starts from the original flat
+        // structure rather than restructuring an already-restructured one.
+        function resetFlowRows() {
+            if (!flowTrack) { return; }
+            Array.prototype.slice.call(flowTrack.querySelectorAll('.hflow-row')).forEach(function (row) {
+                Array.prototype.slice.call(row.children).forEach(function (child) { flowTrack.appendChild(child); });
+                row.remove();
+            });
+            Array.prototype.slice.call(flowTrack.querySelectorAll('.hflow-drop')).forEach(function (drop) { drop.remove(); });
+            Array.prototype.slice.call(flowTrack.querySelectorAll('.hconn.hconn-hidden')).forEach(function (conn) {
+                conn.classList.remove('hconn-hidden');
+            });
+            flowTrack.classList.remove('hflow-track-snaked');
+        }
+
+        // The x-center of an item's ring (its actual visual anchor), not the
+        // item box as a whole — measured relative to the track, so it stays
+        // valid across whatever transform-shifting layoutFlowRows() below
+        // applies to earlier rows.
+        function ringCenterX(item, trackRect) {
+            var ring = item.querySelector('.hnode-ring') || item;
+            var rect = ring.getBoundingClientRect();
+            return (rect.left + rect.right) / 2 - trackRect.left;
+        }
+
+        // Groups the flow's top-level items (the bare first node, then one
+        // .hstep per remaining node) into rows by their measured offsetTop,
+        // then — only when there's more than one row — wraps each row in its
+        // own .hflow-row, reversing alternate ones (.hflow-row-reverse flips
+        // both the row's own direction and, via a descendant selector, each
+        // .hstep's internal [connector, node] order and arrow direction, so
+        // the connector still lands on the correct side of its node once the
+        // row reads right-to-left). The .hconn that used to sit between the
+        // last node of one row and the first node of the next no longer
+        // means anything (those nodes aren't adjacent on screen anymore) —
+        // it's hidden (not removed, so a later relayout with a different
+        // wrap point can bring it back) and replaced with a short vertical
+        // .hflow-drop connector between the two rows, carrying over the same
+        // rows-out label.
+        //
+        // Both the drop connector and the next row itself are then
+        // positioned by MEASURING where the previous row's last ring
+        // actually ended up, not by packing against the track's edge —
+        // edge-packing only lines up with the previous row by coincidence,
+        // since a row's real content width is whatever fit before it
+        // wrapped, which is essentially never exactly the track's full
+        // width (confirmed against a real screenshot: the drop arrow and
+        // the next row's node both landed visibly off-center from the ring
+        // above them).
+        function layoutFlowRows() {
+            if (!flowTrack) { return; }
+            resetFlowRows();
+
+            var items = Array.prototype.slice.call(flowTrack.children).filter(function (el) {
+                return el.classList.contains('hnode-wrap') || el.classList.contains('hstep');
+            });
+            if (items.length === 0) { return; }
+
+            var rows = [];
+            var current = [];
+            var currentTop = null;
+            items.forEach(function (item) {
+                var top = item.offsetTop;
+                if (currentTop !== null && Math.abs(top - currentTop) > 2) {
+                    rows.push(current);
+                    current = [];
+                }
+                current.push(item);
+                currentTop = top;
+            });
+            if (current.length > 0) { rows.push(current); }
+
+            if (rows.length <= 1) { return; }
+
+            flowTrack.classList.add('hflow-track-snaked');
+
+            var prevLastItem = null;
+
+            rows.forEach(function (rowItems, rowIndex) {
+                var reversed = rowIndex % 2 === 1;
+                var dropConn = null;
+
+                if (rowIndex > 0) {
+                    var firstItem = rowItems[0];
+                    var oldConn = firstItem.querySelector('.hconn');
+                    var labelText = '';
+                    if (oldConn) {
+                        var oldLabel = oldConn.querySelector('.hconn-label');
+                        if (oldLabel) { labelText = oldLabel.textContent || ''; }
+                        oldConn.classList.add('hconn-hidden');
+                    }
+
+                    var dropWrap = document.createElement('div');
+                    dropWrap.className = 'hflow-drop';
+                    dropConn = document.createElement('div');
+                    dropConn.className = 'hflow-drop-connector';
+                    var dropLine = document.createElement('div');
+                    dropLine.className = 'hflow-drop-line';
+                    dropConn.appendChild(dropLine);
+                    if (labelText) {
+                        var labelSpan = document.createElement('span');
+                        labelSpan.className = 'hconn-label';
+                        labelSpan.textContent = labelText;
+                        dropConn.appendChild(labelSpan);
+                    }
+                    dropWrap.appendChild(dropConn);
+                    flowTrack.appendChild(dropWrap);
+                }
+
+                var rowEl = document.createElement('div');
+                rowEl.className = 'hflow-row' + (reversed ? ' hflow-row-reverse' : '');
+                rowItems.forEach(function (item) { rowEl.appendChild(item); });
+                flowTrack.appendChild(rowEl);
+
+                if (rowIndex > 0) {
+                    var trackRect = flowTrack.getBoundingClientRect();
+                    var targetX = ringCenterX(prevLastItem, trackRect);
+
+                    var dropWidth = dropConn.offsetWidth || 0;
+                    dropConn.style.marginLeft = (targetX - dropWidth / 2) + 'px';
+
+                    var currentX = ringCenterX(rowItems[0], trackRect);
+                    rowEl.style.transform = 'translateX(' + (targetX - currentX) + 'px)';
+                }
+
+                prevLastItem = rowItems[rowItems.length - 1];
+            });
+        }
+
+        layoutFlowRows();
+        window.addEventListener('resize', layoutFlowRows);
+
+        var scrollArea = document.querySelector('.plan-flow-h');
+
+        function resetPopover(pop) {
+            pop.classList.remove('flip-up');
+            pop.style.transform = '';
+            pop.style.removeProperty('--arrow-shift');
+            pop.style.maxHeight = '';
+            pop.style.overflowY = '';
+        }
+
+        function closeAllPopovers() {
+            document.querySelectorAll('[data-popover]').forEach(function (p) { p.hidden = true; resetPopover(p); });
+            document.querySelectorAll('[data-node-toggle]').forEach(function (n) { n.setAttribute('aria-expanded', 'false'); });
+        }
+
+        // Vertical: flips to open *above* the node instead of below when
+        // there isn't enough room left in the visible flow area — but only
+        // when there's actually MORE room above than below. Blindly flipping
+        // whenever below didn't fit (the original logic) missed that
+        // scrollArea's getBoundingClientRect() is relative to the currently
+        // visible, scrolled viewport, not the whole flow: a node near the
+        // top of what's currently in view has just as little room above it,
+        // so flipping there ran the popover off the top of the scroll
+        // container and got clipped to a barely-visible sliver — confirmed
+        // against a real screenshot. Whichever side is picked, its height is
+        // also capped to what's actually available there (with its own
+        // scrollbar) so a popover that still doesn't fully fit is at least
+        // fully reachable, never silently clipped away by the container's
+        // own overflow. Horizontal: same edge-aware clamp as before, against
+        // the scroll viewport.
+        function positionPopover(pop, node) {
+            resetPopover(pop);
+            if (!scrollArea) { return; }
+            var margin = 10;
+            var verticalGap = 16;
+            var nodeRect = node.getBoundingClientRect();
+            var areaRect = scrollArea.getBoundingClientRect();
+
+            var popHeight = pop.offsetHeight || 160;
+            var spaceBelow = areaRect.bottom - nodeRect.bottom;
+            var spaceAbove = nodeRect.top - areaRect.top;
+            var fitsBelow = popHeight + verticalGap <= spaceBelow;
+            var flip = !fitsBelow && spaceAbove > spaceBelow;
+
+            if (flip) {
+                pop.classList.add('flip-up');
+            }
+
+            var available = (flip ? spaceAbove : spaceBelow) - verticalGap;
+            if (popHeight > available) {
+                pop.style.maxHeight = Math.max(available, 60) + 'px';
+                pop.style.overflowY = 'auto';
+            }
+
+            var popRect = pop.getBoundingClientRect();
+            var shift = 0;
+            if (popRect.left < areaRect.left + margin) {
+                shift = (areaRect.left + margin) - popRect.left;
+            } else if (popRect.right > areaRect.right - margin) {
+                shift = (areaRect.right - margin) - popRect.right;
+            }
+            if (shift !== 0) {
+                pop.style.transform = 'translateX(-50%) translateX(' + shift + 'px)';
+                pop.style.setProperty('--arrow-shift', shift + 'px');
+            }
+        }
+
+        function openPopoverFor(node) {
+            var pop = node.parentElement.querySelector('[data-popover]');
+            if (!pop) { return; }
+            var wasOpen = !pop.hidden;
+            closeAllPopovers();
+            if (!wasOpen) {
+                pop.hidden = false;
+                node.setAttribute('aria-expanded', 'true');
+                positionPopover(pop, node);
+            }
+        }
+
+        // Real <button> elements already activate on Enter/Space in every
+        // real browser (this webview runs in Chromium via VS Code, a fully
+        // spec-compliant engine) — the keydown handler below is defensive
+        // belt-and-suspenders, not a workaround for a real gap, and it
+        // guarantees Space never also scrolls the panel the way it can on a
+        // non-button focusable element.
+        function isActivationKey(e) {
+            return e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar';
+        }
+
+        document.querySelectorAll('[data-node-toggle]').forEach(function (node) {
+            node.addEventListener('click', function (e) {
+                e.stopPropagation();
+                openPopoverFor(node);
+            });
+            node.addEventListener('keydown', function (e) {
+                if (!isActivationKey(e)) { return; }
+                e.preventDefault();
+                openPopoverFor(node);
+            });
+        });
+
+        document.querySelectorAll('[data-popover]').forEach(function (pop) {
+            // A click inside the open popover (e.g. to select its text) must
+            // not bubble to the document-level "click anywhere closes it"
+            // handler below.
+            pop.addEventListener('click', function (e) { e.stopPropagation(); });
+        });
+
+        document.addEventListener('click', closeAllPopovers);
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') { closeAllPopovers(); }
+        });
+
+        document.querySelectorAll('.plan-warning-item').forEach(function (item) {
+            function activate() {
+                var id = item.getAttribute('data-jump-to');
+                var target = document.querySelector('.hnode[data-node-id="' + id + '"]');
+                if (!target) { return; }
+                if (target.scrollIntoView) { target.scrollIntoView({ block: 'nearest', inline: 'nearest' }); }
+                openPopoverFor(target);
+                if (target.focus) { target.focus(); }
+            }
+            item.addEventListener('click', function (e) { e.stopPropagation(); activate(); });
+            item.addEventListener('keydown', function (e) {
+                if (!isActivationKey(e)) { return; }
+                e.preventDefault();
+                activate();
+            });
+        });
+
+        var sqlToggle = document.querySelector('[data-sql-toggle]');
+        if (sqlToggle) {
+            sqlToggle.addEventListener('click', function () {
+                var sql = sqlToggle.nextElementSibling;
+                if (!sql) { return; }
+                sql.hidden = !sql.hidden;
+                sqlToggle.textContent = (sql.hidden ? '▸' : '▾') + ' Query text';
+                sqlToggle.setAttribute('aria-expanded', sql.hidden ? 'false' : 'true');
+            });
+        }
+        var copyBtn = document.querySelector('[data-copy-plan]');
+        if (copyBtn) {
+            copyBtn.addEventListener('click', function () {
+                var vscodeApi = window.__vscode || (window.acquireVsCodeApi && window.acquireVsCodeApi());
+                if (vscodeApi) { window.__vscode = vscodeApi; }
+                var data = document.getElementById('plan-text-data');
+                if (!vscodeApi || !data) { return; }
+                vscodeApi.postMessage({ command: 'copyPlanText', text: data.value });
+            });
+        }
+    })();
+    </script>`;
+}
+
+export function buildPlanContentCss(): string {
+    return `
+        .plan-flow-caption {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 14px;
+            border-bottom: 1px solid var(--vscode-panel-border);
+            font-size: 11px;
+            color: var(--vscode-descriptionForeground);
+            font-family: var(--vscode-editor-font-family);
+        }
+        .plan-copy-btn {
+            flex: none;
+            font-size: 11px;
+            padding: 3px 8px;
+            border-radius: 4px;
+            border: 1px solid var(--vscode-button-border, var(--vscode-panel-border));
+            background-color: var(--vscode-button-secondaryBackground, transparent);
+            color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+            cursor: pointer;
+        }
+        .plan-copy-btn:hover {
+            background-color: var(--vscode-button-secondaryHoverBackground, var(--vscode-list-hoverBackground));
+        }
+        .plan-copy-btn:focus-visible, .plan-sql-toggle:focus-visible {
+            outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px;
+        }
+        .plan-sql-toggle {
+            display: inline-block;
+            margin: 6px 0 0 14px;
+            font-size: 11px;
+            font-family: inherit;
+            background: none;
+            border: none;
+            padding: 0;
+            color: var(--vscode-textLink-foreground, var(--vscode-descriptionForeground));
+            cursor: pointer;
+            user-select: none;
+        }
+        .plan-sql-toggle:hover { text-decoration: underline; }
+        .plan-sql {
+            display: block;
+            margin: 6px 14px 0;
+            font-family: var(--vscode-editor-font-family);
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-break: break-word;
+            color: var(--vscode-descriptionForeground);
+            background-color: var(--vscode-textCodeBlock-background, var(--vscode-editorWidget-background));
+            border-radius: 4px;
+            padding: 8px 10px;
+        }
+        /* Explicit override, same reasoning as .plan-popover[hidden]
+           below — author "display" rules beat the browser's default
+           [hidden] handling, so it must be restated here too. */
+        .plan-sql[hidden] {
+            display: none;
+        }
+
+        .plan-body { display: flex; flex: 1; min-height: 0; overflow: hidden; }
+        .plan-flow-h { flex: 1; min-width: 0; overflow: auto; padding: 30px 22px 200px; }
+        .plan-empty { color: var(--vscode-descriptionForeground); padding: 4px; }
+        /* Wraps onto additional rows instead of forcing a long horizontal
+           scroll for plans with many operators — each connector travels
+           with its destination node in one .hstep flex item (below) so a
+           row never wraps with an arrow left pointing at nothing. */
+        .hflow-track { display: flex; flex-wrap: wrap; align-items: flex-start; width: 100%; row-gap: 28px; }
+        /* Once the script above finds the flow actually wrapped, it swaps
+           this to a plain vertical stack of .hflow-row children — each one
+           already the full width it needs, so flex-wrap above is no longer
+           relevant. */
+        .hflow-track-snaked { flex-direction: column; flex-wrap: nowrap; row-gap: 0; }
+        .hstep { display: flex; align-items: flex-start; flex: none; }
+
+        /* -- snake/boustrophedon row wrap: alternating rows read in the
+           opposite direction and start directly below where the previous
+           row ended, instead of restarting at the far left across a large
+           gap (a real complaint on a wide, many-operator plan). Reversing
+           just the row's own direction isn't enough — each .hstep's own
+           [connector, node] child order also has to flip via the descendant
+           selector below, or a node's incoming connector ends up rendered
+           on the wrong side of it once the row reads right-to-left. -- */
+        .hflow-row { display: flex; align-items: flex-start; width: 100%; }
+        /* No justify-content here: row-reverse already swaps which edge is
+           "main-start" to the right, so the default flex-start packs this
+           row's content flush against the right edge on its own. Adding an
+           explicit flex-end would target "main-end", which row-reverse has
+           just swapped to mean the LEFT edge — undoing the whole point of
+           reversing the row (confirmed against a real screenshot: it sent
+           the row's lone item straight back to the far left). */
+        .hflow-row-reverse { flex-direction: row-reverse; }
+        .hflow-row-reverse .hstep { flex-direction: row-reverse; }
+        .hflow-row-reverse .hconn-line::after {
+            right: auto; left: -1px; border-left: none; border-right: 6px solid var(--vscode-panel-border);
+        }
+        /* The connector between the last node of one row and the first node
+           of the next no longer means anything spatially (see hconn-hidden
+           below) — this vertical stub replaces it. Both its horizontal
+           position (margin-left) and the following row's own position
+           (transform: translateX, on .hflow-row/.hflow-row-reverse above)
+           are computed in script, from the actual measured position of the
+           ring the previous row ended on — not packed against the track's
+           edge, which only lines up by coincidence (confirmed against a
+           real screenshot: edge-packing left both the arrow and the next
+           row's node visibly off-center from the ring above them). */
+        .hflow-drop { display: flex; width: 100%; margin: 2px 0; }
+        .hflow-drop-connector {
+            width: 118px; flex: none; display: flex; flex-direction: column; align-items: center; padding: 2px 0 6px;
+        }
+        .hflow-drop-line { width: 2px; height: 18px; background-color: var(--vscode-panel-border); position: relative; }
+        .hflow-drop-line::after {
+            content: ''; position: absolute; left: 50%; bottom: -1px; transform: translateX(-50%);
+            width: 0; height: 0; border-left: 4px solid transparent; border-right: 4px solid transparent;
+            border-top: 6px solid var(--vscode-panel-border);
+        }
+        /* .hconn.hconn-hidden (two classes), not .hconn-hidden alone: .hconn's
+           own display:flex rule below is also a single-class selector, so a
+           same-specificity override here would be a tie the browser resolves
+           by source order — fragile, and exactly the bug this already was
+           until caught against a real screenshot. Two classes beats one
+           regardless of where either rule sits in the sheet. */
+        .hconn.hconn-hidden { display: none; }
+
+        .hnode-wrap { display: flex; flex-direction: column; align-items: center; width: 118px; flex: none; position: relative; }
+        .hnode {
+            display: flex; flex-direction: column; align-items: center; width: 100%;
+            cursor: pointer; background: none; border: none; padding: 0; margin: 0; font: inherit; color: inherit;
+        }
+        .hnode:focus-visible {
+            outline: 2px solid var(--vscode-focusBorder); outline-offset: 3px; border-radius: 8px;
+        }
+        .hnode-system { opacity: 0.75; }
+        .hnode:hover .hnode-ring { filter: brightness(1.15); }
+        .hnode-pct {
+            font-family: var(--vscode-editor-font-family); font-size: 11px; font-weight: 700;
+            color: var(--vscode-descriptionForeground); margin-bottom: 5px;
+        }
+        .hnode-hot .hnode-pct { color: var(--vscode-charts-red); font-size: 13px; }
+        .hnode-ring {
+            width: 46px; height: 46px; border-radius: 50%; flex: none; position: relative;
+            display: flex; align-items: center; justify-content: center;
+        }
+        .hnode-ring::before {
+            content: ''; position: absolute; inset: 5px; border-radius: 50%;
+            background-color: var(--vscode-editor-background);
+        }
+        .hnode-badge {
+            position: relative; z-index: 1; font-family: var(--vscode-editor-font-family);
+            font-weight: 700; font-size: 12px; color: var(--vscode-foreground);
+        }
+        .hnode-hot .hnode-badge { color: var(--vscode-charts-red); }
+        .hnode-warn {
+            position: absolute; top: -2px; right: -2px; z-index: 2;
+            background-color: var(--vscode-editorWarning-foreground, var(--vscode-charts-orange));
+            color: var(--vscode-editor-background); font-size: 8px; line-height: 1; border-radius: 50%;
+            width: 13px; height: 13px; display: flex; align-items: center; justify-content: center;
+        }
+        .hnode-name { display: block; font-size: 11px; font-weight: 600; margin-top: 7px; text-align: center; line-height: 1.3; }
+        .hnode-type {
+            display: block; font-size: 8.5px; color: var(--vscode-descriptionForeground); text-transform: uppercase;
+            letter-spacing: 0.04em; margin-top: 1px;
+        }
+        .hnode-sub {
+            display: block; font-size: 9px; color: var(--vscode-descriptionForeground); font-family: var(--vscode-editor-font-family);
+            text-align: center; margin-top: 2px; max-width: 112px; overflow: hidden;
+            text-overflow: ellipsis; white-space: nowrap;
+        }
+
+        .hconn { display: flex; flex-direction: column; align-items: center; flex: none; width: 44px; margin-top: 27px; }
+        .hconn-line { width: 100%; height: 2px; background-color: var(--vscode-panel-border); position: relative; }
+        .hconn-line::after {
+            content: ''; position: absolute; right: -1px; top: 50%; transform: translateY(-50%);
+            width: 0; height: 0; border-top: 4px solid transparent; border-bottom: 4px solid transparent;
+            border-left: 6px solid var(--vscode-panel-border);
+        }
+        .hconn-label {
+            margin-top: 6px; background-color: var(--vscode-editorWidget-background);
+            border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+            color: var(--vscode-foreground); font-family: var(--vscode-editor-font-family);
+            font-weight: 700; font-size: 9.5px; padding: 2px 7px; border-radius: 9px; white-space: nowrap;
+        }
+
+        /* -- click-to-reveal popover: a sibling of the node button in
+           .hnode-wrap, not nested inside it. Flips to open above the node
+           (.flip-up) instead of below when there isn't enough room left in
+           the visible flow area — the actual fix for a popover clipping
+           against the row beneath it once the flow could wrap onto multiple
+           rows (a prior version routed detail to a persistent side panel
+           instead of fixing this directly; that traded away the "detail
+           appears right where you clicked" immediacy this feature is
+           actually for, so it's back to a fixed popover). -- */
+        .plan-popover {
+            position: absolute; left: 50%; transform: translateX(-50%);
+            top: calc(100% + 12px);
+            width: 220px; background-color: var(--vscode-editorWidget-background);
+            border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+            border-radius: 6px; padding: 8px 10px; box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+            z-index: 30; text-align: left; cursor: default;
+            display: flex; flex-direction: column; gap: 3px;
+        }
+        .plan-popover.flip-up { top: auto; bottom: calc(100% + 12px); }
+        .plan-popover::before {
+            content: ''; position: absolute; top: -6px; left: calc(50% - var(--arrow-shift, 0px)); transform: translateX(-50%);
+            width: 0; height: 0; border-left: 6px solid transparent; border-right: 6px solid transparent;
+            border-bottom: 6px solid var(--vscode-widget-border, var(--vscode-panel-border));
+        }
+        .plan-popover.flip-up::before {
+            top: auto; bottom: -6px; border-bottom: none;
+            border-top: 6px solid var(--vscode-widget-border, var(--vscode-panel-border));
+        }
+        /* [hidden] is a plain (non-!important) UA-stylesheet rule, so the
+           class rule above — an author style setting display: flex — silently
+           overrides it without this explicit, higher-specificity override.
+           Same class of bug caught (via live screenshot) in earlier versions
+           of this file. */
+        .plan-popover[hidden] {
+            display: none;
+        }
+        .plan-popover-title { font-size: 12px; font-weight: 600; margin-bottom: 4px; word-break: break-word; }
+        /* Label stacked above value, not side-by-side: a long label (e.g.
+           "Per-node rows") next to a long value (e.g. a Traits list, or the
+           "not available" fallback) left almost no room for the value
+           column when squeezed side-by-side in a 220px popover, and
+           word-break: break-word chopped it mid-word ("not avai / labl / e")
+           to fit — confirmed via a real screenshot. Full-width, top-aligned
+           text wraps at normal word boundaries instead. */
+        .plan-detail-row { display: flex; flex-direction: column; gap: 1px; font-size: 11px; }
+        .plan-detail-k {
+            color: var(--vscode-descriptionForeground); font-size: 9.5px;
+            text-transform: uppercase; letter-spacing: 0.04em;
+        }
+        .plan-detail-v { text-align: left; overflow-wrap: break-word; font-family: var(--vscode-editor-font-family); }
+
+        /* -- persistent side rail: plan-level summaries only -- */
+        .plan-side {
+            width: 208px; flex: none; border-left: 1px solid var(--vscode-panel-border);
+            padding: 14px; overflow-y: auto; display: flex; flex-direction: column; gap: 12px;
+        }
+        .plan-side-card {
+            background-color: var(--vscode-editorWidget-background);
+            border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+            border-radius: 6px; padding: 10px 12px;
+        }
+        .plan-side-card h4 {
+            margin: 0 0 8px; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.06em;
+            color: var(--vscode-descriptionForeground); font-weight: 700;
+        }
+        .plan-side-row { display: flex; justify-content: space-between; align-items: baseline; padding: 4px 0; font-size: 11.5px; }
+        .plan-side-row + .plan-side-row { border-top: 1px solid var(--vscode-panel-border); }
+        .plan-side-row span:first-child { color: var(--vscode-descriptionForeground); }
+        .plan-side-row span:last-child { font-family: var(--vscode-editor-font-family); font-weight: 600; }
+        .hcat-bar {
+            display: flex; width: 100%; height: 7px; border-radius: 4px; overflow: hidden;
+            margin: 2px 0 8px; background-color: var(--vscode-panel-border);
+        }
+        .hcat-bar span { display: block; height: 100%; }
+        .hcat-legend { display: flex; flex-direction: column; gap: 4px; font-size: 10px; font-family: var(--vscode-editor-font-family); }
+        .hcat-legend div { display: flex; justify-content: space-between; }
+        .hcat-legend i { display: inline-block; width: 7px; height: 7px; border-radius: 2px; margin-right: 6px; vertical-align: -1px; }
+        .hcat-empty { color: var(--vscode-descriptionForeground); font-size: 11px; }
+        .plan-side-hint {
+            border-style: dashed;
+            border-color: var(--vscode-widget-border, var(--vscode-panel-border));
+        }
+        .plan-side-hint p {
+            margin: 0; font-size: 11px; line-height: 1.5; color: var(--vscode-descriptionForeground);
+        }
+        .plan-side-hint code {
+            font-family: var(--vscode-editor-font-family);
+            background-color: var(--vscode-textCodeBlock-background, var(--vscode-editorWidget-background));
+            border-radius: 3px; padding: 1px 4px;
+        }
+
+        /* -- warnings summary: leads the rail, reads as fast as the hot node -- */
+        .plan-side-warnings h4 { color: var(--vscode-editorWarning-foreground, var(--vscode-charts-orange)); }
+        .plan-warning-item {
+            display: block; width: 100%; text-align: left; background: none; border: none;
+            padding: 6px 0; margin: 0; font: inherit; color: inherit; cursor: pointer;
+        }
+        .plan-warning-item + .plan-warning-item { border-top: 1px solid var(--vscode-panel-border); }
+        .plan-warning-item:hover { background-color: var(--vscode-list-hoverBackground); }
+        .plan-warning-item:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 2px; }
+        .plan-warning-part {
+            display: block; font-size: 10px; font-weight: 600;
+            color: var(--vscode-editorWarning-foreground, var(--vscode-charts-orange)); margin-bottom: 2px;
+        }
+        .plan-warning-msg { display: block; font-size: 10.5px; color: var(--vscode-descriptionForeground); line-height: 1.4; }
+    `;
+}
+
+export interface PlanErrorViewOptions {
+    message: string;
+}
+
+export function buildPlanErrorHtml(options: PlanErrorViewOptions): string {
+    return `<div class="plan-status-container">
+        <div class="plan-status-title">⚠ Couldn't load the execution plan</div>
+        <div class="plan-status-message">${escapeHtml(options.message)}</div>
+    </div>`;
+}
+
+export function buildPlanLoadingHtml(): string {
+    return `<div class="plan-status-container">
+        <div class="plan-status-title">Fetching execution plan…</div>
+    </div>`;
+}
+
+export function buildPlanStatusCss(): string {
+    return `
+        .plan-status-container { padding: 20px; }
+        .plan-status-title { font-weight: 600; margin-bottom: 6px; }
+        .plan-status-message {
+            font-family: var(--vscode-editor-font-family);
+            font-size: 12px;
+            white-space: pre-wrap;
+            color: var(--vscode-descriptionForeground);
+        }
+    `;
+}

--- a/src/plan/profileRowNormalizer.ts
+++ b/src/plan/profileRowNormalizer.ts
@@ -7,7 +7,7 @@
  * what Exasol's profile columns are named.
  */
 import { Plan, PlanNode, PerNodeStat } from './planModel';
-import { classifyOperator } from './operatorTaxonomy';
+import { classifyOperator, OperatorClassification } from './operatorTaxonomy';
 import { computeWarnings, WarningThresholds, DEFAULT_WARNING_THRESHOLDS } from './planWarnings';
 
 /** One profile row, field names shared verbatim across all three source views
@@ -29,6 +29,8 @@ export interface RawProfileRow {
     cpu: number | undefined;
     tempDbRamPeak: number | undefined;
     hddWrite: number | undefined;
+    /** HDD_READ, MiB/s — see PlanNode.hddRead in planModel.ts. */
+    hddRead: number | undefined;
     net: number | undefined;
     remarks: string | undefined;
     sqlText: string | undefined;
@@ -73,6 +75,7 @@ export function mapDbRowToRawProfileRow(row: Record<string, unknown>): RawProfil
         cpu: toNumber(row.CPU),
         tempDbRamPeak: toNumber(row.TEMP_DB_RAM_PEAK),
         hddWrite: toNumber(row.HDD_WRITE),
+        hddRead: toNumber(row.HDD_READ),
         net: toNumber(row.NET),
         remarks: toStringOrUndefined(row.REMARKS),
         sqlText: toStringOrUndefined(row.SQL_TEXT)
@@ -89,38 +92,53 @@ function max(values: Array<number | undefined>): number | undefined {
     return defined.length > 0 ? Math.max(...defined) : undefined;
 }
 
+interface CollapsedGroup {
+    collapsed: RawProfileRow;
+    perNodeStats: PerNodeStat | undefined;
+    perNodeDurationStats: PerNodeStat | undefined;
+}
+
 /**
  * Collapses the rows for one PART_ID into a single representative row plus
  * (when the rows came from $EXA_PROFILE_DETAILS_LAST_DAY, i.e. carry IPROC)
- * a real per-node PerNodeStat on OUT_ROWS. Never invents a PerNodeStat for
- * rows that didn't actually carry a node identifier.
+ * real per-node PerNodeStats on OUT_ROWS and DURATION. Never invents a
+ * PerNodeStat for rows that didn't actually carry a node identifier.
  */
-function collapseGroup(rows: RawProfileRow[]): { collapsed: RawProfileRow; perNodeStats: PerNodeStat | undefined } {
+function collapseGroup(rows: RawProfileRow[]): CollapsedGroup {
     const first = rows[0];
     const isPerNode = rows.every(r => r.iproc !== undefined);
 
     const collapsed: RawProfileRow = {
         ...first,
-        objectRows: max(rows.map(r => r.objectRows)),
+        // Selectivity's numerator (see PlanNode.objectRows): in the
+        // per-IPROC details tier, OBJECT_ROWS is the node-local shard row
+        // count (verified live: a 176,792-row temp table reported
+        // OBJECT_ROWS 44,632 per node across 4 nodes), i.e. the same
+        // per-node scale as OUT_ROWS — so it must sum across rows exactly
+        // like OUT_ROWS does, not max. Summary tiers (one row per part, no
+        // IPROC) are unaffected either way. A prior max-vs-sum mismatch here
+        // mixed a per-node scale with a cluster scale and could render
+        // selectivity over 100%.
+        objectRows: sum(rows.map(r => r.objectRows)),
         outRows: sum(rows.map(r => r.outRows)),
         // The operator isn't done until its slowest node finishes.
         duration: max(rows.map(r => r.duration)),
         cpu: max(rows.map(r => r.cpu)),
         tempDbRamPeak: max(rows.map(r => r.tempDbRamPeak)),
         hddWrite: sum(rows.map(r => r.hddWrite)),
+        // HDD_READ is a per-node RATE (MiB/s), not a volume — summing rates
+        // across nodes would not mean anything, so it collapses the same way
+        // as duration/cpu: the max observed rate across nodes.
+        hddRead: max(rows.map(r => r.hddRead)),
         net: sum(rows.map(r => r.net))
     };
 
     if (!isPerNode) {
-        return { collapsed, perNodeStats: undefined };
+        return { collapsed, perNodeStats: undefined, perNodeDurationStats: undefined };
     }
 
     const rowCounts = rows.map(r => r.outRows).filter((v): v is number => v !== undefined);
-    if (rowCounts.length === 0) {
-        return { collapsed, perNodeStats: undefined };
-    }
-
-    const perNodeStats: PerNodeStat = {
+    const perNodeStats: PerNodeStat | undefined = rowCounts.length > 0 ? {
         metric: 'rows',
         min: Math.min(...rowCounts),
         max: Math.max(...rowCounts),
@@ -132,25 +150,47 @@ function collapseGroup(rows: RawProfileRow[]): { collapsed: RawProfileRow; perNo
         // fields summarize (e.g. an avg over 2 real values mislabeled as
         // spanning 3 nodes, understating the true skew ratio in the process).
         nodeCount: rowCounts.length
-    };
+    } : undefined;
 
-    return { collapsed, perNodeStats };
+    // Independent of perNodeStats above: a node group can have per-node
+    // DURATION values (every real IPROC row carries one) even when OUT_ROWS
+    // itself is missing, so this is computed from its own defined population
+    // rather than gated on rowCounts.
+    const durations = rows.map(r => r.duration).filter((v): v is number => v !== undefined);
+    const perNodeDurationStats: PerNodeStat | undefined = durations.length > 0 ? {
+        metric: 'duration',
+        min: Math.min(...durations),
+        max: Math.max(...durations),
+        avg: durations.reduce((a, b) => a + b, 0) / durations.length,
+        nodeCount: durations.length
+    } : undefined;
+
+    return { collapsed, perNodeStats, perNodeDurationStats };
 }
 
 function buildNode(
     partId: number,
     collapsed: RawProfileRow,
     perNodeStats: PerNodeStat | undefined,
+    perNodeDurationStats: PerNodeStat | undefined,
+    classification: OperatorClassification,
     totalDuration: number,
+    nonSystemDuration: number,
     thresholds: WarningThresholds
 ): PlanNode {
-    const { operatorType, traits } = classifyOperator(collapsed.partName);
-    const costPercent = totalDuration > 0 && collapsed.duration !== undefined
-        ? (collapsed.duration / totalDuration) * 100
+    const { operatorType, traits } = classification;
+    // See PlanNode.costPercent in planModel.ts: system steps divide by the
+    // whole plan (there is no more meaningful denominator for COMPILE/
+    // EXECUTE); every other node divides by totalDuration with system-step
+    // time already subtracted out, so bookkeeping no longer deflates every
+    // real operator's share.
+    const denominator = traits.isSystemStep ? totalDuration : nonSystemDuration;
+    const costPercent = denominator > 0 && collapsed.duration !== undefined
+        ? (collapsed.duration / denominator) * 100
         : undefined;
 
     const warnings = computeWarnings(
-        { traits, hddWrite: collapsed.hddWrite, net: collapsed.net, perNodeStats, costPercent },
+        { traits, hddWrite: collapsed.hddWrite, net: collapsed.net, perNodeStats, perNodeDurationStats, costPercent },
         thresholds
     );
 
@@ -163,14 +203,17 @@ function buildNode(
         objectName: collapsed.objectName,
         partInfo: collapsed.partInfo,
         remarks: collapsed.remarks,
+        objectRows: collapsed.objectRows,
         rowsOut: collapsed.outRows,
         duration: collapsed.duration,
         cpu: collapsed.cpu,
         net: collapsed.net,
         tempDbRamPeak: collapsed.tempDbRamPeak,
         hddWrite: collapsed.hddWrite,
+        hddRead: collapsed.hddRead,
         costPercent,
         perNodeStats,
+        perNodeDurationStats,
         warnings,
         // No parent/child column exists in any of these profile views — see
         // planModel.ts. Node ordering (by PART_ID) is the real signal.
@@ -206,10 +249,25 @@ export function normalizeProfileRows(
     const partIds = Array.from(byPartId.keys()).sort((a, b) => a - b);
     const collapsedByPartId = partIds.map(partId => ({ partId, ...collapseGroup(byPartId.get(partId)!) }));
 
-    const totalDuration = sum(collapsedByPartId.map(g => g.collapsed.duration)) ?? 0;
+    // Classified up front (not inside buildNode) because the F2 denominator
+    // below needs isSystemStep for every node before any node can be built.
+    const classifications = collapsedByPartId.map(g => classifyOperator(g.collapsed.partName));
 
-    const nodes = collapsedByPartId.map(g =>
-        buildNode(g.partId, g.collapsed, g.perNodeStats, totalDuration, thresholds)
+    // Plan.totalDuration itself is untouched by this — it stays wall-time
+    // over every node (system steps included) for the overview's "Total
+    // time" figure. nonSystemDuration is only ever used as costPercent's
+    // denominator for non-system nodes (see buildNode above).
+    const totalDuration = sum(collapsedByPartId.map(g => g.collapsed.duration)) ?? 0;
+    const systemDuration = sum(
+        collapsedByPartId.map((g, i) => classifications[i].traits.isSystemStep ? g.collapsed.duration : undefined)
+    ) ?? 0;
+    const nonSystemDuration = totalDuration - systemDuration;
+
+    const nodes = collapsedByPartId.map((g, i) =>
+        buildNode(
+            g.partId, g.collapsed, g.perNodeStats, g.perNodeDurationStats,
+            classifications[i], totalDuration, nonSystemDuration, thresholds
+        )
     );
 
     const perNodeStatsAvailable = nodes.some(n => n.perNodeStats !== undefined);

--- a/src/plan/profileRowNormalizer.ts
+++ b/src/plan/profileRowNormalizer.ts
@@ -1,0 +1,228 @@
+/**
+ * Pure normalization: raw EXA_*_PROFILE_* / $EXA_PROFILE_DETAILS_LAST_DAY
+ * rows -> the normalized Plan model (planModel.ts).
+ *
+ * Zero VS Code / driver dependencies by design, so this is testable with
+ * plain sample row data — this file is the only place that needs to know
+ * what Exasol's profile columns are named.
+ */
+import { Plan, PlanNode, PerNodeStat } from './planModel';
+import { classifyOperator } from './operatorTaxonomy';
+import { computeWarnings, WarningThresholds, DEFAULT_WARNING_THRESHOLDS } from './planWarnings';
+
+/** One profile row, field names shared verbatim across all three source views
+ * except iproc/inRows/memPeak which only $EXA_PROFILE_DETAILS_LAST_DAY provides. */
+export interface RawProfileRow {
+    /** Kept as an exact digit string — see Plan.sessionId/stmtId in planModel.ts. */
+    sessionId: string;
+    stmtId: string;
+    partId: number;
+    /** Node index within the cluster — present only from $EXA_PROFILE_DETAILS_LAST_DAY. */
+    iproc: number | undefined;
+    partName: string;
+    partInfo: string | undefined;
+    objectSchema: string | undefined;
+    objectName: string | undefined;
+    objectRows: number | undefined;
+    outRows: number | undefined;
+    duration: number | undefined;
+    cpu: number | undefined;
+    tempDbRamPeak: number | undefined;
+    hddWrite: number | undefined;
+    net: number | undefined;
+    remarks: string | undefined;
+    sqlText: string | undefined;
+}
+
+export type ProfileSource = Plan['source'];
+
+function toNumber(value: unknown): number | undefined {
+    if (value === null || value === undefined || value === '') {
+        return undefined;
+    }
+    const n = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+function toStringOrUndefined(value: unknown): string | undefined {
+    if (value === null || value === undefined) {
+        return undefined;
+    }
+    const s = String(value);
+    return s.length > 0 ? s : undefined;
+}
+
+/**
+ * Maps one raw driver row (column names as returned by getRowsFromResult,
+ * e.g. row.PART_ID) into the typed RawProfileRow shape. Tolerant of the
+ * driver returning numeric columns as strings.
+ */
+export function mapDbRowToRawProfileRow(row: Record<string, unknown>): RawProfileRow {
+    return {
+        sessionId: toStringOrUndefined(row.SESSION_ID) ?? '',
+        stmtId: toStringOrUndefined(row.STMT_ID) ?? '',
+        partId: toNumber(row.PART_ID) ?? 0,
+        iproc: toNumber(row.IPROC),
+        partName: toStringOrUndefined(row.PART_NAME) ?? 'UNKNOWN',
+        partInfo: toStringOrUndefined(row.PART_INFO),
+        objectSchema: toStringOrUndefined(row.OBJECT_SCHEMA),
+        objectName: toStringOrUndefined(row.OBJECT_NAME),
+        objectRows: toNumber(row.OBJECT_ROWS),
+        outRows: toNumber(row.OUT_ROWS),
+        duration: toNumber(row.DURATION),
+        cpu: toNumber(row.CPU),
+        tempDbRamPeak: toNumber(row.TEMP_DB_RAM_PEAK),
+        hddWrite: toNumber(row.HDD_WRITE),
+        net: toNumber(row.NET),
+        remarks: toStringOrUndefined(row.REMARKS),
+        sqlText: toStringOrUndefined(row.SQL_TEXT)
+    };
+}
+
+function sum(values: Array<number | undefined>): number | undefined {
+    const defined = values.filter((v): v is number => v !== undefined);
+    return defined.length > 0 ? defined.reduce((a, b) => a + b, 0) : undefined;
+}
+
+function max(values: Array<number | undefined>): number | undefined {
+    const defined = values.filter((v): v is number => v !== undefined);
+    return defined.length > 0 ? Math.max(...defined) : undefined;
+}
+
+/**
+ * Collapses the rows for one PART_ID into a single representative row plus
+ * (when the rows came from $EXA_PROFILE_DETAILS_LAST_DAY, i.e. carry IPROC)
+ * a real per-node PerNodeStat on OUT_ROWS. Never invents a PerNodeStat for
+ * rows that didn't actually carry a node identifier.
+ */
+function collapseGroup(rows: RawProfileRow[]): { collapsed: RawProfileRow; perNodeStats: PerNodeStat | undefined } {
+    const first = rows[0];
+    const isPerNode = rows.every(r => r.iproc !== undefined);
+
+    const collapsed: RawProfileRow = {
+        ...first,
+        objectRows: max(rows.map(r => r.objectRows)),
+        outRows: sum(rows.map(r => r.outRows)),
+        // The operator isn't done until its slowest node finishes.
+        duration: max(rows.map(r => r.duration)),
+        cpu: max(rows.map(r => r.cpu)),
+        tempDbRamPeak: max(rows.map(r => r.tempDbRamPeak)),
+        hddWrite: sum(rows.map(r => r.hddWrite)),
+        net: sum(rows.map(r => r.net))
+    };
+
+    if (!isPerNode) {
+        return { collapsed, perNodeStats: undefined };
+    }
+
+    const rowCounts = rows.map(r => r.outRows).filter((v): v is number => v !== undefined);
+    if (rowCounts.length === 0) {
+        return { collapsed, perNodeStats: undefined };
+    }
+
+    const perNodeStats: PerNodeStat = {
+        metric: 'rows',
+        min: Math.min(...rowCounts),
+        max: Math.max(...rowCounts),
+        avg: rowCounts.reduce((a, b) => a + b, 0) / rowCounts.length,
+        // Must be rowCounts.length, not rows.length: if some IPROC rows carry
+        // an undefined OUT_ROWS, min/max/avg above are only ever computed from
+        // rowCounts — using the larger rows.length here would describe a
+        // "nodeCount" that doesn't match the population the other three
+        // fields summarize (e.g. an avg over 2 real values mislabeled as
+        // spanning 3 nodes, understating the true skew ratio in the process).
+        nodeCount: rowCounts.length
+    };
+
+    return { collapsed, perNodeStats };
+}
+
+function buildNode(
+    partId: number,
+    collapsed: RawProfileRow,
+    perNodeStats: PerNodeStat | undefined,
+    totalDuration: number,
+    thresholds: WarningThresholds
+): PlanNode {
+    const { operatorType, traits } = classifyOperator(collapsed.partName);
+    const costPercent = totalDuration > 0 && collapsed.duration !== undefined
+        ? (collapsed.duration / totalDuration) * 100
+        : undefined;
+
+    const warnings = computeWarnings(
+        { traits, hddWrite: collapsed.hddWrite, net: collapsed.net, perNodeStats, costPercent },
+        thresholds
+    );
+
+    return {
+        id: String(partId),
+        operatorType,
+        operatorLabel: collapsed.partName,
+        traits,
+        objectSchema: collapsed.objectSchema,
+        objectName: collapsed.objectName,
+        partInfo: collapsed.partInfo,
+        remarks: collapsed.remarks,
+        rowsOut: collapsed.outRows,
+        duration: collapsed.duration,
+        cpu: collapsed.cpu,
+        net: collapsed.net,
+        tempDbRamPeak: collapsed.tempDbRamPeak,
+        hddWrite: collapsed.hddWrite,
+        costPercent,
+        perNodeStats,
+        warnings,
+        // No parent/child column exists in any of these profile views — see
+        // planModel.ts. Node ordering (by PART_ID) is the real signal.
+        children: []
+    };
+}
+
+/**
+ * Builds the normalized Plan from raw profile rows already scoped to one
+ * (sessionId, stmtId) — the caller (planProvider) is responsible for that
+ * filtering via SQL WHERE clauses; this function additionally defends by
+ * ignoring any row that doesn't match, rather than trusting the caller blindly.
+ */
+export function normalizeProfileRows(
+    rawRows: Record<string, unknown>[],
+    context: { sessionId: string; stmtId: string; source: ProfileSource },
+    thresholds: WarningThresholds = DEFAULT_WARNING_THRESHOLDS
+): Plan {
+    const rows = rawRows
+        .map(mapDbRowToRawProfileRow)
+        .filter(r => r.sessionId === context.sessionId && r.stmtId === context.stmtId);
+
+    const byPartId = new Map<number, RawProfileRow[]>();
+    for (const row of rows) {
+        const group = byPartId.get(row.partId);
+        if (group) {
+            group.push(row);
+        } else {
+            byPartId.set(row.partId, [row]);
+        }
+    }
+
+    const partIds = Array.from(byPartId.keys()).sort((a, b) => a - b);
+    const collapsedByPartId = partIds.map(partId => ({ partId, ...collapseGroup(byPartId.get(partId)!) }));
+
+    const totalDuration = sum(collapsedByPartId.map(g => g.collapsed.duration)) ?? 0;
+
+    const nodes = collapsedByPartId.map(g =>
+        buildNode(g.partId, g.collapsed, g.perNodeStats, totalDuration, thresholds)
+    );
+
+    const perNodeStatsAvailable = nodes.some(n => n.perNodeStats !== undefined);
+    const queryText = rows.find(r => r.sqlText !== undefined)?.sqlText;
+
+    return {
+        sessionId: context.sessionId,
+        stmtId: context.stmtId,
+        queryText,
+        totalDuration,
+        nodes,
+        edges: [],
+        perNodeStatsAvailable,
+        source: context.source
+    };
+}

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -44,8 +44,10 @@ export interface QueryResult {
  * forward from a known point rather than guess how many implicit
  * COMMIT/ROLLBACK statements land between this query and the identity
  * capture. Never throws — a failure here should never fail the query itself.
+ * Exported for objectActions.ts's previewTableData, which needs the same
+ * capture on its own driver/gating.
  */
-async function captureBaselineStatementIdentity(driver: ExasolDriver): Promise<{ sessionId?: string; baselineStmtId?: string }> {
+export async function captureBaselineStatementIdentity(driver: ExasolDriver): Promise<{ sessionId?: string; baselineStmtId?: string }> {
     return safeFetch('Failed to capture baseline session/statement id for plan lookup', async () => {
         const result = await rawQuery(driver, 'SELECT CURRENT_SESSION AS SID, CURRENT_STATEMENT AS STID');
         const rows = getRowsFromResult(result);

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -4,6 +4,7 @@ import { ConnectionManager } from './connectionManager';
 import { getColumnsFromResult, getRowsFromResult, rawQuery, rawExecute, extractColumnMetadata, extractColumnName, ColumnMetadata, stripCommentsPreservingStrings, safeFetch } from './utils';
 import { parseLocalCsvImport, resolveImportPath } from './localCsvImport';
 import { getOutputChannel } from './extension';
+import { isExecutionPlanEnabled } from './settings';
 
 export type { ColumnMetadata };
 
@@ -89,15 +90,12 @@ export class QueryExecutor {
             // a stalled import instead of hanging forever.
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver();
+                const shouldCapturePlanIdentity = isExecutionPlanEnabled()
+                    && (this.connectionManager.isExecutionPlanAvailable?.(activeConnection.id) ?? true);
 
-                // Same identity capture as every other execution path below
-                // (see captureBaselineStatementIdentity). A local CSV import
-                // is still a real IMPORT statement from Exasol's own
-                // perspective and still gets profiled — this branch just
-                // predates the Plan feature and was never wired up to record
-                // where to look the profile up afterward, unlike every other
-                // statement type.
-                const identity = await captureBaselineStatementIdentity(driver);
+                const identity = shouldCapturePlanIdentity
+                    ? await captureBaselineStatementIdentity(driver)
+                    : {};
                 const importStartTime = Date.now();
 
                 const absPath = resolveImportPath(localImport.filePath);
@@ -122,14 +120,21 @@ export class QueryExecutor {
             finalQuery += ` LIMIT ${maxRows}`;
         }
 
-        // Use centralized retry logic from ConnectionManager
+        // Use centralized retry logic from ConnectionManager. executeWithRetry
+        // acquires this connection's mutex (see runExclusive) before invoking
+        // this callback at all, and queryStartTime below is set only after
+        // getDriver() and the identity capture both finish — so executionTime
+        // reflects only the real statement's own round-trip, excluding both
+        // the identity-capture query and any time spent queued behind another
+        // in-flight operation on the same connection.
         return await this.connectionManager.executeWithRetry(async () => {
             const driver = await this.connectionManager.getDriver();
+            const shouldCapturePlanIdentity = isExecutionPlanEnabled()
+                && (this.connectionManager.isExecutionPlanAvailable?.(activeConnection.id) ?? true);
 
-            // Captured before the query runs (see captureBaselineStatementIdentity
-            // for why), on a fresh timer so this round-trip never inflates the
-            // executionTime shown to the user.
-            const identity = await captureBaselineStatementIdentity(driver);
+            const identity = shouldCapturePlanIdentity
+                ? await captureBaselineStatementIdentity(driver)
+                : {};
             const queryStartTime = Date.now();
 
             // Classify the query to determine which driver method to use

--- a/src/queryExecutor.ts
+++ b/src/queryExecutor.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
+import type { ExasolDriver } from '@exasol/exasol-driver-ts';
 import { ConnectionManager } from './connectionManager';
-import { getColumnsFromResult, getRowsFromResult, rawQuery, rawExecute, extractColumnMetadata, extractColumnName, ColumnMetadata, stripCommentsPreservingStrings } from './utils';
+import { getColumnsFromResult, getRowsFromResult, rawQuery, rawExecute, extractColumnMetadata, extractColumnName, ColumnMetadata, stripCommentsPreservingStrings, safeFetch } from './utils';
 import { parseLocalCsvImport, resolveImportPath } from './localCsvImport';
+import { getOutputChannel } from './extension';
 
 export type { ColumnMetadata };
 
@@ -11,6 +13,46 @@ export interface QueryResult {
     rows: any[];
     rowCount: number;
     executionTime: number;
+    /**
+     * SESSION_ID for this connection, and CURRENT_STATEMENT read *before* this
+     * query ran (exact digit strings — see plan/planModel.ts for why not
+     * `number`). Not the query's own STMT_ID: Exasol has no "id of the
+     * statement that just ran" primitive, since CURRENT_STATEMENT returns the
+     * id of whatever statement asks the question. planProvider.ts searches
+     * forward from this baseline for the query's real STMT_ID. Undefined if
+     * capture failed — the plan feature just won't be available for this
+     * result, everything else about the query is unaffected.
+     */
+    sessionId?: string;
+    baselineStmtId?: string;
+    /**
+     * Id of the connection this query actually ran on, captured at execution
+     * time. The plan lookup must run against *this* connection/session, not
+     * whichever connection happens to be active when the user later opens the
+     * Plan tab (a profile is only visible from the session that produced it —
+     * or, cross-session, only after propagation/flush). Undefined only for
+     * code paths that never populate session/statement ids anyway.
+     */
+    connectionId?: string;
+}
+
+/**
+ * Best-effort capture of the identifiers needed to look up this statement's
+ * profile data later (see src/plan/planProvider.ts). Runs as a round-trip on
+ * the same driver/session *before* the query, so planProvider can search
+ * forward from a known point rather than guess how many implicit
+ * COMMIT/ROLLBACK statements land between this query and the identity
+ * capture. Never throws — a failure here should never fail the query itself.
+ */
+async function captureBaselineStatementIdentity(driver: ExasolDriver): Promise<{ sessionId?: string; baselineStmtId?: string }> {
+    return safeFetch('Failed to capture baseline session/statement id for plan lookup', async () => {
+        const result = await rawQuery(driver, 'SELECT CURRENT_SESSION AS SID, CURRENT_STATEMENT AS STID');
+        const rows = getRowsFromResult(result);
+        if (rows.length === 0) {
+            return {};
+        }
+        return { sessionId: String(rows[0].SID), baselineStmtId: String(rows[0].STID) };
+    }, {}, getOutputChannel());
 }
 
 export class QueryExecutor {
@@ -27,8 +69,6 @@ export class QueryExecutor {
         const config = vscode.workspace.getConfiguration('exasol');
         const maxRows = config.get<number>('maxResultRows', 10000);
         const queryTimeoutMs = config.get<number>('queryTimeout', 300) * 1000;
-
-        const startTime = Date.now();
 
         // Clean the query - remove trailing semicolons and trim
         let finalQuery = query.trim().replace(/;+\s*$/, '').trim();
@@ -49,17 +89,30 @@ export class QueryExecutor {
             // a stalled import instead of hanging forever.
             return await this.connectionManager.executeWithRetry(async () => {
                 const driver = await this.connectionManager.getDriver();
+
+                // Same identity capture as every other execution path below
+                // (see captureBaselineStatementIdentity). A local CSV import
+                // is still a real IMPORT statement from Exasol's own
+                // perspective and still gets profiled — this branch just
+                // predates the Plan feature and was never wired up to record
+                // where to look the profile up afterward, unlike every other
+                // statement type.
+                const identity = await captureBaselineStatementIdentity(driver);
+                const importStartTime = Date.now();
+
                 const absPath = resolveImportPath(localImport.filePath);
                 const rowCount = await driver.importFromCsvFile(localImport.table, absPath, localImport.options);
 
-                const executionTime = Date.now() - startTime;
+                const executionTime = Date.now() - importStartTime;
 
                 return {
                     columns: [],
                     columnMetadata: [],
                     rows: [],
                     rowCount,
-                    executionTime
+                    executionTime,
+                    connectionId: activeConnection.id,
+                    ...identity
                 };
             }, undefined, { timeoutMs: queryTimeoutMs, ...(cancellationToken ? { cancellationToken } : {}) });
         }
@@ -73,6 +126,12 @@ export class QueryExecutor {
         return await this.connectionManager.executeWithRetry(async () => {
             const driver = await this.connectionManager.getDriver();
 
+            // Captured before the query runs (see captureBaselineStatementIdentity
+            // for why), on a fresh timer so this round-trip never inflates the
+            // executionTime shown to the user.
+            const identity = await captureBaselineStatementIdentity(driver);
+            const queryStartTime = Date.now();
+
             // Classify the query to determine which driver method to use
             const isResultSet = this.isResultSetQuery(finalQuery);
 
@@ -84,7 +143,7 @@ export class QueryExecutor {
                 // correctly and surface proper SQL error messages.
                 const result = await rawQuery(driver, finalQuery);
 
-                const executionTime = Date.now() - startTime;
+                const executionTime = Date.now() - queryStartTime;
                 const columnsMeta = getColumnsFromResult(result);
                 const rows = getRowsFromResult(result);
                 const columns = columnsMeta.map(extractColumnName);
@@ -95,13 +154,15 @@ export class QueryExecutor {
                     columnMetadata,
                     rows,
                     rowCount: rows.length,
-                    executionTime
+                    executionTime,
+                    connectionId: activeConnection.id,
+                    ...identity
                 };
             } else {
                 // Non-result-set commands (CREATE, ALTER, DROP, RENAME, INSERT, etc.) - use execute()
                 const rawExecuteResult = await rawExecute(driver, finalQuery);
 
-                const executionTime = Date.now() - startTime;
+                const executionTime = Date.now() - queryStartTime;
                 const columnsMeta = getColumnsFromResult(rawExecuteResult);
                 const rows = getRowsFromResult(rawExecuteResult);
                 const columns = columnsMeta.map(extractColumnName);
@@ -116,7 +177,9 @@ export class QueryExecutor {
                     columnMetadata,
                     rows,
                     rowCount: affectedRows,
-                    executionTime
+                    executionTime,
+                    connectionId: activeConnection.id,
+                    ...identity
                 };
             }
         }, undefined, cancellationToken ? { cancellationToken } : undefined);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export function isExecutionPlanEnabled(): boolean {
+    return vscode.workspace.getConfiguration('exasol').get<boolean>('executionPlan', true) !== false;
+}

--- a/src/test/helpers/mockConnectionManager.ts
+++ b/src/test/helpers/mockConnectionManager.ts
@@ -30,6 +30,23 @@ export function createRawResult(columns: string[], rows: any[][]): any {
     };
 }
 
+/**
+ * A raw-mode SQL-error response, exactly as the real driver hands one back
+ * for responseType: 'raw' — status: 'error' with NO throw (verified against
+ * node_modules/@exasol/exasol-driver-ts: it only calls verifyNoError(), which
+ * does the throwing, for the 'default' response type; 'raw' responses are
+ * returned as-is). Only getRowsFromResult() (or an equivalent explicit
+ * status check) surfaces this as a thrown error — a caller that discards a
+ * raw response without checking it will not see this failure at all.
+ */
+export function createRawErrorResult(sqlCode: string, text: string): any {
+    return {
+        status: 'error',
+        responseData: {},
+        exception: { sqlCode, text }
+    };
+}
+
 export function createEmptyRawResult(columns: string[]): any {
     return {
         status: 'ok',

--- a/src/test/local/planTabRenderer.test.ts
+++ b/src/test/local/planTabRenderer.test.ts
@@ -1,0 +1,76 @@
+import * as assert from 'assert';
+import { JSDOM } from 'jsdom';
+import { buildResultPlanTabBarHtml, buildResultPlanTabBarCss } from '../../panels/planTabRenderer';
+
+function parseDom(html: string): Document {
+    return new JSDOM(`<html><body>${html}</body></html>`).window.document;
+}
+
+suite('buildResultPlanTabBarHtml', () => {
+
+    test('renders exactly two tabs: Results and Plan', () => {
+        const doc = parseDom(buildResultPlanTabBarHtml('results', 'idle', 'n0nce'));
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.strictEqual(tabs.length, 2);
+        assert.strictEqual(tabs[0].querySelector('.rv-tab-label')!.textContent, 'Results');
+        assert.strictEqual(tabs[1].querySelector('.rv-tab-label')!.textContent, 'Plan');
+    });
+
+    test('marks the Results tab active when activeView is results', () => {
+        const doc = parseDom(buildResultPlanTabBarHtml('results', 'idle', 'n0nce'));
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.ok(tabs[0].classList.contains('active'));
+        assert.ok(!tabs[1].classList.contains('active'));
+    });
+
+    test('marks the Plan tab active when activeView is plan', () => {
+        const doc = parseDom(buildResultPlanTabBarHtml('plan', 'ready', 'n0nce'));
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.ok(!tabs[0].classList.contains('active'));
+        assert.ok(tabs[1].classList.contains('active'));
+    });
+
+    test('shows a loading label while the plan is being fetched', () => {
+        const doc = parseDom(buildResultPlanTabBarHtml('plan', 'loading', 'n0nce'));
+        const planLabel = doc.querySelectorAll('.rv-tab-label')[1].textContent;
+        assert.ok(planLabel!.includes('loading'));
+    });
+
+    test('applies the error class to the Plan tab when planStatus is error', () => {
+        const doc = parseDom(buildResultPlanTabBarHtml('plan', 'error', 'n0nce'));
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.ok(!tabs[0].classList.contains('error'));
+        assert.ok(tabs[1].classList.contains('error'));
+    });
+
+    test('tabs carry the correct data-view attribute for click handling', () => {
+        const doc = parseDom(buildResultPlanTabBarHtml('results', 'idle', 'n0nce'));
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.strictEqual(tabs[0].getAttribute('data-view'), 'results');
+        assert.strictEqual(tabs[1].getAttribute('data-view'), 'plan');
+    });
+
+    test('uses rv-tab / rv-tab-bar classes, never the unrelated tab/tab-bar classes', () => {
+        // These must stay distinct from tabBarRenderer.ts's classes so
+        // resultsGrid.tsx's generic .tab click handler never intercepts clicks
+        // meant for this tab strip.
+        const html = buildResultPlanTabBarHtml('results', 'idle', 'n0nce');
+        const doc = parseDom(html);
+        assert.strictEqual(doc.querySelectorAll('.tab').length, 0);
+        assert.strictEqual(doc.querySelectorAll('.tab-bar').length, 0);
+    });
+
+    test('the inline script carries the provided nonce', () => {
+        const html = buildResultPlanTabBarHtml('results', 'idle', 'abc123');
+        assert.ok(html.includes('nonce="abc123"'));
+    });
+});
+
+suite('buildResultPlanTabBarCss', () => {
+    test('returns non-empty CSS with the expected selectors', () => {
+        const css = buildResultPlanTabBarCss();
+        assert.ok(css.includes('.rv-tab-bar'));
+        assert.ok(css.includes('.rv-tab.active'));
+        assert.ok(css.includes('.rv-tab.error'));
+    });
+});

--- a/src/test/local/planWebview.test.ts
+++ b/src/test/local/planWebview.test.ts
@@ -74,14 +74,17 @@ function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
         objectName: undefined,
         partInfo: undefined,
         remarks: undefined,
+        objectRows: undefined,
         rowsOut: 100,
         duration: 0.01,
         cpu: 50,
         net: undefined,
         tempDbRamPeak: undefined,
         hddWrite: undefined,
+        hddRead: undefined,
         costPercent: 25,
         perNodeStats: undefined,
+        perNodeDurationStats: undefined,
         warnings: [],
         children: [],
         ...overrides
@@ -115,6 +118,37 @@ suite('buildPlanContentHtml', () => {
         assert.deepStrictEqual(names, ['SCAN', 'JOIN', 'SORT']);
     });
 
+    test('the ring carries a title attribute naming the operator type, as a cheap hover legend (finding 5)', () => {
+        const plan = makePlan([makeNode({ operatorType: 'GROUP_BY' })]);
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+        assert.strictEqual(doc.querySelector('.hnode-ring')!.getAttribute('title'), 'Group By');
+    });
+
+    test('the statement/total-time/operator-count summary lives only in the rail now, not the caption strip (finding 22, rail consolidation)', () => {
+        // The caption strip used to repeat "Statement N · X ms total · N
+        // operators" — the exact same numbers the Profile overview rail
+        // already showed for Total time (and, after this change, Statement
+        // and Operators too). The caption is now just the toolbar row: the
+        // copy button, nothing else.
+        const plan = makePlan([makeNode()], { stmtId: '39', totalDuration: 0.5 });
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+
+        const caption = doc.querySelector('.plan-flow-caption')!;
+        assert.ok(!caption.textContent!.includes('Statement 39'), 'the caption must no longer repeat the statement number');
+        assert.ok(!/\btotal\b/.test(caption.textContent!), 'the caption must no longer repeat the total time');
+        assert.ok(!/\boperator/.test(caption.textContent!), 'the caption must no longer repeat the operator count');
+        assert.ok(caption.querySelector('[data-copy-plan]'), 'the copy-as-text button must still render, unchanged');
+
+        // The explanatory title attribute (finding 22) migrated from the
+        // caption onto the rail's own Statement row.
+        const statementRow = Array.from(doc.querySelectorAll('.plan-side-row')).find(
+            el => el.querySelector('span:first-child')!.textContent === 'Statement'
+        );
+        assert.ok(statementRow, 'expected a Statement row in the Profile overview rail');
+        assert.strictEqual(statementRow!.getAttribute('title'), 'Serial number of the statement within its session');
+        assert.strictEqual(statementRow!.querySelector('span:last-child')!.textContent, '39');
+    });
+
     test('escapes a malicious operator label / object name / remarks / query text', () => {
         const evil = '<script>alert(1)</script>';
         const plan = makePlan(
@@ -139,6 +173,47 @@ suite('buildPlanContentHtml', () => {
         const plan = makePlan([makeNode()], { queryText: undefined });
         const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
         assert.strictEqual(doc.querySelector('.plan-sql'), null);
+    });
+
+    suite('merged toolbar row (finding 1, round 7)', () => {
+        test('with query text: the caption row hosts both the toggle (left) and the copy button (right)', () => {
+            const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const caption = doc.querySelector('.plan-flow-caption')!;
+            const toggle = caption.querySelector('[data-sql-toggle]');
+            const copyBtn = caption.querySelector('[data-copy-plan]');
+            assert.ok(toggle, 'expected the query-text toggle inside the merged row');
+            assert.ok(copyBtn, 'expected the copy button inside the merged row');
+            assert.strictEqual(toggle!.nextElementSibling, copyBtn, 'the toggle must precede the copy button in DOM order (left-to-right)');
+        });
+
+        test('without query text: the row renders with only the copy button, no toggle', () => {
+            const plan = makePlan([makeNode()], { queryText: undefined });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const caption = doc.querySelector('.plan-flow-caption')!;
+            assert.strictEqual(caption.querySelector('[data-sql-toggle]'), null);
+            assert.ok(caption.querySelector('[data-copy-plan]'), 'the copy button must still render');
+        });
+
+        test('the copy button is kept flush right via margin-left: auto, not justify-content alone (works with or without the toggle)', () => {
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.plan-copy-btn\s*\{[^}]*margin-left:\s*auto/.test(css),
+                'expected .plan-copy-btn to claim its own leading space via margin-left: auto, robust whether or not the toggle sibling renders'
+            );
+            assert.ok(
+                /\.plan-flow-caption\s*\{[^}]*justify-content:\s*space-between/.test(css),
+                'expected justify-content: space-between restored now the row has two children again when the toggle renders'
+            );
+        });
+
+        test('the query-text pre sits directly after the merged row, not nested inside it', () => {
+            const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const caption = doc.querySelector('.plan-flow-caption')!;
+            assert.strictEqual(caption.querySelector('.plan-sql'), null, '.plan-sql must not be nested inside the caption row');
+            assert.strictEqual(caption.nextElementSibling!.className, 'plan-sql', '.plan-sql must directly follow the merged row');
+        });
     });
 
     suite('collapsible query text', () => {
@@ -168,7 +243,11 @@ suite('buildPlanContentHtml', () => {
             const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
             const html = buildPlanContentHtml(plan, 'n0nce');
             assert.ok(html.includes('data-sql-toggle'));
-            assert.ok(html.includes('nextElementSibling'), 'expected the toggle to reference its sibling, not query the whole document');
+            // The toggle now shares .plan-flow-caption with the Copy button
+            // (the merged toolbar row, finding 1) so .plan-sql is no longer
+            // its own nextElementSibling — it's the next sibling of the
+            // whole caption row instead, reached via closest().
+            assert.ok(html.includes('closest') && html.includes('nextElementSibling'), 'expected the toggle to reference the caption row\'s sibling, not query the whole document');
         });
 
         test('clicking the toggle reveals the query text, flips the label, and updates aria-expanded (real script execution)', () => {
@@ -283,6 +362,31 @@ suite('buildPlanContentHtml', () => {
             assert.ok(doc.querySelector('.hconn'));
         });
 
+        test('pluralizes "row" correctly: singular for exactly 1, plural otherwise (finding 6)', () => {
+            // Prefixed with the default left-to-right arrow (finding 21) —
+            // see the "direction arrows" suite below for the reversed-row case.
+            const singular = parseDom(buildPlanContentHtml(
+                makePlan([makeNode({ id: '1', rowsOut: 1 }), makeNode({ id: '2' })]), 'n0nce'
+            ));
+            assert.strictEqual(singular.querySelector('.hconn-label')!.textContent, '→ 1 row');
+
+            const plural = parseDom(buildPlanContentHtml(
+                makePlan([makeNode({ id: '1', rowsOut: 0 }), makeNode({ id: '2' })]), 'n0nce'
+            ));
+            assert.strictEqual(plural.querySelector('.hconn-label')!.textContent, '→ 0 rows');
+
+            const many = parseDom(buildPlanContentHtml(
+                makePlan([makeNode({ id: '1', rowsOut: 500 }), makeNode({ id: '2' })]), 'n0nce'
+            ));
+            assert.strictEqual(many.querySelector('.hconn-label')!.textContent, '→ 500 rows');
+        });
+
+        test('the connector pill carries a direction arrow (finding 21)', () => {
+            const plan = makePlan([makeNode({ id: '1', rowsOut: 250 }), makeNode({ id: '2' })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hconn-label')!.textContent, '→ 250 rows');
+        });
+
         test('renders exactly nodeCount - 1 connectors', () => {
             const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' }), makeNode({ id: '3' })]);
             const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
@@ -309,6 +413,71 @@ suite('buildPlanContentHtml', () => {
             const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
             assert.strictEqual(doc.querySelector('.hstep'), null);
             assert.ok(doc.querySelector('.hnode'));
+        });
+    });
+
+    suite('node caption sub-line', () => {
+        suite('middle truncation of a long object caption (finding 19)', () => {
+            test('middle-truncates a long name, keeping the distinguishing tail rather than the leading half', () => {
+                const plan = makePlan([makeNode({ objectSchema: 'SYS', objectName: 'EXA_SESSION_ROLES' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const subs = Array.from(doc.querySelectorAll('.hnode-sub')).map(el => el.textContent);
+                assert.ok(subs.includes('SYS.EXA_…ION_ROLES'), `expected the middle-truncated caption, got: ${JSON.stringify(subs)}`);
+            });
+
+            test('leaves a short name untouched', () => {
+                const plan = makePlan([makeNode({ objectSchema: 'S', objectName: 'T' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const subs = Array.from(doc.querySelectorAll('.hnode-sub')).map(el => el.textContent);
+                assert.ok(subs.includes('S.T'));
+            });
+
+            test('the popover shows the full, untruncated object name', () => {
+                const plan = makePlan([makeNode({ objectSchema: 'SYS', objectName: 'EXA_SESSION_ROLES' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                assert.ok(doc.querySelector('.plan-popover')!.textContent!.includes('SYS.EXA_SESSION_ROLES'));
+            });
+
+            test('does not truncate the duration sub-line, only the object caption', () => {
+                const plan = makePlan([makeNode({ duration: 123.456, objectSchema: undefined, objectName: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const subs = Array.from(doc.querySelectorAll('.hnode-sub')).map(el => el.textContent);
+                assert.ok(!subs.some(s => s && s.includes('…')), 'the duration line must never be middle-truncated');
+            });
+        });
+
+        suite('temp-table dimming (finding 20)', () => {
+            test('dims the object caption when partInfo mentions a TEMPORARY table', () => {
+                const plan = makePlan([makeNode({
+                    objectSchema: undefined, objectName: 'tmp_subselect3', partInfo: 'result of a JOIN on TEMPORARY table'
+                })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const objectSub = Array.from(doc.querySelectorAll('.hnode-sub')).find(el => el.textContent === 'tmp_subselect3');
+                assert.ok(objectSub, 'expected the object caption to render');
+                assert.ok(objectSub!.classList.contains('hnode-sub-temp'));
+            });
+
+            test('the check is case-insensitive', () => {
+                const plan = makePlan([makeNode({ objectName: 'tmp_x', partInfo: 'on temporary table' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const objectSub = Array.from(doc.querySelectorAll('.hnode-sub')).find(el => el.textContent === 'tmp_x');
+                assert.ok(objectSub!.classList.contains('hnode-sub-temp'));
+            });
+
+            test('does not dim a plain (non-temporary) object caption', () => {
+                const plan = makePlan([makeNode({ objectName: 'REAL_TABLE', partInfo: 'a regular scan' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const objectSub = Array.from(doc.querySelectorAll('.hnode-sub')).find(el => el.textContent === 'REAL_TABLE');
+                assert.strictEqual(objectSub!.classList.contains('hnode-sub-temp'), false);
+            });
+
+            test('does not dim the duration sub-line even on a temp-table node', () => {
+                const plan = makePlan([makeNode({ duration: 0.01, objectName: 'tmp_x', partInfo: 'on TEMPORARY table' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const durationSub = Array.from(doc.querySelectorAll('.hnode-sub')).find(el => el.textContent === '10.0 ms');
+                assert.ok(durationSub);
+                assert.strictEqual(durationSub!.classList.contains('hnode-sub-temp'), false);
+            });
         });
     });
 
@@ -397,6 +566,91 @@ suite('buildPlanContentHtml', () => {
         });
     });
 
+    suite('hover peek title and arrow-key navigation (finding 9)', () => {
+        test('the button carries a one-line title of duration, cost share, and warning count', () => {
+            const plan = makePlan([makeNode({
+                duration: 0.123, costPercent: 52,
+                warnings: [
+                    { type: 'SPILLED_TO_DISK', message: 'a', detail: {} },
+                    { type: 'HIGH_SKEW', message: 'b', detail: {} }
+                ]
+            })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode')!.getAttribute('title'), '123 ms · 52% · 2 warnings');
+        });
+
+        test('omits whichever parts are undefined, joining only what is actually known', () => {
+            const plan = makePlan([makeNode({ duration: undefined, costPercent: 52, warnings: [] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode')!.getAttribute('title'), '52%');
+        });
+
+        test('omits the title attribute entirely when nothing is known at all', () => {
+            const plan = makePlan([makeNode({ duration: undefined, costPercent: undefined, warnings: [] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode')!.hasAttribute('title'), false);
+        });
+
+        test('the ring keeps its own operator-type title, distinct from the button\'s hover-peek title (finding 5 vs finding 9)', () => {
+            const plan = makePlan([makeNode({ operatorType: 'JOIN', duration: 0.01, costPercent: 10 })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode-ring')!.getAttribute('title'), 'Join');
+            assert.notStrictEqual(doc.querySelector('.hnode')!.getAttribute('title'), 'Join');
+        });
+
+        test('ArrowRight moves focus to the next node button in DOM order (real script execution)', () => {
+            const plan = makePlan([
+                makeNode({ id: '1' }), makeNode({ id: '2' }), makeNode({ id: '3' })
+            ]);
+            const dom = buildInteractiveDom(plan);
+            const nodes = Array.from(dom.window.document.querySelectorAll('[data-node-toggle]')) as HTMLElement[];
+            nodes[0].focus();
+            assert.strictEqual(dom.window.document.activeElement, nodes[0]);
+
+            keydown(dom, nodes[0], 'ArrowRight');
+            assert.strictEqual(dom.window.document.activeElement, nodes[1], 'ArrowRight must move focus to the next node');
+        });
+
+        test('ArrowLeft moves focus to the previous node button', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]);
+            const dom = buildInteractiveDom(plan);
+            const nodes = Array.from(dom.window.document.querySelectorAll('[data-node-toggle]')) as HTMLElement[];
+            nodes[1].focus();
+
+            keydown(dom, nodes[1], 'ArrowLeft');
+            assert.strictEqual(dom.window.document.activeElement, nodes[0]);
+        });
+
+        test('ArrowRight on the last node does nothing (no wraparound, no error)', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]);
+            const dom = buildInteractiveDom(plan);
+            const nodes = Array.from(dom.window.document.querySelectorAll('[data-node-toggle]')) as HTMLElement[];
+            nodes[1].focus();
+
+            keydown(dom, nodes[1], 'ArrowRight');
+            assert.strictEqual(dom.window.document.activeElement, nodes[1], 'focus must stay put at the last node');
+        });
+
+        test('ArrowLeft on the first node does nothing', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]);
+            const dom = buildInteractiveDom(plan);
+            const nodes = Array.from(dom.window.document.querySelectorAll('[data-node-toggle]')) as HTMLElement[];
+            nodes[0].focus();
+
+            keydown(dom, nodes[0], 'ArrowLeft');
+            assert.strictEqual(dom.window.document.activeElement, nodes[0]);
+        });
+
+        test('the arrow-key handler prevents default, so it never also scrolls the panel', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('[data-node-toggle]')!;
+            const event = new dom.window.KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
+            node.dispatchEvent(event);
+            assert.strictEqual(event.defaultPrevented, true);
+        });
+    });
+
     suite('warning badge', () => {
         test('shows the warning badge on a node with warnings', () => {
             const plan = makePlan([makeNode({
@@ -454,13 +708,40 @@ suite('buildPlanContentHtml', () => {
         });
 
         test('is titled with the operator (and object, when present)', () => {
+            // A zero-width space follows the '.' between schema and object
+            // (finding E, break opportunities) — invisible, but present in
+            // textContent, so the exact string includes it.
             const withObject = parseDom(buildPlanContentHtml(
                 makePlan([makeNode({ operatorLabel: 'PIPE SCAN', objectSchema: 'S', objectName: 'T' })]), 'n0nce'
             ));
-            assert.strictEqual(withObject.querySelector('.plan-popover-title')!.textContent, 'PIPE SCAN — S.T');
+            assert.strictEqual(withObject.querySelector('.plan-popover-title')!.textContent, 'PIPE SCAN — S.​T');
 
             const withoutObject = parseDom(buildPlanContentHtml(makePlan([makeNode({ operatorLabel: 'COMPILE', objectName: undefined })]), 'n0nce'));
             assert.strictEqual(withoutObject.querySelector('.plan-popover-title')!.textContent, 'COMPILE');
+        });
+
+        suite('title break opportunities (finding E)', () => {
+            test('inserts a zero-width space after every "." and "_" so a long qualified name breaks at a natural boundary', () => {
+                const plan = makePlan([makeNode({
+                    operatorLabel: 'PIPE SCAN', objectSchema: 'SNAP_SALESFORCE', objectName: 'CONTRACT_DOCUMENTS'
+                })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const title = doc.querySelector('.plan-popover-title')!.textContent;
+                assert.strictEqual(title, 'PIPE SCAN — SNAP_​SALESFORCE.​CONTRACT_​DOCUMENTS');
+            });
+
+            test('a title with neither "." nor "_" is left untouched', () => {
+                const plan = makePlan([makeNode({ operatorLabel: 'COMPILE', objectName: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                assert.strictEqual(doc.querySelector('.plan-popover-title')!.textContent, 'COMPILE');
+            });
+
+            test('the break-opportunity character never breaks out of the escaped markup (applied after escapeHtml, not before)', () => {
+                const evil = '"><script>alert(1)</script>';
+                const plan = makePlan([makeNode({ operatorLabel: evil })]);
+                const html = buildPlanContentHtml(plan, 'n0nce');
+                assert.ok(!html.includes('<script>alert(1)</script>'), 'raw script tag must never appear');
+            });
         });
 
         test('lists key fields not shown on the node face', () => {
@@ -476,6 +757,219 @@ suite('buildPlanContentHtml', () => {
             const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
             const detailText = doc.querySelector('.plan-popover')!.textContent!;
             assert.ok(detailText.includes('min 100 / max 900 / avg 500 / nodes 4'));
+        });
+
+        test('labels the share row "Duration share", not "Cost share" (finding 12)', () => {
+            const plan = makePlan([makeNode({ costPercent: 33 })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+            assert.ok(labels.some(l => l && l.startsWith('Duration share')));
+            assert.ok(!labels.includes('Cost share'));
+        });
+
+        suite('duration-share denominator suffix (finding B)', () => {
+            test('a non-system node is labeled "Duration share (of query)"', () => {
+                const plan = makePlan([makeNode({ costPercent: 45, traits: { ...PASSTHROUGH_TRAITS, isSystemStep: false } })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(labels.includes('Duration share (of query)'));
+            });
+
+            test('a system-step node is labeled "Duration share (of total)"', () => {
+                const plan = makePlan([makeNode({ costPercent: 31, traits: { ...PASSTHROUGH_TRAITS, isSystemStep: true } })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(labels.includes('Duration share (of total)'));
+                assert.ok(!labels.includes('Duration share (of query)'));
+            });
+        });
+
+        test('labels CPU as "CPU (max node)" (finding 24)', () => {
+            const plan = makePlan([makeNode({ cpu: 50 })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+            assert.ok(labels.includes('CPU (max node)'));
+            assert.ok(!labels.includes('CPU'));
+        });
+
+        test('orders metrics first, then Part info/Remarks, then the remaining identity fields last (finding 17, finding D)', () => {
+            // D: Part info/Remarks moved up to directly after the metrics
+            // block (scan popovers carry filter columns in Remarks — worth
+            // a glance without scrolling past Part id/Operator/Object/Traits
+            // first).
+            const plan = makePlan([makeNode({
+                duration: 1, costPercent: 50, cpu: 50, rowsOut: 100,
+                objectSchema: 'S', objectName: 'T', partInfo: 'info', remarks: 'remark'
+            })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+
+            const indexOf = (label: string): number => labels.indexOf(label);
+            assert.strictEqual(indexOf('Duration'), 0, 'Duration must be the first detail row');
+            assert.ok(indexOf('Duration share (of query)') < indexOf('CPU (max node)'));
+            assert.ok(indexOf('CPU (max node)') < indexOf('Rows out'));
+            assert.ok(indexOf('Rows out') < indexOf('Part info'), 'metrics must all precede Part info/Remarks');
+            assert.ok(indexOf('Part info') < indexOf('Remarks'));
+            assert.ok(indexOf('Remarks') < indexOf('Part id'), 'Part info/Remarks must come before the remaining identity fields');
+            assert.ok(indexOf('Part id') < indexOf('Object'));
+            assert.ok(indexOf('Object') < indexOf('Traits'), 'Traits comes last');
+        });
+
+        suite('numeric metric rows always show a dash instead of vanishing (finding 23)', () => {
+            test('Rows out shows "—" when undefined, rather than disappearing', () => {
+                const plan = makePlan([makeNode({ rowsOut: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'Rows out'
+                );
+                assert.ok(row, 'the Rows out row must still render when the value is undefined');
+                assert.strictEqual(row!.querySelector('.plan-detail-v')!.textContent, '—');
+            });
+
+            test('CPU (max node) shows "—" when undefined', () => {
+                const plan = makePlan([makeNode({ cpu: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'CPU (max node)'
+                );
+                assert.ok(row);
+                assert.strictEqual(row!.querySelector('.plan-detail-v')!.textContent, '—');
+            });
+
+            test('Temp DB RAM peak shows "—" when undefined', () => {
+                const plan = makePlan([makeNode({ tempDbRamPeak: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'Temp DB RAM peak'
+                );
+                assert.ok(row);
+                assert.strictEqual(row!.querySelector('.plan-detail-v')!.textContent, '—');
+            });
+
+            test('identity/text fields (Object, Part info, Remarks) still omit entirely when absent — not numeric metrics', () => {
+                const plan = makePlan([makeNode({ objectName: undefined, partInfo: undefined, remarks: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(!labels.includes('Object'));
+                assert.ok(!labels.includes('Part info'));
+                assert.ok(!labels.includes('Remarks'));
+            });
+        });
+
+        suite('scan selectivity (finding 3)', () => {
+            test('shows "Scanned: N rows -> M (P%)" when both objectRows and rowsOut are defined', () => {
+                const plan = makePlan([makeNode({ objectRows: 10000, rowsOut: 250 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'Scanned'
+                );
+                assert.ok(row);
+                assert.strictEqual(row!.querySelector('.plan-detail-v')!.textContent, '10,000 rows → 250 (2.5%)');
+            });
+
+            test('omits the Scanned row when objectRows is undefined', () => {
+                const plan = makePlan([makeNode({ objectRows: undefined, rowsOut: 250 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(!labels.includes('Scanned'));
+            });
+
+            test('omits the Scanned row when objectRows is zero (guards the division)', () => {
+                const plan = makePlan([makeNode({ objectRows: 0, rowsOut: 0 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(!labels.includes('Scanned'));
+            });
+
+            test('shows the raw row counts but omits the percentage when rowsOut exceeds objectRows (inconsistent data, not >100% selectivity)', () => {
+                const plan = makePlan([makeNode({ objectRows: 1594, rowsOut: 6314 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'Scanned'
+                );
+                assert.ok(row, 'the row counts must still be shown');
+                const value = row!.querySelector('.plan-detail-v')!.textContent;
+                assert.strictEqual(value, '1,594 rows → 6,314');
+                assert.ok(!value!.includes('%'), 'must never render a >100% selectivity percentage');
+            });
+        });
+
+        suite('HDD read (finding 7)', () => {
+            test('shows "HDD read: N MiB/s" only when greater than zero', () => {
+                const plan = makePlan([makeNode({ hddRead: 3.2 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'HDD read'
+                );
+                assert.ok(row);
+                assert.strictEqual(row!.querySelector('.plan-detail-v')!.textContent, '3.2 MiB/s');
+            });
+
+            test('omits the row when HDD read is zero', () => {
+                const plan = makePlan([makeNode({ hddRead: 0 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(!labels.includes('HDD read'));
+            });
+
+            test('omits the row when HDD read is undefined', () => {
+                const plan = makePlan([makeNode({ hddRead: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(!labels.includes('HDD read'));
+            });
+        });
+
+        suite('per-node durations (finding 4)', () => {
+            test('shows the min/max/avg/nodes breakdown when present', () => {
+                const plan = makePlan([makeNode({
+                    perNodeDurationStats: { metric: 'duration', min: 0.01, max: 0.34, avg: 0.12, nodeCount: 4 }
+                })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const row = Array.from(doc.querySelectorAll('.plan-detail-row')).find(
+                    el => el.querySelector('.plan-detail-k')!.textContent === 'Per-node durations'
+                );
+                assert.ok(row);
+                assert.strictEqual(row!.querySelector('.plan-detail-v')!.textContent, 'min 10.0 ms / max 340 ms / avg 120 ms / nodes 4');
+            });
+
+            test('omits the row entirely when perNodeDurationStats is undefined (unlike per-node rows, which shows "not available")', () => {
+                const plan = makePlan([makeNode({ perNodeDurationStats: undefined })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                assert.ok(!labels.includes('Per-node durations'));
+            });
+
+            suite('1ms noise floor (finding C)', () => {
+                test('shows the row when the slowest node is exactly at the 1ms floor', () => {
+                    const plan = makePlan([makeNode({
+                        perNodeDurationStats: { metric: 'duration', min: 0.0001, max: 0.001, avg: 0.0005, nodeCount: 4 }
+                    })]);
+                    const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                    const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                    assert.ok(labels.includes('Per-node durations'), 'a 1ms max meets the floor and must render');
+                });
+
+                test('omits the row when the slowest node is just under the 1ms floor', () => {
+                    const plan = makePlan([makeNode({
+                        perNodeDurationStats: { metric: 'duration', min: 0.0001, max: 0.0009, avg: 0.0005, nodeCount: 4 }
+                    })]);
+                    const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                    const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                    assert.ok(!labels.includes('Per-node durations'), 'a 0.9ms max is below the floor and must be treated as measurement noise');
+                });
+
+                test('per-node ROWS behavior is unaffected by the duration floor', () => {
+                    const plan = makePlan([makeNode({
+                        perNodeStats: { metric: 'rows', min: 1, max: 2, avg: 1.5, nodeCount: 4 },
+                        perNodeDurationStats: { metric: 'duration', min: 0.0001, max: 0.0009, avg: 0.0005, nodeCount: 4 }
+                    })]);
+                    const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                    const labels = Array.from(doc.querySelectorAll('.plan-detail-k')).map(el => el.textContent);
+                    assert.ok(labels.includes('Per-node rows'), 'the rows line must still render regardless of the duration floor');
+                    assert.ok(!labels.includes('Per-node durations'));
+                });
+            });
         });
 
         test('a long "not available" per-node-rows value wraps at word boundaries, not mid-word', () => {
@@ -498,6 +992,88 @@ suite('buildPlanContentHtml', () => {
             const plan = makePlan([makeNode()]);
             const html = buildPlanContentHtml(plan, 'my-nonce-value');
             assert.ok(html.includes('nonce="my-nonce-value"'));
+        });
+
+        suite('per-node copy (finding 11)', () => {
+            test('renders a copy button in the popover title row', () => {
+                const plan = makePlan([makeNode({ id: '1' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const btn = doc.querySelector('.plan-node-copy');
+                assert.ok(btn, 'expected a per-node copy button');
+                assert.strictEqual(btn!.tagName, 'BUTTON');
+                assert.strictEqual(btn!.getAttribute('data-copy-node'), '1');
+                assert.ok(doc.querySelector('.plan-popover-title-row')!.contains(btn));
+            });
+
+            test('the button does not leak into the popover title\'s own text content', () => {
+                const plan = makePlan([makeNode({ operatorLabel: 'PIPE SCAN' })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                assert.strictEqual(doc.querySelector('.plan-popover-title')!.textContent, 'PIPE SCAN');
+            });
+
+            test('embeds this node\'s exact operatorBlock() text in a hidden sibling textarea', () => {
+                const plan = makePlan([makeNode({ id: '3', operatorLabel: 'PIPE SCAN', duration: 0.05, costPercent: 20 })]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const textarea = doc.querySelector('.plan-node-copy-data') as HTMLTextAreaElement;
+                assert.ok(textarea);
+                assert.strictEqual(textarea.hasAttribute('hidden'), true);
+                assert.ok(textarea.value.includes('PIPE SCAN [part 3]'));
+                assert.ok(textarea.value.includes('Duration: 50.0 ms'));
+            });
+
+            test('a multi-node plan\'s per-node text matches the numbering of the full "Copy as text" export', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', operatorLabel: 'SCAN' }),
+                    makeNode({ id: '2', operatorLabel: 'JOIN' })
+                ]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const textareas = Array.from(doc.querySelectorAll('.plan-node-copy-data')) as HTMLTextAreaElement[];
+                assert.ok(textareas[0].value.startsWith('1. SCAN [part 1]'));
+                assert.ok(textareas[1].value.startsWith('2. JOIN [part 2]'));
+            });
+
+            test('escapes a malicious value inside the embedded per-node textarea', () => {
+                const evil = '</textarea><script>alert(1)</script>';
+                const plan = makePlan([makeNode({ remarks: evil })]);
+                const html = buildPlanContentHtml(plan, 'n0nce');
+                assert.ok(!html.includes('</textarea><script>alert(1)</script>'), 'raw markup must never appear unescaped');
+            });
+
+            test('clicking the copy button posts a copyPlanText message with this node\'s text (real script execution)', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', operatorLabel: 'SCAN' }),
+                    makeNode({ id: '2', operatorLabel: 'JOIN' })
+                ]);
+                const dom = buildInteractiveDom(plan);
+                const doc = dom.window.document;
+                const posted: Array<{ command: string; text: string }> = [];
+                (dom.window as unknown as { __vscode: { postMessage: (m: { command: string; text: string }) => void } }).__vscode = {
+                    postMessage: (m) => posted.push(m)
+                };
+
+                const node2Popover = doc.querySelector('.hnode[data-node-id="2"]')!.parentElement!.querySelector('[data-popover]')!;
+                const copyBtn = node2Popover.querySelector('.plan-node-copy')!;
+                click(dom, copyBtn);
+
+                assert.strictEqual(posted.length, 1);
+                assert.strictEqual(posted[0].command, 'copyPlanText');
+                assert.ok(posted[0].text.startsWith('2. JOIN [part 2]'), `expected node 2's own block, got: ${posted[0].text}`);
+            });
+
+            test('clicking the copy button does not close the popover (stopPropagation)', () => {
+                const plan = makePlan([makeNode({ id: '1' })]);
+                const dom = buildInteractiveDom(plan);
+                const doc = dom.window.document;
+                const node = doc.querySelector('.hnode')!;
+                const pop = popoverFor(dom, node);
+
+                click(dom, node);
+                assert.strictEqual(pop.hidden, false, 'precondition: popover open');
+
+                const copyBtn = pop.querySelector('.plan-node-copy')!;
+                click(dom, copyBtn);
+                assert.strictEqual(pop.hidden, false, 'clicking the copy button must not close its own popover');
+            });
         });
     });
 
@@ -672,6 +1248,30 @@ suite('buildPlanContentHtml', () => {
             assert.strictEqual(pop.classList.contains('flip-up'), true);
         });
 
+        test('flips up when the popover fits fully above, even with an unremarkable margin over space below (finding 18)', () => {
+            // popHeight(80) + gap(16) = 96 needed. spaceBelow (90) doesn't
+            // quite fit (fitsBelow false); spaceAbove (120) fits outright
+            // (fitsAbove true). Whenever a popover fits above but not below,
+            // spaceAbove is necessarily also the numerically larger side
+            // (see the comment above positionPopover for why those two legs
+            // of the flip condition's disjunction can never actually
+            // diverge) — this pins the fitsAbove-driven flip and confirms
+            // it needs no height cap once it lands somewhere that fits.
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 80);
+            stubRect(node, { top: 120, bottom: 140 });
+            stubRect(scrollArea, { top: 0, bottom: 230 });
+
+            click(dom, node);
+            assert.strictEqual(pop.classList.contains('flip-up'), true);
+            assert.strictEqual(pop.style.maxHeight, '', 'the popover fits fully above; no height cap should apply');
+        });
+
         test('when neither side actually fits, the popover is capped to the room available on the side it opens on, with its own scrollbar, rather than left to be clipped by the container', () => {
             const plan = makePlan([makeNode({ id: '1' })]);
             const dom = buildInteractiveDom(plan);
@@ -689,8 +1289,40 @@ suite('buildPlanContentHtml', () => {
 
             click(dom, node);
             assert.strictEqual(pop.classList.contains('flip-up'), true, 'precondition: this scenario should flip (90px above beats -15px below)');
-            assert.strictEqual(pop.style.maxHeight, '74px', 'expected the cap to be the actual room available above (90 - 16px gap), not a bare guess');
+            // Room available above is 90 - 16px gap = 74, then floored down
+            // to a whole multiple of line-height (finding 15) — JSDOM has no
+            // real stylesheet loaded, so getComputedStyle(pop).lineHeight
+            // resolves to 'normal' here and the 16px fallback applies:
+            // floor(74 / 16) * 16 = 64.
+            assert.strictEqual(pop.style.maxHeight, '64px', 'expected the cap floored to a whole 16px line-height multiple, not the bare 74px available room');
             assert.strictEqual(pop.style.overflowY, 'auto', 'expected an internal scrollbar so the rest of the content stays reachable');
+        });
+
+        test('floors the height cap to a whole multiple of the popover\'s line-height, never landing mid-line (finding 15)', () => {
+            // A real screenshot showed the popover's title row itself
+            // half-clipped right above the scrollbar an unfloored cap
+            // produced. Faking a real, non-'normal' computed line-height
+            // isn't practical without loading the actual stylesheet into
+            // JSDOM, so this exercises the documented 16px fallback path
+            // instead of a custom line-height value — still enough to prove
+            // the flooring itself actually runs, with numbers distinct from
+            // the regression test above.
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 300);
+            stubRect(node, { top: 100, bottom: 120 });
+            stubRect(scrollArea, { top: 0, bottom: 110 });
+
+            click(dom, node);
+            assert.strictEqual(pop.classList.contains('flip-up'), true, 'precondition: 100px above must beat -10px below');
+            // Available = 100 - 16 = 84; floor(84 / 16) * 16 = 80 — not 84,
+            // proving the value was actually floored rather than passed
+            // through.
+            assert.strictEqual(pop.style.maxHeight, '80px');
         });
 
         test('does not cap the height when the popover already fits in the space it opens on', () => {
@@ -970,6 +1602,57 @@ suite('buildPlanContentHtml', () => {
                 'expected the two-class .hconn.hconn-hidden selector, which beats .hconn\'s own display rule regardless of source order'
             );
         });
+
+        suite('connector pill direction arrows (finding 21)', () => {
+            test('an unreversed row keeps the default left-to-right arrow', () => {
+                const dom = buildInteractiveDom(fiveNodePlan());
+                const doc = dom.window.document;
+                stubRows(flowItemsOf(dom), [2, 3]);
+                resize(dom);
+
+                const stepB = doc.querySelector('.hnode[data-node-id="2"]')!.closest('.hstep')!;
+                assert.strictEqual(stepB.querySelector('.hconn-label')!.textContent, '→ 100 rows', 'row 0 is never reversed, so its connector keeps the default arrow');
+            });
+
+            test('a reversed row\'s connectors flip to the right-to-left arrow, count text unchanged', () => {
+                const dom = buildInteractiveDom(fiveNodePlan());
+                const doc = dom.window.document;
+                stubRows(flowItemsOf(dom), [2, 3]);
+                resize(dom);
+
+                const stepD = doc.querySelector('.hnode[data-node-id="4"]')!.closest('.hstep')!;
+                const stepE = doc.querySelector('.hnode[data-node-id="5"]')!.closest('.hstep')!;
+                assert.strictEqual(stepD.querySelector('.hconn-label')!.textContent, '← 300 rows', 'row 1 is reversed, so its connectors must read right-to-left');
+                assert.strictEqual(stepE.querySelector('.hconn-label')!.textContent, '← 400 rows');
+            });
+
+            test('the vertical drop connector between rows reads "down", not the carried-over horizontal arrow', () => {
+                const dom = buildInteractiveDom(fiveNodePlan());
+                const doc = dom.window.document;
+                stubRows(flowItemsOf(dom), [2, 3]);
+                resize(dom);
+
+                const dropLabel = doc.querySelector('.hflow-drop .hconn-label')!;
+                assert.strictEqual(dropLabel.textContent, '↓ 200 rows');
+            });
+
+            test('reverting to a single row (resetFlowRows) restores every connector to the default arrow', () => {
+                const dom = buildInteractiveDom(fiveNodePlan());
+                const doc = dom.window.document;
+                const items = flowItemsOf(dom);
+
+                stubRows(items, [2, 3]);
+                resize(dom);
+                const stepDBefore = doc.querySelector('.hnode[data-node-id="4"]')!.closest('.hstep')!;
+                assert.strictEqual(stepDBefore.querySelector('.hconn-label')!.textContent, '← 300 rows', 'precondition: row 1 was reversed and flipped');
+
+                items.forEach(item => Object.defineProperty(item, 'offsetTop', { value: 0, configurable: true }));
+                resize(dom);
+
+                const allLabels = Array.from(doc.querySelectorAll('.hconn-label')).map(el => el.textContent);
+                assert.ok(allLabels.every(t => t!.startsWith('→ ')), `expected every connector reset to the default arrow, got: ${JSON.stringify(allLabels)}`);
+            });
+        });
     });
 
     suite('warnings summary (side rail)', () => {
@@ -1034,6 +1717,105 @@ suite('buildPlanContentHtml', () => {
 
             keydown(dom, warningItem, 'Enter');
             assert.strictEqual(pop.hidden, false);
+        });
+
+        suite('jump highlight (finding 8)', () => {
+            test('clicking a warning item adds a transient highlight class to the node it jumps to', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', warnings: [] }),
+                    makeNode({ id: '2', warnings: [{ type: 'SPILLED_TO_DISK', message: 'x', detail: {} }] })
+                ]);
+                const dom = buildInteractiveDom(plan);
+                const warningItem = dom.window.document.querySelector('.plan-warning-item')!;
+                const node2 = dom.window.document.querySelector('.hnode[data-node-id="2"]')!;
+                assert.strictEqual(node2.classList.contains('hnode-jumped'), false, 'precondition: not highlighted yet');
+
+                click(dom, warningItem);
+                assert.strictEqual(node2.classList.contains('hnode-jumped'), true, 'the jumped-to node must carry the transient highlight class');
+            });
+
+            test('a second jump moves the highlight instead of stacking it on more than one node', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', warnings: [{ type: 'SPILLED_TO_DISK', message: 'a', detail: {} }] }),
+                    makeNode({ id: '2', warnings: [{ type: 'SPILLED_TO_DISK', message: 'b', detail: {} }] })
+                ]);
+                const dom = buildInteractiveDom(plan);
+                const items = Array.from(dom.window.document.querySelectorAll('.plan-warning-item'));
+                const node1 = dom.window.document.querySelector('.hnode[data-node-id="1"]')!;
+                const node2 = dom.window.document.querySelector('.hnode[data-node-id="2"]')!;
+
+                click(dom, items[0]);
+                assert.strictEqual(node1.classList.contains('hnode-jumped'), true);
+
+                click(dom, items[1]);
+                assert.strictEqual(node1.classList.contains('hnode-jumped'), false, 'only one node may carry the highlight at a time');
+                assert.strictEqual(node2.classList.contains('hnode-jumped'), true);
+            });
+
+            // Regression test for the pending-timer bug: jumpHighlight() used
+            // to start a new 1600ms removal timer on every jump without
+            // clearing the previous one, so jumping to the SAME node twice in
+            // quick succession let the FIRST jump's timer fire later and
+            // erase the highlight the second jump had just (re-)applied. No
+            // sinon/fake-timer setup exists anywhere in this codebase (no
+            // "sinon" dependency, no other test fakes timers), so this
+            // asserts only the timing-free half of the bug — the class is
+            // still present immediately after the second jump — rather than
+            // advancing a clock to prove the stale timer no longer fires.
+            test('jumping to the same node twice leaves the class present immediately after the second jump', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', warnings: [{ type: 'SPILLED_TO_DISK', message: 'a', detail: {} }] })
+                ]);
+                const dom = buildInteractiveDom(plan);
+                const warningItem = dom.window.document.querySelector('.plan-warning-item')!;
+                const node = dom.window.document.querySelector('.hnode[data-node-id="1"]')!;
+
+                click(dom, warningItem);
+                assert.strictEqual(node.classList.contains('hnode-jumped'), true, 'precondition: first jump highlights the node');
+
+                click(dom, warningItem);
+                assert.strictEqual(node.classList.contains('hnode-jumped'), true, 'the second jump to the same node must still leave it highlighted');
+            });
+        });
+
+        suite('severity sort (finding 16)', () => {
+            test('orders spill first, then redistribution, then duration skew, then row skew — noise-y skew ranked below a genuinely large one', () => {
+                const plan = makePlan([
+                    // Deliberately built out of the expected order, and with
+                    // a "noisy" skew (huge ratio, trivial row count) ranked
+                    // alongside a genuinely large one, mirroring the real
+                    // screenshot in the roast doc (four 0-1-row noise
+                    // warnings burying two real ones).
+                    makeNode({ id: 'skewSmall', warnings: [
+                        { type: 'HIGH_SKEW', message: 'skewSmall', detail: { min: 0, max: 10, avg: 2, nodeCount: 4, ratio: 5 } }
+                    ] }),
+                    makeNode({ id: 'durSkew', warnings: [
+                        { type: 'HIGH_DURATION_SKEW', message: 'durSkew', detail: { minSeconds: 0, maxSeconds: 5, avgSeconds: 1, nodeCount: 4, ratio: 2 } }
+                    ] }),
+                    makeNode({ id: 'spill', warnings: [
+                        { type: 'SPILLED_TO_DISK', message: 'spill', detail: { hddWriteMiB: 10 } }
+                    ] }),
+                    makeNode({ id: 'skewBig', warnings: [
+                        { type: 'HIGH_SKEW', message: 'skewBig', detail: { min: 0, max: 2000, avg: 1000, nodeCount: 4, ratio: 0.1 } }
+                    ] }),
+                    makeNode({ id: 'redistribution', warnings: [
+                        { type: 'LARGE_REDISTRIBUTION', message: 'redistribution', detail: { netMiB: 500, costPercent: 30, thresholdPercent: 20 } }
+                    ] })
+                ]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const order = Array.from(doc.querySelectorAll('.plan-warning-item')).map(el => el.getAttribute('data-jump-to'));
+                assert.deepStrictEqual(order, ['spill', 'redistribution', 'durSkew', 'skewBig', 'skewSmall']);
+            });
+
+            test('keeps plan (node) order for warnings that tie on both priority and impact', () => {
+                const plan = makePlan([
+                    makeNode({ id: 'first', warnings: [{ type: 'ROW_ESTIMATE_MISMATCH', message: 'x', detail: {} }] }),
+                    makeNode({ id: 'second', warnings: [{ type: 'ROW_ESTIMATE_MISMATCH', message: 'y', detail: {} }] })
+                ]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const order = Array.from(doc.querySelectorAll('.plan-warning-item')).map(el => el.getAttribute('data-jump-to'));
+                assert.deepStrictEqual(order, ['first', 'second'], 'ties must not be shuffled from their original plan order');
+            });
         });
     });
 
@@ -1113,6 +1895,55 @@ suite('buildPlanContentHtml', () => {
             assert.ok(legendText.includes('Join'));
             assert.ok(legendText.includes('25%'));
         });
+
+        suite('absolute duration in the legend', () => {
+            test('each row shows label, absolute duration, and percent as three separate spans', () => {
+                // Mirrors the concrete example: a 188ms Group By step that is
+                // 81% of a 232ms total.
+                const plan = makePlan([
+                    makeNode({ id: '1', operatorType: 'GROUP_BY', duration: 0.188 }),
+                    makeNode({ id: '2', operatorType: 'SCAN', duration: 0.044 })
+                ], { totalDuration: 0.232 });
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const rows = Array.from(doc.querySelectorAll('.hcat-legend > div'));
+
+                const groupByRow = rows.find(r => r.textContent!.includes('Group By'))!;
+                const groupBySpans = Array.from(groupByRow.querySelectorAll('span'));
+                assert.strictEqual(groupBySpans.length, 3, 'expected label, duration, and percent as three spans');
+                assert.ok(groupBySpans[0].textContent!.includes('Group By'));
+                assert.strictEqual(groupBySpans[1].textContent, '188 ms');
+                assert.strictEqual(groupBySpans[2].textContent, '81%');
+
+                const scanRow = rows.find(r => r.textContent!.includes('Scan'))!;
+                const scanSpans = Array.from(scanRow.querySelectorAll('span'));
+                assert.strictEqual(scanSpans[1].textContent, '44.0 ms');
+                assert.strictEqual(scanSpans[2].textContent, '19%');
+            });
+
+            test('the flex layout keeps duration/percent fixed-width and right-aligned, with the label taking the remaining space', () => {
+                const css = buildPlanContentCss();
+                assert.ok(
+                    /\.hcat-legend div\s*\{[^}]*display:\s*flex/.test(css),
+                    'expected .hcat-legend div to stay a flex row'
+                );
+                assert.ok(
+                    /\.hcat-legend div span:first-child\s*\{[^}]*flex:\s*1/.test(css),
+                    'expected the label span to grow and fill the remaining space'
+                );
+                assert.ok(
+                    /\.hcat-legend div span:not\(:first-child\)\s*\{[^}]*flex:\s*none/.test(css),
+                    'expected duration/percent to stay fixed-width, not stretch'
+                );
+            });
+        });
+
+        test('the heading says the breakdown is of total, since it always includes system-step time (finding B)', () => {
+            const plan = makePlan([makeNode({ id: '1', operatorType: 'SCAN', duration: 4 })], { totalDuration: 4 });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const heading = Array.from(doc.querySelectorAll('.plan-side-card h4')).find(h => h.textContent && h.textContent.includes('Time by category'));
+            assert.ok(heading, 'expected the "Time by category" heading to render');
+            assert.ok(heading!.textContent!.includes('(of total)'), `expected the "(of total)" suffix, got: ${heading!.textContent}`);
+        });
     });
 
     suite('side rail', () => {
@@ -1120,6 +1951,129 @@ suite('buildPlanContentHtml', () => {
             const plan = makePlan([makeNode()], { source: 'DETAILS' });
             const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
             assert.ok(doc.querySelector('.plan-side')!.textContent!.includes('per-node detail'));
+        });
+
+        suite('Session/Statement rows (only on-screen place both ids appear)', () => {
+            function rowValue(doc: Document, label: string): string | null | undefined {
+                const row = Array.from(doc.querySelectorAll('.plan-side-row')).find(
+                    el => el.querySelector('span:first-child')!.textContent === label
+                );
+                return row?.querySelector('span:last-child')!.textContent;
+            }
+
+            test('renders the exact session and statement id digit strings, above Source', () => {
+                // A session id past Number.MAX_SAFE_INTEGER (2^53 - 1 =
+                // 9,007,199,254,740,991) pins the no-rounding guarantee
+                // end-to-end: Plan.sessionId/stmtId are kept as exact digit
+                // strings for exactly this reason (see planModel.ts) — a
+                // real DECIMAL(20,0) SESSION_ID routinely exceeds it, and
+                // rendering `Number(sessionId)` anywhere in this path would
+                // silently corrupt the value a user needs to paste verbatim
+                // into a SESSION_ID = ... filter.
+                const plan = makePlan([makeNode()], { sessionId: '17714852875571234567', stmtId: '42' });
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                assert.strictEqual(rowValue(doc, 'Session'), '17714852875571234567');
+                assert.strictEqual(rowValue(doc, 'Statement'), '42');
+
+                const labels = Array.from(doc.querySelectorAll('.plan-side-row')).map(
+                    el => el.querySelector('span:first-child')!.textContent
+                );
+                assert.ok(labels.indexOf('Session') < labels.indexOf('Source'), 'Session must render above Source');
+                assert.ok(labels.indexOf('Statement') < labels.indexOf('Source'), 'Statement must render above Source');
+            });
+
+            test('escapes a malicious session/statement id the same as every other field', () => {
+                const evil = '<script>alert(1)</script>';
+                const plan = makePlan([makeNode()], { sessionId: evil, stmtId: evil });
+                const html = buildPlanContentHtml(plan, 'n0nce');
+                assert.ok(!html.includes('<script>alert(1)</script>'), 'raw script tag must never appear');
+            });
+
+            test('the value column can wrap/break instead of clipping a full 20-digit session id', () => {
+                const css = buildPlanContentCss();
+                assert.ok(
+                    /\.plan-side-row\s*\{[^}]*flex-wrap:\s*wrap/.test(css),
+                    'expected .plan-side-row to allow wrapping onto its own line for a long value'
+                );
+                assert.ok(
+                    /\.plan-side-row\s+span:last-child\s*\{[^}]*overflow-wrap:\s*break-word/.test(css),
+                    'expected the value span to allow breaking a long, unbroken digit string as a last resort'
+                );
+            });
+        });
+
+        suite('Operators row (rail consolidation)', () => {
+            function rowValue(doc: Document, label: string): string | null | undefined {
+                const row = Array.from(doc.querySelectorAll('.plan-side-row')).find(
+                    el => el.querySelector('span:first-child')!.textContent === label
+                );
+                return row?.querySelector('span:last-child')!.textContent;
+            }
+
+            test('shows the operator count with the same singular/plural handling the old caption used', () => {
+                const singular = parseDom(buildPlanContentHtml(makePlan([makeNode({ id: '1' })]), 'n0nce'));
+                assert.strictEqual(rowValue(singular, 'Operators'), '1 operator');
+
+                const plural = parseDom(buildPlanContentHtml(makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]), 'n0nce'));
+                assert.strictEqual(rowValue(plural, 'Operators'), '2 operators');
+
+                const empty = parseDom(buildPlanContentHtml(makePlan([]), 'n0nce'));
+                assert.strictEqual(rowValue(empty, 'Operators'), '0 operators');
+            });
+        });
+
+        test('renders the Profile overview rows in order: Session, Statement, Total time, Operators, Nodes observed, Source', () => {
+            // Session/Statement lead — together they're the composite key
+            // copied into a EXA_*_PROFILE_LAST_DAY / EXA_SQL_LAST_DAY
+            // cross-check, Session first as the wider key and matching those
+            // views' own column order. Facts about the plan follow; Source
+            // (a provenance caveat, not a fact about the query) comes last.
+            const plan = makePlan([makeNode()], {
+                sessionId: '123', stmtId: '39', totalDuration: 0.5,
+                source: 'DETAILS'
+            });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const card = Array.from(doc.querySelectorAll('.plan-side-card')).find(
+                c => c.querySelector('h4')!.textContent === 'Profile overview'
+            )!;
+            const labels = Array.from(card.querySelectorAll('.plan-side-row')).map(
+                el => el.querySelector('span:first-child')!.textContent
+            );
+            assert.deepStrictEqual(labels, ['Session', 'Statement', 'Total time', 'Operators', 'Nodes observed', 'Source']);
+        });
+
+        suite('badge legend card (finding 2, round 7)', () => {
+            const EXPECTED_PAIRS: Array<[string, string]> = [
+                ['S', 'Scan'], ['J', 'Join'], ['G', 'Group By'], ['O', 'Sort'],
+                ['N', 'Network'], ['D', 'DML'], ['‖', 'Sync'], ['⚙', 'System'], ['⋯', 'Other']
+            ];
+
+            test('renders all 9 operator types, in a fixed order, each with its correct glyph/label pair', () => {
+                // Same data every node already renders on its own ring (see
+                // OPERATOR_BADGE/OPERATOR_TYPE_LABEL in planFormat.ts) — no
+                // new data, just all nine listed in one place.
+                const doc = parseDom(buildPlanContentHtml(makePlan([makeNode()]), 'n0nce'));
+                const legendCard = Array.from(doc.querySelectorAll('.plan-side-card')).find(
+                    c => c.querySelector('h4')!.textContent === 'Legend'
+                )!;
+                assert.ok(legendCard, 'expected a "Legend" card in the rail');
+
+                const items = Array.from(legendCard.querySelectorAll('.plan-legend-item'));
+                assert.strictEqual(items.length, 9);
+
+                const pairs = items.map(item => {
+                    const spans = Array.from(item.querySelectorAll('span'));
+                    return [spans[0].textContent, spans[1].textContent];
+                });
+                assert.deepStrictEqual(pairs, EXPECTED_PAIRS);
+            });
+
+            test('the Legend card is the last card in the rail', () => {
+                const doc = parseDom(buildPlanContentHtml(makePlan([makeNode()]), 'n0nce'));
+                const cards = Array.from(doc.querySelectorAll('.plan-side > .plan-side-card'));
+                const headings = cards.map(c => c.querySelector('h4')!.textContent);
+                assert.strictEqual(headings[headings.length - 1], 'Legend');
+            });
         });
 
         test('labels DBA_SUMMARY distinctly from USER_SUMMARY', () => {
@@ -1269,6 +2223,43 @@ suite('CSS builders', () => {
         const css = buildPlanContentCss();
         assert.ok(/\.hnode:focus-visible\s*\{[^}]*outline/.test(css));
         assert.ok(/\.plan-warning-item:focus-visible\s*\{[^}]*outline/.test(css));
+    });
+
+    test('defines the transient jump-highlight ring (finding 8)', () => {
+        const css = buildPlanContentCss();
+        assert.ok(
+            /\.hnode-jumped\s+\.hnode-ring\s*\{[^}]*outline:/.test(css),
+            'expected .hnode-jumped .hnode-ring to carry an outline'
+        );
+    });
+
+    test('defines the temp-object dimming rule (finding 20)', () => {
+        const css = buildPlanContentCss();
+        assert.ok(
+            /\.hnode-sub-temp\s*\{[^}]*opacity:/.test(css),
+            'expected .hnode-sub-temp to dim the caption'
+        );
+    });
+
+    test('the popover is 280px wide, not the old 220px (finding E)', () => {
+        const css = buildPlanContentCss();
+        assert.ok(
+            /\.plan-popover\s*\{[^}]*width:\s*280px/.test(css),
+            'expected .plan-popover to be widened to 280px'
+        );
+        assert.ok(!/\.plan-popover\s*\{[^}]*width:\s*220px/.test(css));
+    });
+
+    test('the popover title row keeps a fixed gap: flex layout with the copy button pinned to flex: none (finding E)', () => {
+        const css = buildPlanContentCss();
+        assert.ok(
+            /\.plan-popover-title-row\s*\{[^}]*display:\s*flex[^}]*gap:/.test(css),
+            'expected .plan-popover-title-row to be a flex container with a gap'
+        );
+        assert.ok(
+            /\.plan-node-copy\s*\{[^}]*flex:\s*none/.test(css),
+            'expected the copy button to be flex: none so it never shrinks/stretches with a long title'
+        );
     });
 
     test('buildPlanStatusCss returns non-empty CSS', () => {

--- a/src/test/local/planWebview.test.ts
+++ b/src/test/local/planWebview.test.ts
@@ -1127,7 +1127,7 @@ suite('buildPlanContentHtml', () => {
                 const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
                 const hint = doc.querySelector('.plan-side-hint');
                 assert.ok(hint);
-                assert.ok(hint!.textContent!.includes("ALTER SESSION SET PROFILE = 'ON'"));
+                assert.ok(hint!.textContent!.includes('Reconnect with'));
             });
 
             test('omits the hint when at least one node has a defined CPU or Net', () => {
@@ -1198,6 +1198,11 @@ suite('buildPlanErrorHtml', () => {
         assert.ok(doc.querySelector('.plan-status-title'));
         assert.ok(doc.querySelector('.plan-status-message')!.textContent!.includes('boom'));
     });
+
+    test('renders a retry button when requested', () => {
+        const doc = parseDom(buildPlanErrorHtml({ message: 'boom', canRetry: true }));
+        assert.strictEqual(doc.querySelector('[data-plan-retry]')!.textContent, 'Retry');
+    });
 });
 
 suite('buildPlanLoadingHtml', () => {
@@ -1235,5 +1240,10 @@ suite('CSS builders', () => {
     test('buildPlanStatusCss returns non-empty CSS', () => {
         const css = buildPlanStatusCss();
         assert.ok(css.includes('.plan-status-container'));
+    });
+
+    test('the retry button has a visible :focus-visible outline, same as every other interactive control in this feature', () => {
+        const css = buildPlanStatusCss();
+        assert.ok(/\.plan-retry-btn:focus-visible\s*\{[^}]*outline/.test(css));
     });
 });

--- a/src/test/local/planWebview.test.ts
+++ b/src/test/local/planWebview.test.ts
@@ -831,7 +831,41 @@ suite('buildPlanContentHtml', () => {
             assert.strictEqual(dropConn.style.marginLeft, '400px', 'expected the drop connector centered under B\'s ring, 400px from the track\'s own left edge');
 
             const rowEl = track.querySelectorAll('.hflow-row')[1] as HTMLElement;
-            assert.strictEqual(rowEl.style.transform, 'translateX(350px)', 'expected row 1 shifted by exactly the gap between C\'s unshifted position (50) and B\'s ring (400)');
+            assert.strictEqual(rowEl.style.left, '350px', 'expected row 1 shifted by exactly the gap between C\'s unshifted position (50) and B\'s ring (400)');
+        });
+
+        test('shifts a wrapped row via position:relative + left, never via transform (transform would trap a popover\'s z-index inside the row\'s own stacking context)', () => {
+            // Regression test for a real bug (caught against real
+            // screenshots): a popover opened on an earlier row painted
+            // BELOW the content of later rows. `transform` creates a new
+            // stacking context on the row it's applied to, so the
+            // popover's z-index only ever won within that row's own
+            // context — later sibling rows (also stacking contexts,
+            // painted later in DOM order) drew over it regardless of
+            // z-index. `position: relative` + `left` moves a row
+            // identically without creating a stacking context, so a
+            // popover's z-index is free to compete at the track level
+            // against every row, not just its own.
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const doc = dom.window.document;
+            const track = doc.querySelector('.hflow-track')!;
+            stubRows(flowItemsOf(dom), [2, 3]);
+
+            stubRect(track, { top: 0, bottom: 1000, left: 1000, right: 2000 });
+            const nodeB = doc.querySelector('.hnode[data-node-id="2"]')!.closest('.hstep')!;
+            const nodeC = doc.querySelector('.hnode[data-node-id="3"]')!.closest('.hstep')!;
+            stubRingCenter(nodeB, 1400);
+            stubRingCenter(nodeC, 1050);
+
+            resize(dom);
+
+            const rows = Array.from(track.querySelectorAll('.hflow-row')) as HTMLElement[];
+            rows.forEach(row => {
+                assert.strictEqual(row.style.transform, '', 'no .hflow-row may carry a transform: it would create a stacking context that traps the popover z-index inside that row');
+            });
+            assert.strictEqual(rows[0].style.position, '', 'row 0 is never shifted, so it gets no inline position either');
+            assert.strictEqual(rows[1].style.position, 'relative', 'the shifted row must use position:relative, not a transform, to move without creating a stacking context');
+            assert.strictEqual(rows[1].style.left, '350px');
         });
 
         test('hides (not removes) the original connector for the node that now starts a new row, and carries its rows-out label onto the drop connector', () => {

--- a/src/test/local/planWebview.test.ts
+++ b/src/test/local/planWebview.test.ts
@@ -1,0 +1,1239 @@
+import * as assert from 'assert';
+import { JSDOM } from 'jsdom';
+import {
+    buildPlanContentHtml,
+    buildPlanContentCss,
+    buildPlanErrorHtml,
+    buildPlanLoadingHtml,
+    buildPlanStatusCss
+} from '../../plan/planWebview';
+import { Plan, PlanNode, OperatorTraits } from '../../plan/planModel';
+
+function parseDom(html: string): Document {
+    return new JSDOM(`<html><body>${html}</body></html>`).window.document;
+}
+
+/** Actually executes the inline click-handling script, unlike parseDom()
+ * above — needed to prove the popover's open/close/keyboard behavior at
+ * runtime, not just that the right-looking script text is present. */
+function buildInteractiveDom(plan: Plan): JSDOM {
+    const html = buildPlanContentHtml(plan, 'n0nce');
+    return new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: 'dangerously' });
+}
+
+function click(dom: JSDOM, el: Element): void {
+    el.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+}
+
+function keydown(dom: JSDOM, el: Element, key: string): void {
+    el.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+}
+
+function popoverFor(dom: JSDOM, node: Element): HTMLElement {
+    return node.parentElement!.querySelector('[data-popover]') as HTMLElement;
+}
+
+/** JSDOM's real getBoundingClientRect() is always an all-zero rect (no
+ * layout engine), which can't exercise "is there more room above or
+ * below" branches at all — this stubs a concrete rect on one element so a
+ * test can control exactly what positionPopover() sees. */
+function stubRect(el: Element, rect: { top: number; bottom: number; left?: number; right?: number }): void {
+    const left = rect.left ?? 0;
+    const right = rect.right ?? left + 200;
+    (el as unknown as { getBoundingClientRect: () => DOMRect }).getBoundingClientRect = () => ({
+        top: rect.top, bottom: rect.bottom, left, right,
+        width: right - left, height: rect.bottom - rect.top, x: left, y: rect.top,
+        toJSON() { return this; }
+    });
+}
+
+function stubOffsetHeight(el: Element, height: number): void {
+    Object.defineProperty(el, 'offsetHeight', { value: height, configurable: true });
+}
+
+/** Stubs the rect of a flow item's ring specifically (its actual visual
+ * anchor), given the item is a .hstep or bare .hnode-wrap — matching what
+ * layoutFlowRows()'s own ringCenterX() looks up. */
+function stubRingCenter(item: Element, centerX: number): void {
+    const ring = item.querySelector('.hnode-ring') ?? item;
+    stubRect(ring, { top: 0, bottom: 46, left: centerX - 23, right: centerX + 23 });
+}
+
+const PASSTHROUGH_TRAITS: OperatorTraits = {
+    producesRows: true, consumesRows: true, canSpill: true,
+    movesDataOverNetwork: true, blocking: true, isSystemStep: false
+};
+
+function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
+    return {
+        id: '1',
+        operatorType: 'JOIN',
+        operatorLabel: 'JOIN',
+        traits: PASSTHROUGH_TRAITS,
+        objectSchema: undefined,
+        objectName: undefined,
+        partInfo: undefined,
+        remarks: undefined,
+        rowsOut: 100,
+        duration: 0.01,
+        cpu: 50,
+        net: undefined,
+        tempDbRamPeak: undefined,
+        hddWrite: undefined,
+        costPercent: 25,
+        perNodeStats: undefined,
+        warnings: [],
+        children: [],
+        ...overrides
+    };
+}
+
+function makePlan(nodes: PlanNode[], overrides: Partial<Plan> = {}): Plan {
+    return {
+        sessionId: '1',
+        stmtId: '1',
+        queryText: 'SELECT 1',
+        totalDuration: 0.04,
+        nodes,
+        edges: [],
+        perNodeStatsAvailable: false,
+        source: 'USER_SUMMARY',
+        ...overrides
+    };
+}
+
+suite('buildPlanContentHtml', () => {
+
+    test('renders one node per plan node, in order', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', operatorLabel: 'SCAN' }),
+            makeNode({ id: '2', operatorLabel: 'JOIN' }),
+            makeNode({ id: '3', operatorLabel: 'SORT' })
+        ]);
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+        const names = Array.from(doc.querySelectorAll('.hnode-name')).map(el => el.textContent);
+        assert.deepStrictEqual(names, ['SCAN', 'JOIN', 'SORT']);
+    });
+
+    test('escapes a malicious operator label / object name / remarks / query text', () => {
+        const evil = '<script>alert(1)</script>';
+        const plan = makePlan(
+            [makeNode({ operatorLabel: evil, objectSchema: evil, objectName: evil, remarks: evil })],
+            { queryText: evil }
+        );
+        const html = buildPlanContentHtml(plan, 'n0nce');
+
+        assert.ok(!html.includes('<script>alert(1)</script>'), 'raw script tag must never appear');
+        assert.ok(html.includes('&lt;script&gt;'), 'expected escaped angle brackets somewhere in output');
+    });
+
+    test('renders the query text in a <pre> block', () => {
+        const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+        const pre = doc.querySelector('.plan-sql');
+        assert.ok(pre);
+        assert.strictEqual(pre!.textContent, 'SELECT * FROM t');
+    });
+
+    test('omits the query block entirely when queryText is undefined', () => {
+        const plan = makePlan([makeNode()], { queryText: undefined });
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+        assert.strictEqual(doc.querySelector('.plan-sql'), null);
+    });
+
+    suite('collapsible query text', () => {
+        test('the toggle is a real, keyboard-activatable button with aria-expanded', () => {
+            const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const toggle = doc.querySelector('[data-sql-toggle]')!;
+            assert.strictEqual(toggle.tagName, 'BUTTON');
+            assert.strictEqual(toggle.getAttribute('aria-expanded'), 'false');
+        });
+
+        test('the query text is hidden by default, behind the toggle', () => {
+            const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.ok(doc.querySelector('.plan-sql')!.hasAttribute('hidden'));
+        });
+
+        test('the stylesheet actually hides the query block\'s [hidden], not just sets the attribute', () => {
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.plan-sql\[hidden\]\s*\{[^}]*display:\s*none/.test(css),
+                'expected an explicit .plan-sql[hidden] { display: none } override in the stylesheet'
+            );
+        });
+
+        test('the toggle script targets the query block specifically, not the whole document', () => {
+            const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+            const html = buildPlanContentHtml(plan, 'n0nce');
+            assert.ok(html.includes('data-sql-toggle'));
+            assert.ok(html.includes('nextElementSibling'), 'expected the toggle to reference its sibling, not query the whole document');
+        });
+
+        test('clicking the toggle reveals the query text, flips the label, and updates aria-expanded (real script execution)', () => {
+            const plan = makePlan([makeNode()], { queryText: 'SELECT * FROM t' });
+            const dom = buildInteractiveDom(plan);
+            const toggle = dom.window.document.querySelector('[data-sql-toggle]')!;
+            const sql = dom.window.document.querySelector('.plan-sql') as HTMLElement;
+            assert.strictEqual(sql.hidden, true);
+            assert.strictEqual(toggle.textContent, '▸ Query text');
+
+            click(dom, toggle);
+            assert.strictEqual(sql.hidden, false, 'clicking the toggle must reveal the query text');
+            assert.strictEqual(toggle.textContent, '▾ Query text');
+            assert.strictEqual(toggle.getAttribute('aria-expanded'), 'true');
+
+            click(dom, toggle);
+            assert.strictEqual(sql.hidden, true, 'clicking it again must hide the query text');
+            assert.strictEqual(toggle.getAttribute('aria-expanded'), 'false');
+        });
+    });
+
+    suite('cost ring', () => {
+        // The ring's fill is carried as data-ring-pct/data-ring-color, NOT an
+        // inline style="" attribute — the webview's CSP has no
+        // 'unsafe-hashes'/'unsafe-inline' on style-src, and a style-src nonce
+        // only covers nonce'd <style> elements, never inline style attributes,
+        // so the browser would silently drop a style="" here. The value is
+        // painted via the CSSOM instead, by the nonce'd <script> (verified by
+        // the "real script execution" suite below, which checks the actually
+        // computed background rather than any markup attribute).
+        test('clamps a costPercent above 100 to a 100% ring fill', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', costPercent: 250 }),
+                makeNode({ id: '2', costPercent: 5 })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const ring = doc.querySelectorAll('.hnode-ring')[0];
+            assert.strictEqual(ring!.getAttribute('data-ring-pct'), '100');
+            assert.strictEqual(ring!.hasAttribute('style'), false, 'the ring fill must not be a CSP-blocked inline style attribute');
+        });
+
+        test('clamps a negative costPercent to a 0% ring fill', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', costPercent: -10 }),
+                makeNode({ id: '2', costPercent: 5 })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const ring = doc.querySelectorAll('.hnode-ring')[0];
+            assert.strictEqual(ring!.getAttribute('data-ring-pct'), '0');
+        });
+
+        test('renders a 0% ring fill rather than crashing when costPercent is undefined', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', costPercent: undefined }),
+                makeNode({ id: '2', costPercent: 5 })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const ring = doc.querySelectorAll('.hnode-ring')[0];
+            assert.strictEqual(ring!.getAttribute('data-ring-pct'), '0');
+        });
+
+        test('the hot node\'s ring color is carried as data-ring-color, not an inline style', () => {
+            const plan = makePlan([makeNode({ id: '1', costPercent: 50 })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const ring = doc.querySelector('.hnode-ring')!;
+            assert.strictEqual(ring.getAttribute('data-ring-color'), '--vscode-charts-red');
+        });
+    });
+
+    suite('the single highest-cost node', () => {
+        test('gets the hnode-hot class and nothing else does', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', operatorLabel: 'A', costPercent: 10 }),
+                makeNode({ id: '2', operatorLabel: 'B', costPercent: 62 }),
+                makeNode({ id: '3', operatorLabel: 'C', costPercent: 30 })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const hotNodes = doc.querySelectorAll('.hnode-hot');
+            assert.strictEqual(hotNodes.length, 1);
+            assert.strictEqual(hotNodes[0].querySelector('.hnode-name')!.textContent, 'B');
+        });
+
+        test('no node is marked hot when every costPercent is undefined', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', costPercent: undefined }),
+                makeNode({ id: '2', costPercent: undefined })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelectorAll('.hnode-hot').length, 0);
+        });
+    });
+
+    suite('connectors between nodes', () => {
+        test('labels the connector with the preceding node\'s real rowsOut', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', rowsOut: 17200 }),
+                makeNode({ id: '2', rowsOut: 500 })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const label = doc.querySelector('.hconn-label');
+            assert.ok(label);
+            assert.ok(label!.textContent!.includes('17.2k'));
+        });
+
+        test('omits the connector label (but keeps the connector line) when rowsOut is undefined', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', rowsOut: undefined }),
+                makeNode({ id: '2', rowsOut: 500 })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hconn-label'), null);
+            assert.ok(doc.querySelector('.hconn'));
+        });
+
+        test('renders exactly nodeCount - 1 connectors', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' }), makeNode({ id: '3' })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelectorAll('.hconn').length, 2);
+        });
+
+        test('groups each connector with its destination node in one .hstep, so the pair wraps together', () => {
+            // If the flow wraps onto a new row, a bare connector left as a
+            // standalone flex item could stay on the end of one row while
+            // the node it points to wraps to the next — an arrow pointing at
+            // nothing. Grouping them in one non-splitting flex item prevents
+            // that.
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2', operatorLabel: 'JOIN' })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const step = doc.querySelector('.hstep');
+            assert.ok(step, 'expected the second node to be wrapped in .hstep together with its connector');
+            assert.ok(step!.querySelector('.hconn'), '.hstep must contain the connector');
+            assert.ok(step!.querySelector('.hnode'), '.hstep must contain the destination node');
+            assert.strictEqual(step!.querySelector('.hnode-name')!.textContent, 'JOIN');
+        });
+
+        test('the first node is never wrapped in .hstep — it has no incoming connector', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hstep'), null);
+            assert.ok(doc.querySelector('.hnode'));
+        });
+    });
+
+    suite('nodes are real, accessible buttons', () => {
+        test('each node is a real <button>, not a div with a click handler bolted on', () => {
+            const plan = makePlan([makeNode()]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode')!.tagName, 'BUTTON');
+        });
+
+        test('the popover is a sibling of the button, not nested inside it', () => {
+            const plan = makePlan([makeNode()]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const button = doc.querySelector('.hnode')!;
+            assert.strictEqual(button.querySelector('[data-popover]'), null, 'the popover must not be a descendant of the button');
+            assert.ok(button.parentElement!.querySelector('[data-popover]'), 'the popover must be a sibling in the same wrapper');
+        });
+
+        test('the aria-label names the operator, its type, cost share, and warning count', () => {
+            const plan = makePlan([makeNode({
+                operatorLabel: 'PIPE AGGREGATOR',
+                operatorType: 'GROUP_BY',
+                costPercent: 43,
+                warnings: [{ type: 'SPILLED_TO_DISK', message: 'x', detail: {} }]
+            })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const label = doc.querySelector('.hnode')!.getAttribute('aria-label')!;
+            assert.ok(label.includes('PIPE AGGREGATOR'));
+            assert.ok(label.toLowerCase().includes('group by'));
+            assert.ok(label.includes('43%'));
+            assert.ok(label.includes('1 warning'));
+        });
+
+        test('the aria-label omits the warning clause entirely when there are none', () => {
+            const plan = makePlan([makeNode({ warnings: [] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const label = doc.querySelector('.hnode')!.getAttribute('aria-label')!;
+            assert.ok(!label.includes('warning'));
+        });
+
+        test('starts with aria-expanded="false" (popover not yet open)', () => {
+            const plan = makePlan([makeNode()]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode')!.getAttribute('aria-expanded'), 'false');
+        });
+
+        test('a malicious operator label cannot break out of the aria-label attribute', () => {
+            const evil = '"><script>alert(1)</script>';
+            const plan = makePlan([makeNode({ operatorLabel: evil })]);
+            const html = buildPlanContentHtml(plan, 'n0nce');
+            assert.ok(!html.includes('<script>alert(1)</script>'));
+        });
+
+        test('focusing a node and pressing Enter opens its popover, same as a click (real script execution)', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            assert.strictEqual(pop.hidden, true);
+
+            keydown(dom, node, 'Enter');
+            assert.strictEqual(pop.hidden, false, 'Enter must activate the node exactly like a click');
+            assert.strictEqual(node.getAttribute('aria-expanded'), 'true');
+        });
+
+        test('pressing Space also opens it, and the keydown is prevented (so the panel does not scroll)', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            const event = new dom.window.KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+            node.dispatchEvent(event);
+            assert.strictEqual(pop.hidden, false);
+            assert.strictEqual(event.defaultPrevented, true, 'Space must be preventDefault-ed so it never also scrolls the panel');
+        });
+
+        test('an unrelated key (e.g. Tab) does not open the popover', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            keydown(dom, node, 'Tab');
+            assert.strictEqual(pop.hidden, true);
+        });
+    });
+
+    suite('warning badge', () => {
+        test('shows the warning badge on a node with warnings', () => {
+            const plan = makePlan([makeNode({
+                warnings: [{ type: 'SPILLED_TO_DISK', message: 'spilled', detail: {} }]
+            })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.ok(doc.querySelector('.hnode-warn'));
+        });
+
+        test('omits the warning badge on a node with no warnings', () => {
+            const plan = makePlan([makeNode({ warnings: [] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.hnode-warn'), null);
+        });
+
+        test('the warning badge title lists a short label per warning, and is hidden from assistive tech (folded into the button\'s own aria-label instead)', () => {
+            const plan = makePlan([makeNode({
+                warnings: [
+                    { type: 'SPILLED_TO_DISK', message: 'Wrote 10 MiB', detail: {} },
+                    { type: 'LARGE_REDISTRIBUTION', message: 'Moved 500 MiB', detail: {} }
+                ]
+            })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const badge = doc.querySelector('.hnode-warn')!;
+            assert.strictEqual(badge.getAttribute('title'), 'spilled to disk, large redistribution');
+            assert.strictEqual(badge.getAttribute('aria-hidden'), 'true');
+        });
+
+        test('the popover lists the full (escaped) warning message for each warning', () => {
+            const plan = makePlan([makeNode({
+                warnings: [{ type: 'SPILLED_TO_DISK', message: 'Wrote 10 MiB <evil>', detail: {} }]
+            })]);
+            const html = buildPlanContentHtml(plan, 'n0nce');
+            const doc = parseDom(html);
+            assert.ok(doc.querySelector('.plan-popover')!.textContent!.includes('Wrote 10 MiB'));
+            assert.ok(!html.includes('<evil>'));
+        });
+    });
+
+    suite('the popover itself', () => {
+        test('every node has a corresponding hidden popover', () => {
+            const plan = makePlan([makeNode({ id: '7' })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const pop = doc.querySelector('.plan-popover');
+            assert.ok(pop);
+            assert.strictEqual(pop!.hasAttribute('hidden'), true);
+        });
+
+        test('the stylesheet actually hides [hidden], not just sets the attribute', () => {
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.plan-popover\[hidden\]\s*\{[^}]*display:\s*none/.test(css),
+                'expected an explicit .plan-popover[hidden] { display: none } override in the stylesheet'
+            );
+        });
+
+        test('is titled with the operator (and object, when present)', () => {
+            const withObject = parseDom(buildPlanContentHtml(
+                makePlan([makeNode({ operatorLabel: 'PIPE SCAN', objectSchema: 'S', objectName: 'T' })]), 'n0nce'
+            ));
+            assert.strictEqual(withObject.querySelector('.plan-popover-title')!.textContent, 'PIPE SCAN — S.T');
+
+            const withoutObject = parseDom(buildPlanContentHtml(makePlan([makeNode({ operatorLabel: 'COMPILE', objectName: undefined })]), 'n0nce'));
+            assert.strictEqual(withoutObject.querySelector('.plan-popover-title')!.textContent, 'COMPILE');
+        });
+
+        test('lists key fields not shown on the node face', () => {
+            const plan = makePlan([makeNode({ id: '42', cpu: 77.5 })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const detailText = doc.querySelector('.plan-popover')!.textContent!;
+            assert.ok(detailText.includes('42'));
+            assert.ok(detailText.includes('77.5'));
+        });
+
+        test('the per-node rows value is self-describing (min/max/avg/nodes labeled inline), matching the copy-as-text format', () => {
+            const plan = makePlan([makeNode({ perNodeStats: { metric: 'rows', min: 100, max: 900, avg: 500, nodeCount: 4 } })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const detailText = doc.querySelector('.plan-popover')!.textContent!;
+            assert.ok(detailText.includes('min 100 / max 900 / avg 500 / nodes 4'));
+        });
+
+        test('a long "not available" per-node-rows value wraps at word boundaries, not mid-word', () => {
+            // Regression test for a real screenshot: label-beside-value with
+            // word-break: break-word chopped "not available" into
+            // "not avai / labl / e" to fit a squeezed value column. The row
+            // must now stack label above value with overflow-wrap instead.
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.plan-detail-row\s*\{[^}]*flex-direction:\s*column/.test(css),
+                'expected .plan-detail-row to stack label above value, not squeeze them side by side'
+            );
+            assert.ok(
+                !/\.plan-detail-v\s*\{[^}]*word-break:\s*break-word/.test(css),
+                'word-break: break-word chops words mid-character to fit a narrow column — overflow-wrap: break-word (word-boundary-first) is the fix, not this'
+            );
+        });
+
+        test('the script carries the provided nonce', () => {
+            const plan = makePlan([makeNode()]);
+            const html = buildPlanContentHtml(plan, 'my-nonce-value');
+            assert.ok(html.includes('nonce="my-nonce-value"'));
+        });
+    });
+
+    suite('popover open/close behavior (real script execution, not just text matching)', () => {
+        test('clicking a node opens its popover', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelectorAll('.hnode')[0];
+            const pop = popoverFor(dom, node);
+            assert.strictEqual(pop.hidden, true);
+
+            click(dom, node);
+            assert.strictEqual(pop.hidden, false);
+        });
+
+        test('clicking inside an open popover does not close it', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            click(dom, node);
+            assert.strictEqual(pop.hidden, false, 'precondition: popover should be open');
+
+            const innerRow = pop.querySelector('.plan-detail-row')!;
+            click(dom, innerRow);
+            assert.strictEqual(pop.hidden, false, 'a click inside the popover must not close it');
+        });
+
+        test('clicking outside any node closes an open popover', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            click(dom, node);
+            assert.strictEqual(pop.hidden, false);
+
+            click(dom, dom.window.document.body);
+            assert.strictEqual(pop.hidden, true);
+            assert.strictEqual(node.getAttribute('aria-expanded'), 'false');
+        });
+
+        test('pressing Escape closes an open popover', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            click(dom, node);
+            assert.strictEqual(pop.hidden, false);
+
+            keydown(dom, dom.window.document.body, 'Escape');
+            assert.strictEqual(pop.hidden, true);
+        });
+
+        test('opening a second node\'s popover closes the first (accordion, not stacking)', () => {
+            const plan = makePlan([makeNode({ id: '1' }), makeNode({ id: '2' })]);
+            const dom = buildInteractiveDom(plan);
+            const [nodeA, nodeB] = Array.from(dom.window.document.querySelectorAll('.hnode'));
+            const popA = popoverFor(dom, nodeA);
+            const popB = popoverFor(dom, nodeB);
+
+            click(dom, nodeA);
+            assert.strictEqual(popA.hidden, false);
+
+            click(dom, nodeB);
+            assert.strictEqual(popA.hidden, true, 'opening a second popover must close the first');
+            assert.strictEqual(popB.hidden, false);
+        });
+
+        test('clicking an already-open node\'s own ring closes its popover again', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            click(dom, node);
+            assert.strictEqual(pop.hidden, false);
+
+            click(dom, node);
+            assert.strictEqual(pop.hidden, true, 'clicking the same node again should toggle the popover closed');
+        });
+    });
+
+    suite('popover positioning (flip-up when there is no room below)', () => {
+        test('opening a popover actually runs the positioning function and mutates its style, not just text-matches the script source', () => {
+            // JSDOM's getBoundingClientRect() always returns an all-zero rect
+            // (no real layout engine), which deterministically drives
+            // positionPopover() down its "too far left" horizontal branch —
+            // so opening ANY popover here should reliably mutate
+            // style.transform and set --arrow-shift, proving the function
+            // actually runs.
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            assert.strictEqual(pop.style.transform, '');
+            click(dom, node);
+            assert.notStrictEqual(pop.style.transform, '', 'positionPopover() must actually run and set a transform on open');
+            assert.ok(pop.style.getPropertyValue('--arrow-shift'), 'expected --arrow-shift to be set alongside the transform');
+
+            click(dom, node);
+            assert.strictEqual(pop.style.transform, '', 'closing the popover must reset the transform via resetPopover()');
+        });
+
+        test('the CSS defines a flip-up variant that opens above the node instead of below', () => {
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.plan-popover\.flip-up\s*\{[^}]*bottom:\s*calc/.test(css),
+                'expected .plan-popover.flip-up to anchor from the bottom (open upward) instead of the top'
+            );
+        });
+
+        test('closing a flipped-up popover resets the flip-up class', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            // Force the flipped state directly (JSDOM's zero-height layout
+            // never naturally triggers the "not enough room" branch), then
+            // confirm the close path still clears it via resetPopover().
+            pop.classList.add('flip-up');
+            click(dom, node);
+            click(dom, node);
+            assert.strictEqual(pop.classList.contains('flip-up'), false);
+        });
+
+        // Regression coverage for a real bug caught against a real
+        // screenshot: scrollArea.getBoundingClientRect() is relative to the
+        // currently visible, scrolled slice of the flow, not the whole
+        // thing — a node near the top of what's in view has just as little
+        // room above it as below, so blindly flipping whenever "below
+        // didn't fit" (the original rule) could flip a popover straight off
+        // the top of the scroll container, clipped to a barely-visible
+        // sliver. The fix compares both sides and only flips when doing so
+        // actually helps.
+        test('does not flip up merely because space below is tight — only when space above is actually greater', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 100);
+            // Node near the top of the visible slice: only 10px above it,
+            // but a healthy 570px below — below is clearly the better side,
+            // even though the popover (100 + 16 gap) doesn't fully fit there.
+            stubRect(node, { top: 10, bottom: 30 });
+            stubRect(scrollArea, { top: 0, bottom: 600 });
+
+            click(dom, node);
+            assert.strictEqual(pop.classList.contains('flip-up'), false, 'space below (570px) is far larger than space above (10px); it must not flip');
+        });
+
+        test('flips up when space above is genuinely greater than space below', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 100);
+            // Node near the bottom of the visible slice: plenty of room
+            // above (90px), almost none below (5px) — flipping now helps.
+            stubRect(node, { top: 90, bottom: 110 });
+            stubRect(scrollArea, { top: 0, bottom: 115 });
+
+            click(dom, node);
+            assert.strictEqual(pop.classList.contains('flip-up'), true);
+        });
+
+        test('when neither side actually fits, the popover is capped to the room available on the side it opens on, with its own scrollbar, rather than left to be clipped by the container', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 200);
+            // Space above (90px) is greater than space below (-15px, i.e.
+            // the node is already partly below the visible area), so it
+            // flips up — but 200px of popover still doesn't fit in 90px of
+            // available room above.
+            stubRect(node, { top: 90, bottom: 110 });
+            stubRect(scrollArea, { top: 0, bottom: 95 });
+
+            click(dom, node);
+            assert.strictEqual(pop.classList.contains('flip-up'), true, 'precondition: this scenario should flip (90px above beats -15px below)');
+            assert.strictEqual(pop.style.maxHeight, '74px', 'expected the cap to be the actual room available above (90 - 16px gap), not a bare guess');
+            assert.strictEqual(pop.style.overflowY, 'auto', 'expected an internal scrollbar so the rest of the content stays reachable');
+        });
+
+        test('does not cap the height when the popover already fits in the space it opens on', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 100);
+            stubRect(node, { top: 10, bottom: 30 });
+            stubRect(scrollArea, { top: 0, bottom: 600 });
+
+            click(dom, node);
+            assert.strictEqual(pop.style.maxHeight, '', 'plenty of room below (570px) for a 100px popover; no cap should be applied');
+        });
+
+        test('closing resets the height cap and scrollbar alongside the flip-up class', () => {
+            const plan = makePlan([makeNode({ id: '1' })]);
+            const dom = buildInteractiveDom(plan);
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+            const scrollArea = dom.window.document.querySelector('.plan-flow-h')!;
+
+            stubOffsetHeight(pop, 200);
+            stubRect(node, { top: 90, bottom: 110 });
+            stubRect(scrollArea, { top: 0, bottom: 95 });
+
+            click(dom, node);
+            assert.notStrictEqual(pop.style.maxHeight, '', 'precondition: this scenario should have capped the height');
+
+            click(dom, node);
+            assert.strictEqual(pop.style.maxHeight, '');
+            assert.strictEqual(pop.style.overflowY, '');
+        });
+    });
+
+    suite('snake/boustrophedon row wrap (real script execution)', () => {
+        // JSDOM has no real layout engine, so offsetTop is always 0 for
+        // every element by default — the initial script run therefore
+        // always measures a single row (correctly: there's nothing to do
+        // when nothing wrapped). To exercise the restructuring itself,
+        // these tests stub offsetTop per item to simulate a real wrap, then
+        // dispatch a 'resize' event — the same relayout the real script
+        // runs on load also runs on resize, so this is the one hook these
+        // tests need to trigger it deterministically.
+        function flowItemsOf(dom: JSDOM): Element[] {
+            return Array.from(dom.window.document.querySelectorAll('.hflow-track > .hnode-wrap, .hflow-track > .hstep'));
+        }
+
+        function stubRows(items: Element[], rowSizes: number[]): void {
+            let idx = 0;
+            rowSizes.forEach((size, rowIndex) => {
+                for (let i = 0; i < size; i++) {
+                    Object.defineProperty(items[idx], 'offsetTop', { value: rowIndex * 100, configurable: true });
+                    idx += 1;
+                }
+            });
+        }
+
+        function resize(dom: JSDOM): void {
+            dom.window.dispatchEvent(new dom.window.Event('resize'));
+        }
+
+        function fiveNodePlan(): Plan {
+            return makePlan([
+                makeNode({ id: '1', operatorLabel: 'A', rowsOut: 100 }),
+                makeNode({ id: '2', operatorLabel: 'B', rowsOut: 200 }),
+                makeNode({ id: '3', operatorLabel: 'C', rowsOut: 300 }),
+                makeNode({ id: '4', operatorLabel: 'D', rowsOut: 400 }),
+                makeNode({ id: '5', operatorLabel: 'E', rowsOut: 500 })
+            ]);
+        }
+
+        test('leaves the flow exactly as rendered when everything measures on a single row', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const track = dom.window.document.querySelector('.hflow-track')!;
+            assert.strictEqual(track.querySelectorAll('.hflow-row').length, 0);
+            assert.strictEqual(track.classList.contains('hflow-track-snaked'), false);
+        });
+
+        test('restructures into one .hflow-row per measured row once the flow wraps, reversing alternate rows', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const track = dom.window.document.querySelector('.hflow-track')!;
+            stubRows(flowItemsOf(dom), [2, 3]);
+            resize(dom);
+
+            assert.strictEqual(track.classList.contains('hflow-track-snaked'), true);
+            const rows = track.querySelectorAll('.hflow-row');
+            assert.strictEqual(rows.length, 2);
+            assert.strictEqual(rows[0].classList.contains('hflow-row-reverse'), false, 'row 0 must read left-to-right, unchanged');
+            assert.strictEqual(rows[1].classList.contains('hflow-row-reverse'), true, 'row 1 must be reversed');
+        });
+
+        test('keeps DOM order matching the real flow order even inside a reversed row (visual flip is CSS-only)', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            stubRows(flowItemsOf(dom), [2, 3]);
+            resize(dom);
+
+            const names = Array.from(dom.window.document.querySelectorAll('.hnode-name')).map(el => el.textContent);
+            assert.deepStrictEqual(names, ['A', 'B', 'C', 'D', 'E'], 'tab/DOM order must stay in logical flow order; only CSS reverses the visual row');
+        });
+
+        test('inserts exactly one .hflow-drop between rows', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const track = dom.window.document.querySelector('.hflow-track')!;
+            stubRows(flowItemsOf(dom), [2, 3]);
+            resize(dom);
+
+            assert.strictEqual(track.querySelectorAll('.hflow-drop').length, 1, 'expected exactly rows.length - 1 drop connectors');
+        });
+
+        test('aligns the drop connector and the next row to where the previous row\'s last ring actually ended up, not to the track\'s edge', () => {
+            // Regression test for a real bug (caught against a real
+            // screenshot): the drop arrow and the next row's node both
+            // landed visibly off-center from the ring they were meant to
+            // continue from. Packing against the track's full width only
+            // lines up by coincidence — a row's real content width is
+            // whatever fit before it wrapped, essentially never exactly the
+            // track's width. The fix measures the actual ring position and
+            // aligns to that directly.
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const doc = dom.window.document;
+            const track = doc.querySelector('.hflow-track')!;
+            stubRows(flowItemsOf(dom), [2, 3]);
+
+            // The track itself sits at x=1000 in the viewport, to prove the
+            // computation is relative to the track, not the raw viewport.
+            stubRect(track, { top: 0, bottom: 1000, left: 1000, right: 2000 });
+            const nodeB = doc.querySelector('.hnode[data-node-id="2"]')!.closest('.hstep')!;
+            const nodeC = doc.querySelector('.hnode[data-node-id="3"]')!.closest('.hstep')!;
+            stubRingCenter(nodeB, 1400); // B is row 0's last item; its ring sits at x=1400 in the viewport (400 relative to the track)
+            stubRingCenter(nodeC, 1050); // C is row 1's first item; its unshifted ring sits at x=1050 (50 relative to the track)
+
+            resize(dom);
+
+            const dropConn = track.querySelector('.hflow-drop-connector') as HTMLElement;
+            assert.strictEqual(dropConn.style.marginLeft, '400px', 'expected the drop connector centered under B\'s ring, 400px from the track\'s own left edge');
+
+            const rowEl = track.querySelectorAll('.hflow-row')[1] as HTMLElement;
+            assert.strictEqual(rowEl.style.transform, 'translateX(350px)', 'expected row 1 shifted by exactly the gap between C\'s unshifted position (50) and B\'s ring (400)');
+        });
+
+        test('hides (not removes) the original connector for the node that now starts a new row, and carries its rows-out label onto the drop connector', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const doc = dom.window.document;
+            stubRows(flowItemsOf(dom), [2, 3]);
+            resize(dom);
+
+            const nodeC = doc.querySelector('.hnode[data-node-id="3"]')!;
+            const stepC = nodeC.closest('.hstep')!;
+            const originalConn = stepC.querySelector('.hconn')!;
+            assert.strictEqual(originalConn.classList.contains('hconn-hidden'), true);
+            assert.ok(doc.contains(originalConn), 'the original connector must be hidden, not removed, so a later relayout can restore it');
+
+            const drop = doc.querySelector('.hflow-drop')!;
+            const dropLabel = drop.querySelector('.hconn-label')!;
+            assert.ok(dropLabel.textContent!.includes('200'), 'expected the drop connector to carry over node B\'s rowsOut label');
+        });
+
+        test('does not touch the connector between two nodes on the same row', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const doc = dom.window.document;
+            stubRows(flowItemsOf(dom), [2, 3]);
+            resize(dom);
+
+            const nodeB = doc.querySelector('.hnode[data-node-id="2"]')!;
+            const stepB = nodeB.closest('.hstep')!;
+            assert.strictEqual(stepB.querySelector('.hconn')!.classList.contains('hconn-hidden'), false);
+        });
+
+        test('a node moved into a reversed row is still a working popover trigger (event listeners survive the move)', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const doc = dom.window.document;
+            stubRows(flowItemsOf(dom), [2, 3]);
+            resize(dom);
+
+            const nodeD = doc.querySelector('.hnode[data-node-id="4"]')!;
+            const pop = popoverFor(dom, nodeD);
+            assert.strictEqual(pop.hidden, true);
+
+            click(dom, nodeD);
+            assert.strictEqual(pop.hidden, false, 'a node relocated into a reversed row must still open its popover on click');
+        });
+
+        test('relaying out again on a later resize starts fresh, rather than layering onto the previous split', () => {
+            const dom = buildInteractiveDom(fiveNodePlan());
+            const track = dom.window.document.querySelector('.hflow-track')!;
+            const items = flowItemsOf(dom);
+
+            stubRows(items, [2, 3]);
+            resize(dom);
+            assert.strictEqual(track.querySelectorAll('.hflow-row').length, 2, 'precondition: first resize produced two rows');
+
+            items.forEach(item => Object.defineProperty(item, 'offsetTop', { value: 0, configurable: true }));
+            resize(dom);
+
+            assert.strictEqual(track.querySelectorAll('.hflow-row').length, 0, 'a resize that now fits everything on one row must revert to the flat structure');
+            assert.strictEqual(track.querySelectorAll('.hflow-drop').length, 0);
+            assert.strictEqual(track.querySelectorAll('.hconn-hidden').length, 0, 'no connector should be left stuck hidden after reverting to one row');
+            assert.strictEqual(track.classList.contains('hflow-track-snaked'), false);
+        });
+
+        test('the CSS defines the reversed-row and drop-connector rules', () => {
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.hflow-row-reverse\s*\{[^}]*flex-direction:\s*row-reverse/.test(css),
+                'expected .hflow-row-reverse to reverse the row\'s own flex direction'
+            );
+            assert.ok(
+                /\.hflow-row-reverse\s+\.hstep\s*\{[^}]*flex-direction:\s*row-reverse/.test(css),
+                'expected each .hstep inside a reversed row to also flip internally, or its connector lands on the wrong side of its node'
+            );
+            assert.ok(css.includes('.hflow-drop'), 'expected drop-connector styling for the row-to-row transition');
+        });
+
+        test('a reversed row does not pair row-reverse with justify-content: flex-end', () => {
+            // Regression test for a real bug (caught via a real screenshot):
+            // row-reverse swaps which physical edge "main-end" refers to, so
+            // justify-content: flex-end under row-reverse packs content
+            // against the LEFT edge, not the right — sending the reversed
+            // row straight back to the far-left position this feature exists
+            // to fix. The default (flex-start) is what actually packs a
+            // row-reverse container's content flush right.
+            const css = buildPlanContentCss();
+            assert.ok(
+                !/\.hflow-row-reverse\s*\{[^}]*justify-content:\s*flex-end/.test(css),
+                'row-reverse already redefines "end" as the left edge — an explicit justify-content: flex-end here undoes the reversal'
+            );
+        });
+
+        test('the connector-hidden override has enough specificity to actually beat .hconn\'s own display rule', () => {
+            // Regression test for a real bug: a bare .hconn-hidden { display:
+            // none } ties in specificity with .hconn { display: flex }
+            // (both single-class selectors), so which one wins depends on
+            // source order rather than intent — and in the shipped
+            // stylesheet .hconn's rule happened to come later, silently
+            // defeating the hide and leaving a stale connector on screen
+            // right next to the row it no longer connects to anything on.
+            const css = buildPlanContentCss();
+            assert.ok(
+                /\.hconn\.hconn-hidden\s*\{[^}]*display:\s*none/.test(css),
+                'expected the two-class .hconn.hconn-hidden selector, which beats .hconn\'s own display rule regardless of source order'
+            );
+        });
+    });
+
+    suite('warnings summary (side rail)', () => {
+        test('renders one item per warning across the whole plan, not per node', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', warnings: [
+                    { type: 'SPILLED_TO_DISK', message: 'a', detail: {} },
+                    { type: 'HIGH_SKEW', message: 'b', detail: {} }
+                ] }),
+                makeNode({ id: '2', warnings: [{ type: 'LARGE_REDISTRIBUTION', message: 'c', detail: {} }] })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelectorAll('.plan-warning-item').length, 3);
+            assert.ok(doc.querySelector('.plan-side-warnings')!.textContent!.includes('Warnings (3)'));
+        });
+
+        test('omits the warnings card entirely when no node has any warning', () => {
+            const plan = makePlan([makeNode({ warnings: [] }), makeNode({ id: '2', warnings: [] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.plan-side-warnings'), null);
+        });
+
+        test('each item names the operator, its part id, and the full warning message', () => {
+            const plan = makePlan([makeNode({
+                id: '9', operatorLabel: 'PIPE AGGREGATOR',
+                warnings: [{ type: 'SPILLED_TO_DISK', message: 'Wrote 12.5 MiB to disk during execution', detail: {} }]
+            })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const item = doc.querySelector('.plan-warning-item')!;
+            assert.ok(item.textContent!.includes('PIPE AGGREGATOR'));
+            assert.ok(item.textContent!.includes('part 9'));
+            assert.ok(item.textContent!.includes('Wrote 12.5 MiB to disk during execution'));
+        });
+
+        test('each item is a real, keyboard-activatable button', () => {
+            const plan = makePlan([makeNode({ warnings: [{ type: 'SPILLED_TO_DISK', message: 'x', detail: {} }] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.plan-warning-item')!.tagName, 'BUTTON');
+        });
+
+        test('clicking a warning item opens the popover for the node it came from (real script execution)', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', warnings: [] }),
+                makeNode({ id: '2', warnings: [{ type: 'SPILLED_TO_DISK', message: 'x', detail: {} }] })
+            ]);
+            const dom = buildInteractiveDom(plan);
+            const warningItem = dom.window.document.querySelector('.plan-warning-item')!;
+            const node2 = dom.window.document.querySelector('.hnode[data-node-id="2"]')!;
+            const pop2 = popoverFor(dom, node2);
+            assert.strictEqual(pop2.hidden, true);
+
+            click(dom, warningItem);
+            assert.strictEqual(pop2.hidden, false, 'clicking the warning item must open node 2\'s popover, whose warning it is');
+        });
+
+        test('pressing Enter on a warning item also opens its node\'s popover', () => {
+            const plan = makePlan([makeNode({ id: '1', warnings: [{ type: 'SPILLED_TO_DISK', message: 'x', detail: {} }] })]);
+            const dom = buildInteractiveDom(plan);
+            const warningItem = dom.window.document.querySelector('.plan-warning-item')!;
+            const node = dom.window.document.querySelector('.hnode')!;
+            const pop = popoverFor(dom, node);
+
+            keydown(dom, warningItem, 'Enter');
+            assert.strictEqual(pop.hidden, false);
+        });
+    });
+
+    suite('CSP-safe dynamic styling (real script execution, not just markup attributes)', () => {
+        // Regression coverage for a real bug: the ring/bar/legend colors used
+        // to be plain style="" attributes. The webview's CSP has no
+        // 'unsafe-inline'/'unsafe-hashes' on style-src, and a style-src nonce
+        // only covers nonce'd <style> ELEMENTS — never inline style
+        // ATTRIBUTES — so the browser silently dropped them. Values now travel
+        // as data-* attributes and get painted by the nonce'd script via the
+        // CSSOM, which these tests actually execute and observe.
+        test('paints the ring background from data-ring-pct/data-ring-color', () => {
+            const plan = makePlan([makeNode({ id: '1', costPercent: 40 })]);
+            const dom = buildInteractiveDom(plan);
+            const ring = dom.window.document.querySelector('.hnode-ring') as HTMLElement;
+            assert.ok(
+                ring.style.background.includes('conic-gradient') && ring.style.background.includes('40%'),
+                `expected the ring's computed background to be a conic-gradient reflecting 40%, got: ${ring.style.background}`
+            );
+        });
+
+        test('paints each category-bar segment\'s width and color', () => {
+            const plan = makePlan([makeNode({ id: '1', operatorType: 'SCAN', duration: 4 })], { totalDuration: 4 });
+            const dom = buildInteractiveDom(plan);
+            const segment = dom.window.document.querySelector('.hcat-bar span') as HTMLElement;
+            assert.strictEqual(segment.style.width, '100%');
+            assert.ok(segment.style.backgroundColor.includes('--vscode-charts-blue'));
+        });
+
+        test('paints the legend swatch color', () => {
+            const plan = makePlan([makeNode({ id: '1', operatorType: 'SCAN', duration: 4 })], { totalDuration: 4 });
+            const dom = buildInteractiveDom(plan);
+            const swatch = dom.window.document.querySelector('.hcat-legend i') as HTMLElement;
+            assert.ok(swatch.style.backgroundColor.includes('--vscode-charts-blue'));
+        });
+    });
+
+    suite('time by category', () => {
+        test('renders one bar segment per operatorType present, proportioned by its share of totalDuration', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', operatorType: 'SCAN', duration: 3 }),
+                makeNode({ id: '2', operatorType: 'JOIN', duration: 1 })
+            ], { totalDuration: 4 });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelectorAll('.hcat-bar span').length, 2);
+        });
+
+        test('carries each segment\'s width/color as data attributes, not a CSP-blocked inline style', () => {
+            const plan = makePlan([makeNode({ id: '1', operatorType: 'SCAN', duration: 4 })], { totalDuration: 4 });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const segment = doc.querySelector('.hcat-bar span')!;
+            assert.strictEqual(segment.getAttribute('data-width'), '100');
+            assert.strictEqual(segment.getAttribute('data-color-var'), '--vscode-charts-blue');
+            assert.strictEqual(segment.hasAttribute('style'), false);
+
+            const swatch = doc.querySelector('.hcat-legend i')!;
+            assert.strictEqual(swatch.getAttribute('data-color-var'), '--vscode-charts-blue');
+            assert.strictEqual(swatch.hasAttribute('style'), false);
+        });
+
+        test('shows "not available" instead of a bar when totalDuration is zero', () => {
+            const plan = makePlan([makeNode({ duration: undefined })], { totalDuration: 0 });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.ok(doc.querySelector('.hcat-empty'));
+            assert.strictEqual(doc.querySelector('.hcat-bar'), null);
+        });
+
+        test('lists each category with its percent share in the legend', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', operatorType: 'SCAN', duration: 3 }),
+                makeNode({ id: '2', operatorType: 'JOIN', duration: 1 })
+            ], { totalDuration: 4 });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const legendText = doc.querySelector('.hcat-legend')!.textContent!;
+            assert.ok(legendText.includes('Scan'));
+            assert.ok(legendText.includes('75%'));
+            assert.ok(legendText.includes('Join'));
+            assert.ok(legendText.includes('25%'));
+        });
+    });
+
+    suite('side rail', () => {
+        test('labels DETAILS as per-node detail', () => {
+            const plan = makePlan([makeNode()], { source: 'DETAILS' });
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.ok(doc.querySelector('.plan-side')!.textContent!.includes('per-node detail'));
+        });
+
+        test('labels DBA_SUMMARY distinctly from USER_SUMMARY', () => {
+            const dba = parseDom(buildPlanContentHtml(makePlan([makeNode()], { source: 'DBA_SUMMARY' }), 'n0nce'));
+            const user = parseDom(buildPlanContentHtml(makePlan([makeNode()], { source: 'USER_SUMMARY' }), 'n0nce'));
+            assert.ok(dba.querySelector('.plan-side')!.textContent!.includes('DBA'));
+            assert.ok(!user.querySelector('.plan-side')!.textContent!.includes('DBA'));
+        });
+
+        test('shows "not available" for node count when no per-node stats exist anywhere', () => {
+            const plan = makePlan([makeNode({ perNodeStats: undefined })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.ok(doc.querySelector('.plan-side')!.textContent!.includes('not available'));
+        });
+
+        test('shows the max observed node count when per-node stats exist', () => {
+            const plan = makePlan([
+                makeNode({ id: '1', perNodeStats: { metric: 'rows', min: 1, max: 1, avg: 1, nodeCount: 4 } }),
+                makeNode({ id: '2', perNodeStats: { metric: 'rows', min: 1, max: 1, avg: 1, nodeCount: 2 } })
+            ]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            const values = Array.from(doc.querySelectorAll('.plan-side-row span:last-child')).map(el => el.textContent);
+            assert.ok(values.includes('4'));
+        });
+
+        test('holds only plan-level summary cards — no per-node detail card duplicating the popover', () => {
+            const plan = makePlan([makeNode({ warnings: [{ type: 'SPILLED_TO_DISK', message: 'x', detail: {} }] })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.strictEqual(doc.querySelector('.plan-detail-block'), null);
+            assert.strictEqual(doc.querySelector('.plan-detail-card'), null);
+        });
+
+        suite('PROFILE-not-enabled hint', () => {
+            test('shows an educational hint when no node has a defined CPU or Net', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', cpu: undefined, net: undefined }),
+                    makeNode({ id: '2', cpu: undefined, net: undefined })
+                ]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                const hint = doc.querySelector('.plan-side-hint');
+                assert.ok(hint);
+                assert.ok(hint!.textContent!.includes("ALTER SESSION SET PROFILE = 'ON'"));
+            });
+
+            test('omits the hint when at least one node has a defined CPU or Net', () => {
+                const plan = makePlan([
+                    makeNode({ id: '1', cpu: undefined, net: undefined }),
+                    makeNode({ id: '2', cpu: 12.5, net: undefined })
+                ]);
+                const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+                assert.strictEqual(doc.querySelector('.plan-side-hint'), null);
+            });
+        });
+    });
+
+    suite('copy as text', () => {
+        test('renders a copy button and a hidden textarea carrying the plan text summary', () => {
+            const plan = makePlan([makeNode({ operatorLabel: 'PIPE SCAN' })]);
+            const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+            assert.ok(doc.querySelector('[data-copy-plan]'), 'expected a copy-as-text button');
+            const textarea = doc.querySelector('#plan-text-data') as HTMLTextAreaElement;
+            assert.ok(textarea);
+            assert.strictEqual(textarea.hasAttribute('hidden'), true);
+            assert.ok(textarea.value.includes('PIPE SCAN'), 'expected the embedded text to include the rendered operator');
+        });
+
+        test('escapes a malicious query/operator value inside the embedded textarea', () => {
+            const evil = '</textarea><script>alert(1)</script>';
+            const plan = makePlan([makeNode({ operatorLabel: evil })]);
+            const html = buildPlanContentHtml(plan, 'n0nce');
+            assert.ok(!html.includes('</textarea><script>'), 'raw markup must never appear unescaped inside the textarea');
+        });
+
+        test('the copy button posts a copyPlanText message with the textarea contents', () => {
+            const plan = makePlan([makeNode()]);
+            const html = buildPlanContentHtml(plan, 'n0nce');
+            assert.ok(html.includes('data-copy-plan'));
+            assert.ok(html.includes("command: 'copyPlanText'"), 'expected the click handler to post the copyPlanText command');
+            assert.ok(html.includes('plan-text-data'), 'expected the handler to read from the embedded textarea');
+        });
+    });
+
+    test('renders an empty-state message rather than an empty flow when there are no nodes', () => {
+        const plan = makePlan([]);
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+        assert.ok(doc.querySelector('.plan-empty'));
+        assert.strictEqual(doc.querySelectorAll('.hnode').length, 0);
+    });
+
+    test('dims system-step nodes (e.g. COMPILE) but does not hide them', () => {
+        const plan = makePlan([makeNode({
+            operatorType: 'SYSTEM',
+            operatorLabel: 'COMPILE',
+            traits: { ...PASSTHROUGH_TRAITS, isSystemStep: true }
+        })]);
+        const doc = parseDom(buildPlanContentHtml(plan, 'n0nce'));
+        assert.ok(doc.querySelector('.hnode.hnode-system'));
+    });
+});
+
+suite('buildPlanErrorHtml', () => {
+    test('escapes the error message', () => {
+        const html = buildPlanErrorHtml({ message: '<img src=x onerror=alert(1)>' });
+        assert.ok(!html.includes('<img src=x'));
+        assert.ok(html.includes('&lt;img'));
+    });
+
+    test('renders a status title', () => {
+        const doc = parseDom(buildPlanErrorHtml({ message: 'boom' }));
+        assert.ok(doc.querySelector('.plan-status-title'));
+        assert.ok(doc.querySelector('.plan-status-message')!.textContent!.includes('boom'));
+    });
+});
+
+suite('buildPlanLoadingHtml', () => {
+    test('renders a non-empty loading indicator', () => {
+        const doc = parseDom(buildPlanLoadingHtml());
+        assert.ok(doc.querySelector('.plan-status-title'));
+    });
+});
+
+suite('CSS builders', () => {
+    test('buildPlanContentCss returns non-empty CSS with expected selectors', () => {
+        const css = buildPlanContentCss();
+        assert.ok(css.includes('.hnode'));
+        assert.ok(css.includes('.hconn'));
+        assert.ok(css.includes('.plan-popover'));
+        assert.ok(css.includes('.plan-side'));
+        assert.ok(css.includes('.hcat-bar'));
+        assert.ok(css.includes('.plan-warning-item'));
+    });
+
+    test('the flow track wraps onto additional rows instead of forcing a long horizontal scroll', () => {
+        const css = buildPlanContentCss();
+        assert.ok(
+            /\.hflow-track\s*\{[^}]*flex-wrap:\s*wrap/.test(css),
+            'expected .hflow-track to wrap, not rely solely on horizontal scroll'
+        );
+    });
+
+    test('interactive elements have a visible :focus-visible outline for keyboard users', () => {
+        const css = buildPlanContentCss();
+        assert.ok(/\.hnode:focus-visible\s*\{[^}]*outline/.test(css));
+        assert.ok(/\.plan-warning-item:focus-visible\s*\{[^}]*outline/.test(css));
+    });
+
+    test('buildPlanStatusCss returns non-empty CSS', () => {
+        const css = buildPlanStatusCss();
+        assert.ok(css.includes('.plan-status-container'));
+    });
+});

--- a/src/test/local/resultsPanelPlanTab.test.ts
+++ b/src/test/local/resultsPanelPlanTab.test.ts
@@ -172,6 +172,47 @@ suite('ResultsPanel plan tab', () => {
         assert.ok(doc.querySelector('[data-plan-retry]'), 'Plan errors should offer a retry path');
     });
 
+    test('clicking the rendered Retry button actually posts switchResultView, not just tab re-clicks', async () => {
+        // Regression: the tab-bar's own inline script used to bind the click
+        // handler via querySelectorAll('[data-plan-retry]') at parse time,
+        // before this button (rendered later, inside .plan-view) existed in
+        // the document — matching nothing. Executing the real rendered
+        // document's scripts and dispatching a real click is the only way to
+        // catch that; asserting the button's presence and posting the
+        // message directly (as the other tests here do) cannot.
+        const { fakeView } = makeResultsPanel(() => {
+            throw new Error('insufficient privileges for accessing view');
+        });
+        ResultsPanel.show(makeQueryResult());
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        const html = fakeView.getHtml();
+        assert.ok(html.includes('data-plan-retry'), 'expected the plan error body to render a retry button');
+
+        // Stub acquireVsCodeApi before any of the document's own scripts run,
+        // the same way VS Code injects it into a real webview.
+        const stubbedHtml = html.replace('<head>', `<head><script>
+            window.__posted = [];
+            window.acquireVsCodeApi = function () {
+                return { postMessage: function (message) { window.__posted.push(message); } };
+            };
+        </script>`);
+
+        const dom = new JSDOM(stubbedHtml, { runScripts: 'dangerously' });
+        const button = dom.window.document.querySelector('[data-plan-retry]');
+        assert.ok(button, 'expected the retry button in the fully rendered document');
+
+        button!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+        // The posted message is an object from the JSDOM window's own realm,
+        // so compare fields directly rather than via deepStrictEqual (which
+        // treats cross-realm objects as unequal despite identical shape).
+        const posted = (dom.window as any).__posted;
+        assert.strictEqual(posted.length, 1, 'expected exactly one postMessage call');
+        assert.strictEqual(posted[0].command, 'switchResultView');
+        assert.strictEqual(posted[0].view, 'plan');
+    });
+
     test('clicking the Plan tab again after an error retries the fetch', async () => {
         let fetchCount = 0;
         const { fakeView } = makeResultsPanel(sql => {

--- a/src/test/local/resultsPanelPlanTab.test.ts
+++ b/src/test/local/resultsPanelPlanTab.test.ts
@@ -431,10 +431,10 @@ suite('ResultsPanel plan tab', () => {
         assert.deepStrictEqual(tabs, ['Results']);
     });
 
-    test('hides the Plan tab for a result with no captured session/statement id (as produced by preview/describe table)', () => {
-        // objectActions.ts builds preview-table and describe-table results
-        // directly, without ever capturing sessionId/baselineStmtId — only
-        // queryExecutor.ts does that. Such results must render only Results.
+    test('hides the Plan tab for a result with no captured session/statement id (as produced by describe table)', () => {
+        // objectActions.ts's describeTable builds its result directly,
+        // without ever capturing sessionId/baselineStmtId — it's a metadata
+        // lookup, not a profiled statement. Such results must render only Results.
         const { fakeView } = makeResultsPanel(() => createEmptyRawResult(DETAILS_COLUMNS));
         ResultsPanel.show(makeQueryResult({ sessionId: undefined, baselineStmtId: undefined, connectionId: undefined }));
 

--- a/src/test/local/resultsPanelPlanTab.test.ts
+++ b/src/test/local/resultsPanelPlanTab.test.ts
@@ -144,7 +144,12 @@ suite('ResultsPanel plan tab', () => {
         assert.strictEqual(doc.querySelector('.hnode'), null);
     });
 
-    test('a query with no captured session/stmt id shows a clear plan error instead of fetching', async () => {
+    test('a query with no captured session/stmt id never shows a Plan tab, and a stray switch to it does not fetch', async () => {
+        // isPlanAvailableForResult gates both tab rendering and this
+        // switchResultView guard, so a stray 'plan' message for such a
+        // result is redirected back to Results before requestPlan() (whose
+        // own "no session/statement id" message stays as a backstop for
+        // callers that reach it some other way) ever runs.
         let queryCallCount = 0;
         const { fakeView } = makeResultsPanel(() => { queryCallCount++; return createEmptyRawResult(DETAILS_COLUMNS); });
         ResultsPanel.show(makeQueryResult({ sessionId: undefined, baselineStmtId: undefined }));
@@ -153,7 +158,9 @@ suite('ResultsPanel plan tab', () => {
 
         assert.strictEqual(queryCallCount, 0, 'must not attempt a plan fetch without ids');
         const doc = parseDom(fakeView.getHtml());
-        assert.ok(doc.querySelector('.plan-status-message')!.textContent!.includes('session/statement id'));
+        const tabs = Array.from(doc.querySelectorAll('.rv-tab')).map(tab => tab.textContent);
+        assert.deepStrictEqual(tabs, ['Results']);
+        assert.ok(doc.querySelector('.rv-tab.active')!.textContent!.includes('Results'));
     });
 
     test('a fetch failure surfaces the underlying error message, not a crash', async () => {
@@ -418,6 +425,18 @@ suite('ResultsPanel plan tab', () => {
         provider.resolveWebviewView(fakeView.view);
 
         ResultsPanel.show(makeQueryResult());
+
+        const doc = parseDom(fakeView.getHtml());
+        const tabs = Array.from(doc.querySelectorAll('.rv-tab')).map(tab => tab.textContent);
+        assert.deepStrictEqual(tabs, ['Results']);
+    });
+
+    test('hides the Plan tab for a result with no captured session/statement id (as produced by preview/describe table)', () => {
+        // objectActions.ts builds preview-table and describe-table results
+        // directly, without ever capturing sessionId/baselineStmtId — only
+        // queryExecutor.ts does that. Such results must render only Results.
+        const { fakeView } = makeResultsPanel(() => createEmptyRawResult(DETAILS_COLUMNS));
+        ResultsPanel.show(makeQueryResult({ sessionId: undefined, baselineStmtId: undefined, connectionId: undefined }));
 
         const doc = parseDom(fakeView.getHtml());
         const tabs = Array.from(doc.querySelectorAll('.rv-tab')).map(tab => tab.textContent);

--- a/src/test/local/resultsPanelPlanTab.test.ts
+++ b/src/test/local/resultsPanelPlanTab.test.ts
@@ -1,0 +1,351 @@
+import * as assert from 'assert';
+import { JSDOM } from 'jsdom';
+import { registerVscodeMock, registerExtensionMock, vscodeMock } from '../helpers/vscodeMock';
+
+(vscodeMock as any).Uri = { ...(vscodeMock as any).Uri, joinPath: () => ({}) };
+(vscodeMock as any).window = {
+    registerWebviewViewProvider: () => ({ dispose: () => {} }),
+    showInformationMessage: () => {},
+    showWarningMessage: () => {},
+    showErrorMessage: () => {}
+};
+(vscodeMock as any).commands = { registerCommand: () => ({ dispose: () => {} }) };
+(vscodeMock as any).workspace = { getConfiguration: () => ({ get: () => undefined }) };
+(vscodeMock as any).env = { clipboard: { writeText: async () => {} } };
+
+registerVscodeMock();
+registerExtensionMock();
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ResultsPanel } = require('../../panels/resultsPanel');
+
+import { createEmptyRawResult, createRawResult } from '../helpers/mockConnectionManager';
+
+function parseDom(html: string): Document {
+    return new JSDOM(`<html><body>${html}</body></html>`).window.document;
+}
+
+const DETAILS_COLUMNS = ['SESSION_ID', 'STMT_ID', 'PART_ID', 'IPROC', 'PART_NAME', 'OUT_ROWS', 'DURATION', 'SQL_TEXT'];
+
+function detailsRow(sessionId: string, stmtId: string, partName = 'PIPE SCAN'): any[] {
+    return [sessionId, stmtId, 10, 0, partName, 1000, 0.5, 'SELECT 1'];
+}
+
+/**
+ * Builds a fake webview view whose .webview.html assignments are captured,
+ * and whose onDidReceiveMessage handler can be driven directly — the same
+ * approach production code drives via postMessage from the browser side.
+ */
+function makeFakeWebviewView() {
+    let html = '';
+    let handler: ((message: any) => void | Promise<void>) | undefined;
+    const webview: any = {
+        set html(value: string) { html = value; },
+        get html() { return html; },
+        onDidReceiveMessage: (fn: any) => { handler = fn; return { dispose() {} }; },
+        asWebviewUri: (uri: any) => uri,
+        cspSource: 'vscode-resource:'
+    };
+    const view: any = { webview, show: () => {} };
+    return {
+        view,
+        getHtml: () => html,
+        send: async (message: any) => { await handler!(message); }
+    };
+}
+
+/**
+ * Builds a fake ConnectionManager wired to a scriptable fake driver.
+ * `queryImpl` drives rawQuery() (the tier-fetch attempts); rawExecute() (the
+ * FLUSH STATISTICS call planProvider issues first) always succeeds here —
+ * flush-failure handling has its own dedicated test in planProvider.test.ts.
+ */
+function makeFakeConnectionManager(queryImpl: (sql: string) => any) {
+    const fakeDriver = {
+        execute: async () => createEmptyRawResult([]),
+        query: async (sql: string) => queryImpl(sql)
+    };
+    return {
+        getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+        getConnection: (id: string) => ({ id, name: 'Test' }),
+        getDriver: async () => fakeDriver,
+        executeWithRetry: async (fn: () => Promise<any>) => fn()
+    };
+}
+
+function makeResultsPanel(queryImpl: (sql: string) => any) {
+    const connectionManager = makeFakeConnectionManager(queryImpl);
+    const fakeContext: any = { extensionUri: {}, subscriptions: [] };
+    const provider = ResultsPanel.register(fakeContext, connectionManager);
+    const fakeView = makeFakeWebviewView();
+    provider.resolveWebviewView(fakeView.view);
+    return { provider, fakeView };
+}
+
+function makeQueryResult(overrides: Partial<any> = {}) {
+    return {
+        columns: ['X'],
+        columnMetadata: [{ name: 'X', type: 'DECIMAL' }],
+        rows: [{ X: 1 }],
+        rowCount: 1,
+        executionTime: 5,
+        sessionId: '42',
+        baselineStmtId: '16',
+        connectionId: 'conn-1',
+        ...overrides
+    };
+}
+
+suite('ResultsPanel plan tab', () => {
+
+    test('a fresh single-statement result shows the Results tab active with no Plan tab fetch yet', () => {
+        const { fakeView } = makeResultsPanel(() => createEmptyRawResult(DETAILS_COLUMNS));
+        ResultsPanel.show(makeQueryResult());
+        const doc = parseDom(fakeView.getHtml());
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.strictEqual(tabs.length, 2);
+        assert.ok(tabs[0].classList.contains('active'));
+        assert.strictEqual(doc.querySelector('#grid-root') !== null, true);
+    });
+
+    test('clicking the Plan tab fetches and renders a real plan end-to-end', async () => {
+        const { fakeView } = makeResultsPanel(sql =>
+            sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')
+                ? createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')])
+                : createEmptyRawResult(DETAILS_COLUMNS)
+        );
+        ResultsPanel.show(makeQueryResult());
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.rv-tab.active')!.textContent!.includes('Plan'));
+        assert.ok(doc.querySelector('.hnode'), 'expected a rendered plan operator node');
+        assert.ok(doc.body.textContent!.includes('PIPE SCAN'));
+    });
+
+    test('switching back to Results after viewing the plan restores the grid', async () => {
+        const { fakeView } = makeResultsPanel(sql =>
+            sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')
+                ? createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')])
+                : createEmptyRawResult(DETAILS_COLUMNS)
+        );
+        ResultsPanel.show(makeQueryResult());
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+        await fakeView.send({ command: 'switchResultView', view: 'results' });
+
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.rv-tab.active')!.textContent!.includes('Results'));
+        assert.ok(doc.querySelector('#grid-root'));
+        assert.strictEqual(doc.querySelector('.hnode'), null);
+    });
+
+    test('a query with no captured session/stmt id shows a clear plan error instead of fetching', async () => {
+        let queryCallCount = 0;
+        const { fakeView } = makeResultsPanel(() => { queryCallCount++; return createEmptyRawResult(DETAILS_COLUMNS); });
+        ResultsPanel.show(makeQueryResult({ sessionId: undefined, baselineStmtId: undefined }));
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        assert.strictEqual(queryCallCount, 0, 'must not attempt a plan fetch without ids');
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.plan-status-message')!.textContent!.includes('session/statement id'));
+    });
+
+    test('a fetch failure surfaces the underlying error message, not a crash', async () => {
+        // Every tier denied by privilege fails fast with a dedicated message
+        // (see planProvider.test.ts) rather than exhausting the retry budget.
+        const { fakeView } = makeResultsPanel(() => {
+            throw new Error('insufficient privileges for accessing view');
+        });
+        ResultsPanel.show(makeQueryResult());
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.rv-tab.error'), 'Plan tab should show the error state');
+        assert.ok(doc.querySelector('.plan-status-message')!.textContent!.includes("doesn't have permission"));
+    });
+
+    test('re-clicking an already-fetched Plan tab does not re-issue the fetch', async () => {
+        let fetchCount = 0;
+        const { fakeView } = makeResultsPanel(sql => {
+            if (sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')) {
+                fetchCount++;
+                return createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')]);
+            }
+            return createEmptyRawResult(DETAILS_COLUMNS);
+        });
+        ResultsPanel.show(makeQueryResult());
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+        await fakeView.send({ command: 'switchResultView', view: 'results' });
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        assert.strictEqual(fetchCount, 1, 'the plan should be cached after the first fetch');
+    });
+
+    test('running a new query resets the plan tab back to Results/idle', async () => {
+        const { fakeView } = makeResultsPanel(sql =>
+            sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')
+                ? createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')])
+                : createEmptyRawResult(DETAILS_COLUMNS)
+        );
+        ResultsPanel.show(makeQueryResult());
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        // A second query completes — this must reset the sub-tab and any
+        // stale plan state, even though it's a brand-new QueryResult.
+        ResultsPanel.show(makeQueryResult({ sessionId: '99', baselineStmtId: '1' }));
+
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.rv-tab.active')!.textContent!.includes('Results'));
+        assert.strictEqual(doc.querySelector('.hnode'), null);
+    });
+
+    test('a DDL/DML result with no columns still shows the Results | Plan tab strip, with a success summary in Results', () => {
+        // Exasol profiles any statement that runs through the SQL engine —
+        // IMPORT/EXPORT/INSERT/UPDATE/etc. included — and queryExecutor.ts
+        // already captures the session/statement id needed to look that
+        // profile up regardless of whether the statement returned columns.
+        // There's no reason to hide the Plan tab just because there's no
+        // grid to show next to it.
+        const { fakeView } = makeResultsPanel(() => createEmptyRawResult(DETAILS_COLUMNS));
+        ResultsPanel.show(makeQueryResult({ columns: [], rows: [], rowCount: 3, executionTime: 12 }));
+
+        const doc = parseDom(fakeView.getHtml());
+        const tabs = doc.querySelectorAll('.rv-tab');
+        assert.strictEqual(tabs.length, 2, 'expected the Results | Plan tab strip even without a result set');
+        assert.ok(tabs[0].classList.contains('active'));
+        assert.strictEqual(doc.querySelector('#grid-root'), null, 'no result set means no grid to render');
+        assert.ok(doc.querySelector('.success-container'), 'expected the success summary in place of a grid');
+        assert.ok(doc.body.textContent!.includes('3'), 'expected the rows-affected count to show');
+    });
+
+    test('clicking the Plan tab for a no-columns (DDL/DML) result fetches and renders a real plan, same as a SELECT', async () => {
+        const { fakeView } = makeResultsPanel(sql =>
+            sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')
+                ? createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')])
+                : createEmptyRawResult(DETAILS_COLUMNS)
+        );
+        ResultsPanel.show(makeQueryResult({ columns: [], rows: [], rowCount: 1 }));
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.rv-tab.active')!.textContent!.includes('Plan'));
+        assert.ok(doc.querySelector('.hnode'), 'expected a rendered plan operator node, exactly as for a SELECT');
+    });
+
+    test('a copyPlanText message writes the given text to the clipboard and confirms it', async () => {
+        const { fakeView } = makeResultsPanel(sql =>
+            sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')
+                ? createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')])
+                : createEmptyRawResult(DETAILS_COLUMNS)
+        );
+        ResultsPanel.show(makeQueryResult());
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        let copiedText: string | undefined;
+        let infoMessage: string | undefined;
+        (vscodeMock as any).env.clipboard.writeText = async (text: string) => { copiedText = text; };
+        (vscodeMock as any).window.showInformationMessage = (msg: string) => { infoMessage = msg; };
+
+        await fakeView.send({ command: 'copyPlanText', text: 'Execution plan — session 42, statement 16' });
+
+        assert.strictEqual(copiedText, 'Execution plan — session 42, statement 16');
+        assert.ok(infoMessage?.includes('copied to clipboard'));
+    });
+
+    test('fetches the plan against the connection the query ran on, not whichever is active now', async () => {
+        // Regression: the user runs a query on connection A, switches the active
+        // connection to B, then opens the Plan tab. The profile must be looked
+        // up on A (whose session produced it) — looking it up on B would query
+        // the wrong session/server and silently return "no profiling data".
+        const driverConnIds: string[] = [];
+        const connections: Record<string, any> = {
+            'conn-ran': { id: 'conn-ran', name: 'Ran-On' },
+            'conn-active': { id: 'conn-active', name: 'Now-Active' }
+        };
+        const fakeDriver = {
+            execute: async () => createEmptyRawResult([]),
+            query: async (sql: string) =>
+                sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')
+                    ? createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')])
+                    : createEmptyRawResult(DETAILS_COLUMNS)
+        };
+        const connectionManager: any = {
+            getActiveConnection: () => connections['conn-active'],
+            getConnection: (id: string) => connections[id],
+            getDriver: async (id: string) => { driverConnIds.push(id); return fakeDriver; },
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const fakeContext: any = { extensionUri: {}, subscriptions: [] };
+        const provider = ResultsPanel.register(fakeContext, connectionManager);
+        const fakeView = makeFakeWebviewView();
+        provider.resolveWebviewView(fakeView.view);
+
+        ResultsPanel.show(makeQueryResult({ connectionId: 'conn-ran' }));
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        assert.ok(driverConnIds.length > 0, 'the plan fetch must open a driver');
+        assert.ok(
+            // Explicit `: boolean` return type — without it, TS treats this
+            // arrow as a type-predicate overload of .every() and narrows
+            // driverConnIds to `"conn-ran"[]` for the rest of the scope,
+            // which then makes the very next assertion's 'conn-active'
+            // argument a type error.
+            driverConnIds.every((id): boolean => id === 'conn-ran'),
+            `every driver call must target the originating connection; saw ${JSON.stringify(driverConnIds)}`
+        );
+        assert.ok(!driverConnIds.includes('conn-active'), 'must never fetch against the now-active connection');
+    });
+
+    test('a plan fetch that resolves after a newer query has run does not overwrite the newer query\'s view', async () => {
+        let releaseFirstFetch!: () => void;
+        const firstFetchGate = new Promise<void>(resolve => { releaseFirstFetch = resolve; });
+        let call = 0;
+
+        const { fakeView } = makeResultsPanel(async sql => {
+            if (!sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')) {
+                return createEmptyRawResult(DETAILS_COLUMNS);
+            }
+            call++;
+            if (call === 1) {
+                await firstFetchGate; // held open until released below
+                return createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16', 'STALE_SCAN')]);
+            }
+            return createRawResult(DETAILS_COLUMNS, [detailsRow('99', '1', 'FRESH_SCAN')]);
+        });
+
+        ResultsPanel.show(makeQueryResult({ sessionId: '42', baselineStmtId: '16' }));
+        const firstPlanRequest = fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        // A second query completes while the first plan fetch is still pending.
+        ResultsPanel.show(makeQueryResult({ sessionId: '99', baselineStmtId: '1' }));
+
+        releaseFirstFetch();
+        await firstPlanRequest;
+
+        const docAfterStaleResolves = parseDom(fakeView.getHtml());
+        assert.ok(
+            docAfterStaleResolves.querySelector('.rv-tab.active')!.textContent!.includes('Results'),
+            'the stale fetch must not flip the view back to Plan for the new query'
+        );
+        assert.strictEqual(
+            docAfterStaleResolves.querySelector('.hnode'), null,
+            'must not render the old query\'s plan under the new result'
+        );
+
+        // The real test of the guard: without it, planViewState would already
+        // be 'ready' (with the stale session-42 plan) at this point, and this
+        // click would show STALE_SCAN immediately instead of fetching fresh.
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        const docAfterFreshClick = parseDom(fakeView.getHtml());
+        assert.strictEqual(call, 2, 'the guard must force a real second fetch, not reuse the discarded stale result');
+        assert.ok(docAfterFreshClick.body.textContent!.includes('FRESH_SCAN'));
+        assert.ok(!docAfterFreshClick.body.textContent!.includes('STALE_SCAN'));
+    });
+});

--- a/src/test/local/resultsPanelPlanTab.test.ts
+++ b/src/test/local/resultsPanelPlanTab.test.ts
@@ -38,9 +38,10 @@ function detailsRow(sessionId: string, stmtId: string, partName = 'PIPE SCAN'): 
  */
 function makeFakeWebviewView() {
     let html = '';
+    let htmlSetCount = 0;
     let handler: ((message: any) => void | Promise<void>) | undefined;
     const webview: any = {
-        set html(value: string) { html = value; },
+        set html(value: string) { html = value; htmlSetCount++; },
         get html() { return html; },
         onDidReceiveMessage: (fn: any) => { handler = fn; return { dispose() {} }; },
         asWebviewUri: (uri: any) => uri,
@@ -50,6 +51,7 @@ function makeFakeWebviewView() {
     return {
         view,
         getHtml: () => html,
+        getHtmlSetCount: () => htmlSetCount,
         send: async (message: any) => { await handler!(message); }
     };
 }
@@ -68,6 +70,7 @@ function makeFakeConnectionManager(queryImpl: (sql: string) => any) {
     return {
         getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
         getConnection: (id: string) => ({ id, name: 'Test' }),
+        isExecutionPlanAvailable: () => true,
         getDriver: async () => fakeDriver,
         executeWithRetry: async (fn: () => Promise<any>) => fn()
     };
@@ -166,6 +169,31 @@ suite('ResultsPanel plan tab', () => {
         const doc = parseDom(fakeView.getHtml());
         assert.ok(doc.querySelector('.rv-tab.error'), 'Plan tab should show the error state');
         assert.ok(doc.querySelector('.plan-status-message')!.textContent!.includes("doesn't have permission"));
+        assert.ok(doc.querySelector('[data-plan-retry]'), 'Plan errors should offer a retry path');
+    });
+
+    test('clicking the Plan tab again after an error retries the fetch', async () => {
+        let fetchCount = 0;
+        const { fakeView } = makeResultsPanel(sql => {
+            if (sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')) {
+                fetchCount++;
+                if (fetchCount === 1) {
+                    throw new Error('temporary VPN failure');
+                }
+                return createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')]);
+            }
+            return createEmptyRawResult(DETAILS_COLUMNS);
+        });
+        ResultsPanel.show(makeQueryResult());
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+        assert.ok(parseDom(fakeView.getHtml()).body.textContent!.includes('temporary VPN failure'));
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+
+        const doc = parseDom(fakeView.getHtml());
+        assert.strictEqual(fetchCount, 2, 'the error state must be retryable');
+        assert.ok(doc.querySelector('.hnode'), 'expected the retried plan to render');
     });
 
     test('re-clicking an already-fetched Plan tab does not re-issue the fetch', async () => {
@@ -300,6 +328,59 @@ suite('ResultsPanel plan tab', () => {
             `every driver call must target the originating connection; saw ${JSON.stringify(driverConnIds)}`
         );
         assert.ok(!driverConnIds.includes('conn-active'), 'must never fetch against the now-active connection');
+    });
+
+    test('a plan fetch resolving after the user switched back to Results does not rebuild the grid', async () => {
+        let releaseFetch!: () => void;
+        const fetchGate = new Promise<void>(resolve => { releaseFetch = resolve; });
+        const { fakeView } = makeResultsPanel(async sql => {
+            if (sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY')) {
+                await fetchGate;
+                return createRawResult(DETAILS_COLUMNS, [detailsRow('42', '16')]);
+            }
+            return createEmptyRawResult(DETAILS_COLUMNS);
+        });
+        ResultsPanel.show(makeQueryResult());
+
+        const firstPlanRequest = fakeView.send({ command: 'switchResultView', view: 'plan' });
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await fakeView.send({ command: 'switchResultView', view: 'results' });
+        const htmlSetsBeforeResolve = fakeView.getHtmlSetCount();
+
+        releaseFetch();
+        await firstPlanRequest;
+
+        assert.strictEqual(
+            fakeView.getHtmlSetCount(),
+            htmlSetsBeforeResolve,
+            'fetch completion must not re-render while Results is active'
+        );
+        const doc = parseDom(fakeView.getHtml());
+        assert.ok(doc.querySelector('.rv-tab.active')!.textContent!.includes('Results'));
+        assert.ok(doc.querySelector('#grid-root'));
+
+        await fakeView.send({ command: 'switchResultView', view: 'plan' });
+        assert.ok(parseDom(fakeView.getHtml()).querySelector('.hnode'), 'cached plan should render on the next natural switch');
+    });
+
+    test('hides the Plan tab when execution plan profiling is unavailable for the result connection', () => {
+        const connectionManager: any = {
+            getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+            getConnection: (id: string) => ({ id, name: 'Test' }),
+            isExecutionPlanAvailable: () => false,
+            getDriver: async () => { throw new Error('must not fetch'); },
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const fakeContext: any = { extensionUri: {}, subscriptions: [] };
+        const provider = ResultsPanel.register(fakeContext, connectionManager);
+        const fakeView = makeFakeWebviewView();
+        provider.resolveWebviewView(fakeView.view);
+
+        ResultsPanel.show(makeQueryResult());
+
+        const doc = parseDom(fakeView.getHtml());
+        const tabs = Array.from(doc.querySelectorAll('.rv-tab')).map(tab => tab.textContent);
+        assert.deepStrictEqual(tabs, ['Results']);
     });
 
     test('a plan fetch that resolves after a newer query has run does not overwrite the newer query\'s view', async () => {

--- a/src/test/local/webviewRendering.test.ts
+++ b/src/test/local/webviewRendering.test.ts
@@ -2,50 +2,33 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import { JSDOM } from 'jsdom';
+import { registerVscodeMock, registerExtensionMock, vscodeMock } from '../helpers/vscodeMock';
 
-// Mock vscode module before any source imports that depend on it.
-const NodeModule = require('module');
-const originalResolveFilename = NodeModule._resolveFilename;
-NodeModule._resolveFilename = function (request: string, ...args: any[]) {
-    if (request === 'vscode') {
-        return 'vscode';
-    }
-    return originalResolveFilename.call(this, request, ...args);
+// resultsPanel.ts now transitively imports planProvider.ts -> connectionManager.ts
+// -> ./extension (for getOutputChannel), which in turn imports the full set of
+// tree/completion/notebook providers. registerExtensionMock() swaps out
+// ./extension with a lightweight fake before anything requires it, so that
+// whole chain never has to actually load under this test's minimal vscode mock.
+(vscodeMock as any).Uri = { ...(vscodeMock as any).Uri, joinPath: () => ({}) };
+(vscodeMock as any).window = {
+    registerWebviewViewProvider: () => ({ dispose: () => {} }),
+    showSaveDialog: async () => undefined,
+    showInformationMessage: () => {},
+    showWarningMessage: () => {},
 };
-
-const vscodeMock = {
-    Uri: { joinPath: () => ({}) },
-    window: {
-        registerWebviewViewProvider: () => ({ dispose: () => {} }),
-        showSaveDialog: async () => undefined,
-        showInformationMessage: () => {},
-        showWarningMessage: () => {},
-    },
-    commands: {
-        registerCommand: () => ({ dispose: () => {} }),
-        executeCommand: () => {},
-    },
-    workspace: {
-        getConfiguration: () => ({
-            get: () => undefined,
-        }),
-        fs: { writeFile: async () => {} },
-    },
-    env: { clipboard: { writeText: async () => {} } },
-    CancellationTokenSource: class {},
+(vscodeMock as any).commands = {
+    registerCommand: () => ({ dispose: () => {} }),
+    executeCommand: () => {},
 };
+(vscodeMock as any).workspace = {
+    getConfiguration: () => ({ get: () => undefined }),
+    fs: { writeFile: async () => {} },
+};
+(vscodeMock as any).env = { clipboard: { writeText: async () => {} } };
+(vscodeMock as any).CancellationTokenSource = class {};
 
-require.cache['vscode'] = {
-    id: 'vscode',
-    filename: 'vscode',
-    loaded: true,
-    exports: vscodeMock,
-    paths: [],
-    children: [],
-    path: '',
-    require: require,
-    isPreloading: false,
-} as any;
+registerVscodeMock();
+registerExtensionMock();
 
 // Now import source modules that transitively depend on vscode.
 const { ResultsPanel } = require('../../panels/resultsPanel');

--- a/src/test/unit/objectActions.test.ts
+++ b/src/test/unit/objectActions.test.ts
@@ -16,6 +16,7 @@ import { registerVscodeMock, registerExtensionMock, vscodeMock } from '../helper
 };
 (vscodeMock as any).workspace = {
     openTextDocument: (_opts: any) => Promise.resolve({ languageId: 'exasol-sql' }),
+    getConfiguration: () => ({ get: (_key: string, fallback?: unknown) => fallback }),
 };
 
 registerVscodeMock();
@@ -24,6 +25,8 @@ registerExtensionMock();
 // Load ObjectActions after the vscode mock is configured.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { ObjectActions } = require('../../objectActions');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ResultsPanel } = require('../../panels/resultsPanel');
 
 import { createRawResult, createEmptyRawResult, MockConnectionManager, TEST_CONNECTION } from '../helpers/mockConnectionManager';
 
@@ -88,6 +91,7 @@ suite('ObjectActions SQL injection escaping', () => {
         };
         (vscodeMock as any).workspace = {
             openTextDocument: (_opts: any) => Promise.resolve({ languageId: 'exasol-sql' }),
+            getConfiguration: () => ({ get: (_key: string, fallback?: unknown) => fallback }),
         };
     });
 
@@ -237,11 +241,95 @@ suite('ObjectActions SQL injection escaping', () => {
         await oa.previewTableData(TEST_CONNECTION, 'SCHEMA"WITH"QUOTES', 'MY_TABLE', 100, false);
 
         assert.ok(capturedSql.length > 0, 'Driver should have been called');
-        const sql = capturedSql[0];
+        // The baseline identity-capture query (CURRENT_SESSION/CURRENT_STATEMENT)
+        // now runs before the preview query itself, so the preview's own SQL is
+        // the last call rather than necessarily the first.
+        const sql = capturedSql[capturedSql.length - 1];
         assert.ok(
             sql.includes('"SCHEMA""WITH""QUOTES"'),
             `Double quotes in identifier must be doubled. Got: ${sql}`
         );
+    });
+});
+
+suite('ObjectActions.previewTableData: baseline statement identity capture', () => {
+
+    let savedWindow: any;
+    let savedWorkspace: any;
+
+    setup(() => {
+        savedWindow = (vscodeMock as any).window;
+        savedWorkspace = (vscodeMock as any).workspace;
+        (vscodeMock as any).window = {
+            showInformationMessage: () => Promise.resolve(undefined),
+            showErrorMessage: () => Promise.resolve(undefined),
+            withProgress: (_opts: any, task: () => Promise<any>) => task(),
+        };
+        (vscodeMock as any).workspace = {
+            getConfiguration: () => ({ get: (_key: string, fallback?: unknown) => fallback }),
+        };
+    });
+
+    teardown(() => {
+        (vscodeMock as any).window = savedWindow;
+        (vscodeMock as any).workspace = savedWorkspace;
+    });
+
+    /**
+     * Builds an ObjectActions instance whose fake driver returns `identityRows`
+     * (or throws, if 'throw') for the baseline SESSION_ID/STMT_ID capture query,
+     * and a plain one-row result for the preview query itself.
+     */
+    function makeObjectActionsForIdentity(identityRows: any[] | 'throw'): { oa: any } {
+        const mockDriver = {
+            query: async (sql: string) => {
+                if (sql.includes('CURRENT_SESSION')) {
+                    if (identityRows === 'throw') {
+                        throw new Error('simulated identity capture failure');
+                    }
+                    return createRawResult(['SID', 'STID'], identityRows);
+                }
+                return createRawResult(['COL'], [[1]]);
+            }
+        };
+        const mockCM = new MockConnectionManager(mockDriver);
+        return { oa: new ObjectActions(mockCM, {}, { fsPath: '/mock' } as any) };
+    }
+
+    /**
+     * Runs previewTableData with ResultsPanel.show stubbed to capture the
+     * QueryResult it was handed, since previewTableData does not return it directly.
+     */
+    async function previewAndCapture(oa: any): Promise<any> {
+        let captured: any;
+        const originalShow = ResultsPanel.show;
+        (ResultsPanel as any).show = (result: any) => { captured = result; };
+        try {
+            await oa.previewTableData(TEST_CONNECTION, 'MY_SCHEMA', 'MY_TABLE', 100, false);
+        } finally {
+            (ResultsPanel as any).show = originalShow;
+        }
+        return captured;
+    }
+
+    test('carries sessionId/baselineStmtId/connectionId when capture succeeds', async () => {
+        const { oa } = makeObjectActionsForIdentity([[42, 7]]);
+
+        const result = await previewAndCapture(oa);
+
+        assert.strictEqual(result.sessionId, '42');
+        assert.strictEqual(result.baselineStmtId, '7');
+        assert.strictEqual(result.connectionId, TEST_CONNECTION.id, 'must record which connection actually ran the preview query');
+    });
+
+    test('omits sessionId/baselineStmtId (without throwing) when identity capture fails', async () => {
+        const { oa } = makeObjectActionsForIdentity('throw');
+
+        const result = await previewAndCapture(oa);
+
+        assert.strictEqual(result.sessionId, undefined);
+        assert.strictEqual(result.baselineStmtId, undefined);
+        assert.strictEqual(result.rowCount, 1, 'the preview query itself must still succeed');
     });
 });
 

--- a/src/test/unit/operatorTaxonomy.test.ts
+++ b/src/test/unit/operatorTaxonomy.test.ts
@@ -75,6 +75,34 @@ suite('classifyOperator', () => {
         test('MERGE classifies as DML', () => {
             assert.strictEqual(classifyOperator('MERGE').operatorType, 'DML');
         });
+
+        test('SYSTEM TABLE classifies as SCAN, not SYSTEM or OTHER (finding 14)', () => {
+            // Live census: 11.7% of profile rows were SYSTEM TABLE parts,
+            // all landing in OTHER before this rule existed. It reads a
+            // system catalog object and produces rows exactly like any
+            // other scan — the word SYSTEM in its name is not bookkeeping.
+            const { operatorType, traits } = classifyOperator('SYSTEM TABLE');
+            assert.strictEqual(operatorType, 'SCAN');
+            assert.strictEqual(traits.producesRows, true);
+            assert.strictEqual(traits.isSystemStep, false);
+        });
+
+        test('REPLICATE classifies as NETWORK (finding 14)', () => {
+            assert.strictEqual(classifyOperator('REPLICATE').operatorType, 'NETWORK');
+        });
+
+        test('NODE SYNC classifies as SYNC — blocking, but deliberately not a system step (finding 14)', () => {
+            // Real query time (frequently the single hottest node on a real
+            // plan), not execution-engine bookkeeping — it must stay inside
+            // the F2 user/data-flow cost-share denominator rather than
+            // vanishing into the system-step total the way COMPILE/EXECUTE do.
+            const { operatorType, traits } = classifyOperator('NODE SYNC');
+            assert.strictEqual(operatorType, 'SYNC');
+            assert.strictEqual(traits.blocking, true);
+            assert.strictEqual(traits.isSystemStep, false);
+            assert.strictEqual(traits.producesRows, false);
+            assert.strictEqual(traits.consumesRows, false);
+        });
     });
 
     suite('finer PART_NAME values ($EXA_PROFILE_DETAILS_LAST_DAY)', () => {

--- a/src/test/unit/operatorTaxonomy.test.ts
+++ b/src/test/unit/operatorTaxonomy.test.ts
@@ -1,0 +1,131 @@
+import * as assert from 'assert';
+import { classifyOperator } from '../../plan/operatorTaxonomy';
+
+suite('classifyOperator', () => {
+
+    suite('coarse PART_NAME values (EXA_USER_PROFILE_LAST_DAY / EXA_DBA_PROFILE_LAST_DAY)', () => {
+        test('SCAN classifies as SCAN with produces-only traits', () => {
+            const { operatorType, traits } = classifyOperator('SCAN');
+            assert.strictEqual(operatorType, 'SCAN');
+            assert.strictEqual(traits.producesRows, true);
+            assert.strictEqual(traits.consumesRows, false);
+            assert.strictEqual(traits.isSystemStep, false);
+        });
+
+        test('JOIN classifies as JOIN and can spill', () => {
+            const { operatorType, traits } = classifyOperator('JOIN');
+            assert.strictEqual(operatorType, 'JOIN');
+            assert.strictEqual(traits.canSpill, true);
+            assert.strictEqual(traits.movesDataOverNetwork, true);
+        });
+
+        test('GROUP BY classifies as GROUP_BY', () => {
+            assert.strictEqual(classifyOperator('GROUP BY').operatorType, 'GROUP_BY');
+        });
+
+        test('SORT classifies as SORT and is blocking', () => {
+            const { operatorType, traits } = classifyOperator('SORT');
+            assert.strictEqual(operatorType, 'SORT');
+            assert.strictEqual(traits.blocking, true);
+        });
+
+        test('COMPILE / EXECUTE classifies as SYSTEM, not a data-flow operator', () => {
+            const { operatorType, traits } = classifyOperator('COMPILE / EXECUTE');
+            assert.strictEqual(operatorType, 'SYSTEM');
+            assert.strictEqual(traits.isSystemStep, true);
+            assert.strictEqual(traits.producesRows, false);
+        });
+
+        test('COLUMN STATISTICS classifies as SYSTEM', () => {
+            assert.strictEqual(classifyOperator('COLUMN STATISTICS').operatorType, 'SYSTEM');
+        });
+
+        test('INDEX CREATE classifies as SYSTEM', () => {
+            assert.strictEqual(classifyOperator('INDEX CREATE').operatorType, 'SYSTEM');
+        });
+
+        test('COMMIT classifies as SYSTEM', () => {
+            assert.strictEqual(classifyOperator('COMMIT').operatorType, 'SYSTEM');
+        });
+
+        test('INSERT classifies as DML', () => {
+            assert.strictEqual(classifyOperator('INSERT').operatorType, 'DML');
+        });
+
+        test('IMPORT classifies as DML', () => {
+            // Now load-bearing, not just defensive: the Plan tab is offered
+            // for any statement with a captured session/statement id,
+            // IMPORT/EXPORT included (see resultsPanel.ts), so a real IMPORT
+            // plan's operators need to classify correctly too.
+            assert.strictEqual(classifyOperator('IMPORT').operatorType, 'DML');
+        });
+
+        test('EXPORT classifies as DML', () => {
+            assert.strictEqual(classifyOperator('EXPORT').operatorType, 'DML');
+        });
+
+        test('UPDATE classifies as DML', () => {
+            assert.strictEqual(classifyOperator('UPDATE').operatorType, 'DML');
+        });
+
+        test('DELETE classifies as DML', () => {
+            assert.strictEqual(classifyOperator('DELETE').operatorType, 'DML');
+        });
+
+        test('MERGE classifies as DML', () => {
+            assert.strictEqual(classifyOperator('MERGE').operatorType, 'DML');
+        });
+    });
+
+    suite('finer PART_NAME values ($EXA_PROFILE_DETAILS_LAST_DAY)', () => {
+        test('PIPE SCAN classifies as SCAN', () => {
+            assert.strictEqual(classifyOperator('PIPE SCAN').operatorType, 'SCAN');
+        });
+
+        test('PIPE JOIN classifies as JOIN', () => {
+            assert.strictEqual(classifyOperator('PIPE JOIN').operatorType, 'JOIN');
+        });
+
+        test('PIPE AGGREGATOR classifies as GROUP_BY', () => {
+            assert.strictEqual(classifyOperator('PIPE AGGREGATOR').operatorType, 'GROUP_BY');
+        });
+
+        test('GROUPBY POSTPROCESSING classifies as GROUP_BY', () => {
+            assert.strictEqual(classifyOperator('GROUPBY POSTPROCESSING').operatorType, 'GROUP_BY');
+        });
+
+        test('GROUPBY INSERT classifies as GROUP_BY, not DML', () => {
+            // Must be checked before the DML/INSERT rule to avoid misclassification.
+            assert.strictEqual(classifyOperator('GROUPBY INSERT').operatorType, 'GROUP_BY');
+        });
+
+        test('COMPILE alone classifies as SYSTEM', () => {
+            assert.strictEqual(classifyOperator('COMPILE').operatorType, 'SYSTEM');
+        });
+
+        test('EXECUTE alone classifies as SYSTEM', () => {
+            assert.strictEqual(classifyOperator('EXECUTE').operatorType, 'SYSTEM');
+        });
+    });
+
+    suite('unrecognized part names', () => {
+        test('an unknown part name falls back to OTHER with conservative pass-through traits', () => {
+            const { operatorType, traits } = classifyOperator('SOME_FUTURE_OPERATOR');
+            assert.strictEqual(operatorType, 'OTHER');
+            assert.strictEqual(traits.canSpill, false);
+            assert.strictEqual(traits.movesDataOverNetwork, false);
+            assert.strictEqual(traits.producesRows, true);
+            assert.strictEqual(traits.consumesRows, true);
+        });
+
+        test('empty string does not throw and falls back to OTHER', () => {
+            assert.strictEqual(classifyOperator('').operatorType, 'OTHER');
+        });
+    });
+
+    suite('case insensitivity', () => {
+        test('lowercase part name still classifies correctly', () => {
+            assert.strictEqual(classifyOperator('scan').operatorType, 'SCAN');
+        });
+    });
+});

--- a/src/test/unit/planFormat.test.ts
+++ b/src/test/unit/planFormat.test.ts
@@ -7,6 +7,11 @@ const TRAITS: OperatorTraits = {
     movesDataOverNetwork: true, blocking: true, isSystemStep: false
 };
 
+const SYSTEM_TRAITS: OperatorTraits = {
+    producesRows: false, consumesRows: false, canSpill: false,
+    movesDataOverNetwork: false, blocking: false, isSystemStep: true
+};
+
 function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
     return {
         id: '1',
@@ -17,14 +22,17 @@ function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
         objectName: undefined,
         partInfo: undefined,
         remarks: undefined,
+        objectRows: undefined,
         rowsOut: 100,
         duration: 1,
         cpu: 50,
         net: undefined,
         tempDbRamPeak: undefined,
         hddWrite: undefined,
+        hddRead: undefined,
         costPercent: 25,
         perNodeStats: undefined,
+        perNodeDurationStats: undefined,
         warnings: [],
         children: [],
         ...overrides
@@ -160,6 +168,23 @@ suite('hottestNodeId', () => {
 
     test('returns undefined for a plan with no nodes', () => {
         assert.strictEqual(hottestNodeId(makePlan([])), undefined);
+    });
+
+    test('a system step never wins, even with the largest costPercent — its denominator (share of total) is not comparable to a user operator\'s (share of query)', () => {
+        const plan = makePlan([
+            makeNode({ id: 'compile', traits: SYSTEM_TRAITS, costPercent: 35 }),
+            makeNode({ id: 'execute', traits: SYSTEM_TRAITS, costPercent: 43 }),
+            makeNode({ id: 'scan', costPercent: 22 })
+        ]);
+        assert.strictEqual(hottestNodeId(plan), 'scan', 'the only non-system node must win regardless of the system steps\' larger numbers');
+    });
+
+    test('returns undefined when every node is a system step — no actionable data-flow operator to ring', () => {
+        const plan = makePlan([
+            makeNode({ id: 'compile', traits: SYSTEM_TRAITS, costPercent: 35 }),
+            makeNode({ id: 'execute', traits: SYSTEM_TRAITS, costPercent: 65 })
+        ]);
+        assert.strictEqual(hottestNodeId(plan), undefined);
     });
 });
 

--- a/src/test/unit/planFormat.test.ts
+++ b/src/test/unit/planFormat.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { planCategoryBreakdown, hottestNodeId, planLacksDetailMetrics } from '../../plan/planFormat';
+import { fmtRows, planCategoryBreakdown, hottestNodeId, planLacksDetailMetrics } from '../../plan/planFormat';
 import { Plan, PlanNode, OperatorTraits } from '../../plan/planModel';
 
 const TRAITS: OperatorTraits = {
@@ -107,6 +107,12 @@ suite('planCategoryBreakdown', () => {
         const [bucket] = planCategoryBreakdown(plan);
         assert.strictEqual(bucket.label, 'Group By');
         assert.strictEqual(bucket.colorVar, '--vscode-charts-green');
+    });
+});
+
+suite('fmtRows', () => {
+    test('rounds values near one million to M instead of 1000k', () => {
+        assert.strictEqual(fmtRows(999_999), '1.0M');
     });
 });
 

--- a/src/test/unit/planFormat.test.ts
+++ b/src/test/unit/planFormat.test.ts
@@ -114,6 +114,14 @@ suite('fmtRows', () => {
     test('rounds values near one million to M instead of 1000k', () => {
         assert.strictEqual(fmtRows(999_999), '1.0M');
     });
+
+    test('rounds values near one billion to B instead of 1000M', () => {
+        assert.strictEqual(fmtRows(999_950_000), '1.0B');
+    });
+
+    test('formats a value comfortably within the B range with one decimal', () => {
+        assert.strictEqual(fmtRows(1_500_000_000), '1.5B');
+    });
 });
 
 suite('hottestNodeId', () => {

--- a/src/test/unit/planFormat.test.ts
+++ b/src/test/unit/planFormat.test.ts
@@ -1,0 +1,185 @@
+import * as assert from 'assert';
+import { planCategoryBreakdown, hottestNodeId, planLacksDetailMetrics } from '../../plan/planFormat';
+import { Plan, PlanNode, OperatorTraits } from '../../plan/planModel';
+
+const TRAITS: OperatorTraits = {
+    producesRows: true, consumesRows: true, canSpill: true,
+    movesDataOverNetwork: true, blocking: true, isSystemStep: false
+};
+
+function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
+    return {
+        id: '1',
+        operatorType: 'JOIN',
+        operatorLabel: 'JOIN',
+        traits: TRAITS,
+        objectSchema: undefined,
+        objectName: undefined,
+        partInfo: undefined,
+        remarks: undefined,
+        rowsOut: 100,
+        duration: 1,
+        cpu: 50,
+        net: undefined,
+        tempDbRamPeak: undefined,
+        hddWrite: undefined,
+        costPercent: 25,
+        perNodeStats: undefined,
+        warnings: [],
+        children: [],
+        ...overrides
+    };
+}
+
+function makePlan(nodes: PlanNode[], overrides: Partial<Plan> = {}): Plan {
+    return {
+        sessionId: '1',
+        stmtId: '1',
+        queryText: undefined,
+        totalDuration: nodes.reduce((sum, n) => sum + (n.duration ?? 0), 0),
+        nodes,
+        edges: [],
+        perNodeStatsAvailable: false,
+        source: 'DETAILS',
+        ...overrides
+    };
+}
+
+suite('planCategoryBreakdown', () => {
+    test('buckets duration by operatorType and computes percent of totalDuration', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', operatorType: 'SCAN', duration: 3 }),
+            makeNode({ id: '2', operatorType: 'JOIN', duration: 1 })
+        ]);
+        const breakdown = planCategoryBreakdown(plan);
+        assert.strictEqual(breakdown.length, 2);
+        const scan = breakdown.find(b => b.type === 'SCAN')!;
+        const join = breakdown.find(b => b.type === 'JOIN')!;
+        assert.strictEqual(scan.percent, 75);
+        assert.strictEqual(join.percent, 25);
+    });
+
+    test('sums multiple nodes of the same operatorType into one bucket', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', operatorType: 'JOIN', duration: 2 }),
+            makeNode({ id: '2', operatorType: 'JOIN', duration: 2 }),
+            makeNode({ id: '3', operatorType: 'SCAN', duration: 4 })
+        ]);
+        const breakdown = planCategoryBreakdown(plan);
+        assert.strictEqual(breakdown.length, 2);
+        assert.strictEqual(breakdown.find(b => b.type === 'JOIN')!.durationSum, 4);
+        assert.strictEqual(breakdown.find(b => b.type === 'JOIN')!.percent, 50);
+    });
+
+    test('sorts buckets by percent descending', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', operatorType: 'SORT', duration: 1 }),
+            makeNode({ id: '2', operatorType: 'SCAN', duration: 5 }),
+            makeNode({ id: '3', operatorType: 'JOIN', duration: 3 })
+        ]);
+        const order = planCategoryBreakdown(plan).map(b => b.type);
+        assert.deepStrictEqual(order, ['SCAN', 'JOIN', 'SORT']);
+    });
+
+    test('a node with an undefined duration contributes nothing, rather than counting as zero', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', operatorType: 'SCAN', duration: 4 }),
+            makeNode({ id: '2', operatorType: 'OTHER', duration: undefined })
+        ], { totalDuration: 4 });
+        const breakdown = planCategoryBreakdown(plan);
+        assert.strictEqual(breakdown.length, 1);
+        assert.strictEqual(breakdown[0].type, 'SCAN');
+        assert.strictEqual(breakdown[0].percent, 100);
+    });
+
+    test('returns an empty array when totalDuration is zero, never dividing by zero', () => {
+        const plan = makePlan([makeNode({ duration: undefined })], { totalDuration: 0 });
+        assert.deepStrictEqual(planCategoryBreakdown(plan), []);
+    });
+
+    test('returns an empty array for a plan with no nodes', () => {
+        const plan = makePlan([], { totalDuration: 0 });
+        assert.deepStrictEqual(planCategoryBreakdown(plan), []);
+    });
+
+    test('each bucket carries a label and colorVar for rendering', () => {
+        const plan = makePlan([makeNode({ id: '1', operatorType: 'GROUP_BY', duration: 1 })]);
+        const [bucket] = planCategoryBreakdown(plan);
+        assert.strictEqual(bucket.label, 'Group By');
+        assert.strictEqual(bucket.colorVar, '--vscode-charts-green');
+    });
+});
+
+suite('hottestNodeId', () => {
+    test('returns the id of the node with the highest costPercent', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', costPercent: 10 }),
+            makeNode({ id: '2', costPercent: 62 }),
+            makeNode({ id: '3', costPercent: 30 })
+        ]);
+        assert.strictEqual(hottestNodeId(plan), '2');
+    });
+
+    test('breaks ties by returning the first node encountered at the max value', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', costPercent: 50 }),
+            makeNode({ id: '2', costPercent: 50 })
+        ]);
+        assert.strictEqual(hottestNodeId(plan), '1');
+    });
+
+    test('skips nodes with an undefined costPercent when finding the max', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', costPercent: undefined }),
+            makeNode({ id: '2', costPercent: 15 })
+        ]);
+        assert.strictEqual(hottestNodeId(plan), '2');
+    });
+
+    test('returns undefined when no node has a defined costPercent', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', costPercent: undefined }),
+            makeNode({ id: '2', costPercent: undefined })
+        ]);
+        assert.strictEqual(hottestNodeId(plan), undefined);
+    });
+
+    test('returns undefined for a plan with no nodes', () => {
+        assert.strictEqual(hottestNodeId(makePlan([])), undefined);
+    });
+});
+
+suite('planLacksDetailMetrics', () => {
+    test('is true when every node has both cpu and net undefined', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', cpu: undefined, net: undefined }),
+            makeNode({ id: '2', cpu: undefined, net: undefined })
+        ]);
+        assert.strictEqual(planLacksDetailMetrics(plan), true);
+    });
+
+    test('is false when at least one node has a defined cpu', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', cpu: undefined, net: undefined }),
+            makeNode({ id: '2', cpu: 12.5, net: undefined })
+        ]);
+        assert.strictEqual(planLacksDetailMetrics(plan), false);
+    });
+
+    test('is false when at least one node has a defined net, even if cpu is undefined everywhere', () => {
+        const plan = makePlan([
+            makeNode({ id: '1', cpu: undefined, net: undefined }),
+            makeNode({ id: '2', cpu: undefined, net: 0 })
+        ]);
+        assert.strictEqual(planLacksDetailMetrics(plan), false);
+    });
+
+    test('is false for a plan with no nodes — nothing to educate the user about yet', () => {
+        assert.strictEqual(planLacksDetailMetrics(makePlan([])), false);
+    });
+
+    test('a real net:0 (recorded, not missing) counts as defined and prevents the hint', () => {
+        const plan = makePlan([makeNode({ id: '1', cpu: undefined, net: 0 })]);
+        assert.strictEqual(planLacksDetailMetrics(plan), false);
+    });
+});

--- a/src/test/unit/planProvider.test.ts
+++ b/src/test/unit/planProvider.test.ts
@@ -253,7 +253,8 @@ suite('PlanProvider.getPlan', () => {
                 assert.ok(error.message.includes('No profiling data found'));
                 assert.ok(error.message.includes('42'));
                 assert.ok(error.message.includes('3'));
-                assert.ok(error.message.includes('FLUSH STATISTICS'));
+                assert.ok(error.message.includes('execution plans are enabled'));
+                assert.ok(error.message.includes('reconnect'));
                 return true;
             }
         );

--- a/src/test/unit/planProvider.test.ts
+++ b/src/test/unit/planProvider.test.ts
@@ -1,0 +1,389 @@
+import * as assert from 'assert';
+import { registerVscodeMock, registerExtensionMock } from '../helpers/vscodeMock';
+
+registerVscodeMock();
+registerExtensionMock();
+
+// Loaded after the vscode/extension mocks are configured, matching the
+// convention in queryExecutorRouting.test.ts / objectActions.test.ts.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PlanProvider, RETRY_DELAYS_AFTER_FLUSH_FAILURE_MS } = require('../../plan/planProvider');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { BACKGROUND_QUERY_TIMEOUT_MS } = require('../../connectionManager');
+
+import { createRawResult, createEmptyRawResult, createRawErrorResult, TEST_CONNECTION } from '../helpers/mockConnectionManager';
+
+// afterStmtId is a baseline (CURRENT_STATEMENT read before the real query
+// ran), not the real query's own STMT_ID — see planProvider.ts's file header.
+// Both are exact digit strings end-to-end; real Exasol SESSION_IDs exceed
+// what a JS number can represent exactly.
+const TARGET = { sessionId: '42', afterStmtId: '3' };
+
+const DETAILS_COLUMNS = ['SESSION_ID', 'STMT_ID', 'PART_ID', 'IPROC', 'PART_NAME', 'OUT_ROWS', 'DURATION'];
+const SUMMARY_COLUMNS = ['SESSION_ID', 'STMT_ID', 'PART_ID', 'PART_NAME', 'OUT_ROWS', 'DURATION'];
+
+// Resolved STMT_ID (7) is greater than the baseline (3), as it must be.
+function detailsRow(): any[] {
+    return [42, 7, 1, 0, 'PIPE SCAN', 1000, 0.5];
+}
+
+function summaryRow(): any[] {
+    return [42, 7, 1, 'SCAN', 1000, 0.5];
+}
+
+interface Call { method: 'query' | 'execute'; sql: string }
+
+/**
+ * Builds a PlanProvider wired to a fake driver. `queryResponses` are consumed
+ * in order by each rawQuery() call (the tier-fetch attempts); the FLUSH
+ * STATISTICS call (rawExecute) always succeeds unless `flushThrows` or
+ * `flushReturnsError` is set. These model the two distinct ways a raw-mode
+ * driver call can fail: a thrown exception (e.g. connection reset) vs. a
+ * returned {status:'error'} response with no throw at all (e.g. a genuine
+ * SQL-level error like insufficient privilege — verified against the real
+ * driver's source, which only throws for the 'default' response type).
+ */
+function makeProvider(
+    queryResponses: Array<() => any>,
+    options: { flushThrows?: boolean; flushReturnsError?: boolean; retryOptions?: any } = {}
+): { provider: any; calls: Call[] } {
+    const calls: Call[] = [];
+    let callIndex = 0;
+
+    const fakeDriver = {
+        execute: async (sql: string) => {
+            calls.push({ method: 'execute', sql });
+            if (options.flushThrows) {
+                throw new Error('simulated FLUSH STATISTICS failure');
+            }
+            if (options.flushReturnsError) {
+                return createRawErrorResult('42500', 'insufficient privileges to execute FLUSH STATISTICS');
+            }
+            return createEmptyRawResult([]);
+        },
+        query: async (sql: string) => {
+            calls.push({ method: 'query', sql });
+            const respond = queryResponses[callIndex++];
+            if (!respond) {
+                throw new Error(`Unexpected extra driver query() call: ${sql}`);
+            }
+            return respond();
+        }
+    };
+
+    const fakeConnectionManager = {
+        getDriver: async (_connectionId?: string, _role?: string) => fakeDriver,
+        executeWithRetry: async (fn: () => Promise<any>) => fn()
+    };
+
+    return { provider: new PlanProvider(fakeConnectionManager, options.retryOptions), calls };
+}
+
+function queryCalls(calls: Call[]): Call[] {
+    return calls.filter(c => c.method === 'query');
+}
+
+suite('PlanProvider.getPlan', () => {
+
+    test('flushes statistics before attempting any tier', async () => {
+        const { provider, calls } = makeProvider([
+            () => createRawResult(DETAILS_COLUMNS, [detailsRow()])
+        ]);
+
+        await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        assert.strictEqual(calls[0].method, 'execute');
+        assert.ok(calls[0].sql.includes('FLUSH STATISTICS'));
+        assert.strictEqual(calls[1].method, 'query');
+    });
+
+    test('a FLUSH STATISTICS failure does not block the fetch (best-effort)', async () => {
+        const { provider } = makeProvider(
+            [() => createRawResult(DETAILS_COLUMNS, [detailsRow()])],
+            { flushThrows: true }
+        );
+
+        const plan = await provider.getPlan(TEST_CONNECTION, TARGET);
+        assert.strictEqual(plan.source, 'DETAILS');
+    });
+
+    test('a FLUSH STATISTICS returned-error response (no throw) is still treated as a flush failure, using the long retry schedule', async () => {
+        // Regression test: rawExecute() requests the driver's 'raw' response
+        // type, which never throws on a SQL-level error (verified against the
+        // real driver's source — it only calls verifyNoError() for 'default'
+        // responses). The old code awaited rawExecute() and discarded the
+        // result without checking it, so a privilege-denied FLUSH STATISTICS
+        // returned normally, flushSucceeded stayed true, and the short
+        // 3-round schedule was used instead of the long one — reintroducing
+        // the exact false "No profiling data found" bug this schedule split
+        // exists to prevent.
+        const empty = () => createEmptyRawResult(SUMMARY_COLUMNS);
+        const responses: Array<() => any> = [];
+        for (let round = 0; round < 5; round++) {
+            responses.push(empty, empty, empty);
+        }
+        const { provider, calls } = makeProvider(responses, {
+            flushReturnsError: true,
+            retryOptions: { retryDelaysAfterFlushFailureMs: [0, 0, 0, 0, 0] }
+        });
+
+        await assert.rejects(() => provider.getPlan(TEST_CONNECTION, TARGET), /No profiling data found/);
+
+        assert.strictEqual(
+            queryCalls(calls).length, 15,
+            'a returned-error flush response must be treated as a flush failure (5-round schedule), not a success (3-round schedule)'
+        );
+    });
+
+    test('returns a plan from the first (DETAILS) tier when it succeeds', async () => {
+        const { provider, calls } = makeProvider([
+            () => createRawResult(DETAILS_COLUMNS, [detailsRow()])
+        ]);
+
+        const plan = await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        const qCalls = queryCalls(calls);
+        assert.strictEqual(qCalls.length, 1);
+        assert.ok(qCalls[0].sql.includes('$EXA_PROFILE_DETAILS_LAST_DAY'));
+        assert.strictEqual(plan.source, 'DETAILS');
+        assert.strictEqual(plan.nodes.length, 1);
+    });
+
+    test('the resolved stmtId on the returned Plan comes from the actual row data, not the baseline', async () => {
+        const { provider } = makeProvider([
+            () => createRawResult(DETAILS_COLUMNS, [detailsRow()])
+        ]);
+
+        const plan = await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        assert.strictEqual(plan.stmtId, '7', 'must be the resolved STMT_ID (7), not the baseline afterStmtId (3)');
+    });
+
+    test('falls back to DBA_SUMMARY when DETAILS is denied by privilege', async () => {
+        const { provider, calls } = makeProvider([
+            () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } }),
+            () => createRawResult(SUMMARY_COLUMNS, [summaryRow()])
+        ]);
+
+        const plan = await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        const qCalls = queryCalls(calls);
+        assert.strictEqual(qCalls.length, 2);
+        assert.ok(qCalls[1].sql.includes('EXA_DBA_PROFILE_LAST_DAY'));
+        assert.strictEqual(plan.source, 'DBA_SUMMARY');
+    });
+
+    test('falls back all the way to USER_SUMMARY when both privileged tiers are denied', async () => {
+        const { provider, calls } = makeProvider([
+            () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } }),
+            () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } }),
+            () => createRawResult(SUMMARY_COLUMNS, [summaryRow()])
+        ]);
+
+        const plan = await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        const qCalls = queryCalls(calls);
+        assert.strictEqual(qCalls.length, 3);
+        assert.ok(qCalls[2].sql.includes('EXA_USER_PROFILE_LAST_DAY'));
+        assert.strictEqual(plan.source, 'USER_SUMMARY');
+    });
+
+    test('also falls back when a tier reports the object does not exist (schema-drift defense)', async () => {
+        const { provider, calls } = makeProvider([
+            () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42000', text: 'object "$EXA_PROFILE_DETAILS_LAST_DAY" not found' } }),
+            () => createRawResult(SUMMARY_COLUMNS, [summaryRow()])
+        ]);
+
+        const plan = await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        assert.strictEqual(queryCalls(calls).length, 2);
+        assert.strictEqual(plan.source, 'DBA_SUMMARY');
+    });
+
+    test('fails fast with a clear permission message when every tier is denied by privilege', async () => {
+        const deniedByPrivilege = () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } });
+        const { provider, calls } = makeProvider([deniedByPrivilege, deniedByPrivilege, deniedByPrivilege]);
+
+        await assert.rejects(
+            () => provider.getPlan(TEST_CONNECTION, TARGET),
+            (error: Error) => {
+                assert.ok(error.message.includes("doesn't have permission"));
+                assert.ok(error.message.includes('SELECT ANY DICTIONARY'));
+                assert.ok(!error.message.includes('No profiling data found'), 'must not use the generic timing-oriented message');
+                return true;
+            }
+        );
+        assert.strictEqual(queryCalls(calls).length, 3, 'must fail after the first round — retrying a hard permission wall cannot help');
+    });
+
+    test('does not fail fast when the fallback chain is a mix of privilege denial and genuinely empty tiers', async function () {
+        // DETAILS denied by privilege, but USER_SUMMARY was *reached* and is
+        // just empty (e.g. profiling was never turned on) — this is still
+        // worth the normal retry/generic-message path, since it's not a
+        // permission wall on every tier.
+        this.timeout(5000);
+        const deniedByPrivilege = () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } });
+        const { provider, calls } = makeProvider([
+            deniedByPrivilege, () => createEmptyRawResult(SUMMARY_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS),
+            deniedByPrivilege, () => createEmptyRawResult(SUMMARY_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS),
+            deniedByPrivilege, () => createEmptyRawResult(SUMMARY_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS)
+        ]);
+
+        await assert.rejects(
+            () => provider.getPlan(TEST_CONNECTION, TARGET),
+            (error: Error) => {
+                assert.ok(error.message.includes('No profiling data found'));
+                return true;
+            }
+        );
+        assert.strictEqual(queryCalls(calls).length, 9, 'all 3 rounds should still run since it is not a hard permission wall');
+    });
+
+    test('throws a descriptive "no profiling data" error when every tier returns zero rows on every retry round', async function () {
+        this.timeout(5000); // exhausts the full [0, 500, 1000]ms retry budget
+        const { provider, calls } = makeProvider([
+            () => createEmptyRawResult(DETAILS_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS),
+            () => createEmptyRawResult(DETAILS_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS),
+            () => createEmptyRawResult(DETAILS_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS), () => createEmptyRawResult(SUMMARY_COLUMNS)
+        ]);
+
+        await assert.rejects(
+            () => provider.getPlan(TEST_CONNECTION, TARGET),
+            (error: Error) => {
+                assert.ok(error.message.includes('No profiling data found'));
+                assert.ok(error.message.includes('42'));
+                assert.ok(error.message.includes('3'));
+                assert.ok(error.message.includes('FLUSH STATISTICS'));
+                return true;
+            }
+        );
+        assert.strictEqual(queryCalls(calls).length, 9, 'all 3 tiers attempted on all 3 retry rounds');
+    });
+
+    test('the flush-failure retry schedule outlasts the ~9s cross-connection propagation delay', () => {
+        // A FLUSH STATISTICS failure (e.g. no flush privilege) means the data
+        // only becomes visible from this background session after Exasol's own
+        // ~8-9s cross-connection propagation. The retry window for that case
+        // must comfortably exceed it, or a user with read (but not flush)
+        // access gets a false "no profiling data found".
+        const total = RETRY_DELAYS_AFTER_FLUSH_FAILURE_MS.reduce((a: number, b: number) => a + b, 0);
+        assert.ok(total > 9000, `flush-failure retry window (${total}ms) must comfortably exceed the ~8-9s propagation delay`);
+    });
+
+    test('when FLUSH STATISTICS fails, polls the longer flush-failure schedule (more rounds) before giving up', async () => {
+        // FLUSH fails and every tier is genuinely empty on every round. The
+        // fetch must run one full fallback pass per entry in the flush-failure
+        // schedule — more rounds than the 3-round post-flush-success path —
+        // rather than reporting "no data" after the short window. Delays are
+        // zeroed here so the assertion is about round count, not wall-clock.
+        const empty = () => createEmptyRawResult(SUMMARY_COLUMNS);
+        const responses: Array<() => any> = [];
+        for (let round = 0; round < 5; round++) {
+            responses.push(empty, empty, empty);
+        }
+        const { provider, calls } = makeProvider(responses, {
+            flushThrows: true,
+            retryOptions: { retryDelaysAfterFlushFailureMs: [0, 0, 0, 0, 0] }
+        });
+
+        await assert.rejects(() => provider.getPlan(TEST_CONNECTION, TARGET), /No profiling data found/);
+
+        assert.strictEqual(
+            queryCalls(calls).length, 15,
+            'must run all 5 flush-failure rounds x 3 tiers (not the 3-round post-flush-success schedule)'
+        );
+    });
+
+    test('when FLUSH STATISTICS succeeds, uses the short 3-round schedule, not the flush-failure one', async function () {
+        // Contrast to the test above: flush succeeded, so the data should be
+        // visible almost immediately — no reason to poll the long schedule.
+        this.timeout(5000);
+        const empty = () => createEmptyRawResult(SUMMARY_COLUMNS);
+        const responses: Array<() => any> = [];
+        for (let round = 0; round < 3; round++) {
+            responses.push(empty, empty, empty);
+        }
+        const { provider, calls } = makeProvider(responses); // flush succeeds (default)
+
+        await assert.rejects(() => provider.getPlan(TEST_CONNECTION, TARGET), /No profiling data found/);
+
+        assert.strictEqual(queryCalls(calls).length, 9, 'post-flush-success path is the short 3-round schedule');
+    });
+
+    test('a non-recoverable error propagates immediately without trying further tiers or retry rounds', async () => {
+        const { provider, calls } = makeProvider([
+            () => { throw new Error('connection reset'); }
+        ]);
+
+        await assert.rejects(
+            () => provider.getPlan(TEST_CONNECTION, TARGET),
+            /connection reset/
+        );
+        assert.strictEqual(queryCalls(calls).length, 1, 'must not attempt further tiers or retry rounds after a non-recoverable error');
+    });
+
+    test('rejects a non-digit-string sessionId/afterStmtId before ever touching the driver', async () => {
+        const { provider, calls } = makeProvider([() => createRawResult(SUMMARY_COLUMNS, [summaryRow()])]);
+
+        await assert.rejects(() => provider.getPlan(TEST_CONNECTION, { sessionId: 'not-a-number', afterStmtId: '7' }));
+        assert.strictEqual(calls.length, 0, 'not even the flush should run');
+    });
+
+    test('fetches via the background driver role with the background query timeout', async () => {
+        let capturedRole: string | undefined;
+        let capturedTimeout: number | undefined;
+
+        const fakeDriver = {
+            execute: async () => createEmptyRawResult([]),
+            query: async () => createRawResult(SUMMARY_COLUMNS, [summaryRow()])
+        };
+        const fakeConnectionManager = {
+            getDriver: async (_connectionId?: string, role?: string) => {
+                capturedRole = role;
+                return fakeDriver;
+            },
+            executeWithRetry: async (fn: () => Promise<any>, _connectionId?: string, options?: any) => {
+                capturedTimeout = options?.timeoutMs;
+                return fn();
+            }
+        };
+
+        const provider = new PlanProvider(fakeConnectionManager);
+        await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        assert.strictEqual(capturedRole, 'background');
+        assert.strictEqual(capturedTimeout, BACKGROUND_QUERY_TIMEOUT_MS);
+    });
+
+    test('SQL scopes every tier to the target session and searches strictly after the baseline', async () => {
+        const { provider, calls } = makeProvider([() => createRawResult(DETAILS_COLUMNS, [detailsRow()])]);
+        await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        const sql = queryCalls(calls)[0].sql;
+        assert.ok(sql.includes('SESSION_ID = 42'));
+        assert.ok(sql.includes('STMT_ID > 3'), 'must search strictly after the baseline, not for an exact match');
+        assert.ok(sql.includes('MIN(STMT_ID)'), 'must resolve to the first qualifying statement');
+        assert.ok(sql.includes("COMMAND_NAME NOT IN ('COMMIT', 'ROLLBACK')"), 'must exclude implicit transaction bookkeeping');
+    });
+
+    test('only the DETAILS tier orders by IPROC — the summary views have no such column', async () => {
+        // Regression test: EXA_DBA_PROFILE_LAST_DAY/EXA_USER_PROFILE_LAST_DAY
+        // have no IPROC column (confirmed via DESCRIBE against a live
+        // instance); a prior refactor briefly ordered by it unconditionally,
+        // which failed live with "object IPROC not found" on those tiers.
+        const { provider, calls } = makeProvider([
+            () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } }),
+            () => ({ status: 'error', responseData: {}, exception: { sqlCode: '42500', text: 'insufficient privileges for accessing view' } }),
+            () => createRawResult(SUMMARY_COLUMNS, [summaryRow()])
+        ]);
+
+        await provider.getPlan(TEST_CONNECTION, TARGET);
+
+        const [detailsSql, dbaSql, userSql] = queryCalls(calls).map(c => c.sql);
+        assert.ok(detailsSql.includes('ORDER BY PART_ID, IPROC'), 'DETAILS tier should still order by IPROC');
+        assert.ok(!dbaSql.includes('IPROC'), 'DBA_SUMMARY tier must not reference IPROC');
+        assert.ok(!userSql.includes('IPROC'), 'USER_SUMMARY tier must not reference IPROC');
+        assert.ok(dbaSql.includes('ORDER BY PART_ID') && !dbaSql.includes('ORDER BY PART_ID,'));
+        assert.ok(userSql.includes('ORDER BY PART_ID') && !userSql.includes('ORDER BY PART_ID,'));
+    });
+});

--- a/src/test/unit/planTextExport.test.ts
+++ b/src/test/unit/planTextExport.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { buildPlanTextSummary } from '../../plan/planTextExport';
+import { buildPlanTextSummary, operatorBlock } from '../../plan/planTextExport';
 import { Plan, PlanNode, OperatorTraits } from '../../plan/planModel';
 
 const PASSTHROUGH_TRAITS: OperatorTraits = {
@@ -17,14 +17,17 @@ function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
         objectName: undefined,
         partInfo: undefined,
         remarks: undefined,
+        objectRows: undefined,
         rowsOut: 1000,
         duration: 0.5,
         cpu: 50,
         net: undefined,
         tempDbRamPeak: undefined,
         hddWrite: undefined,
+        hddRead: undefined,
         costPercent: 50,
         perNodeStats: undefined,
+        perNodeDurationStats: undefined,
         warnings: [],
         children: [],
         ...overrides
@@ -88,23 +91,40 @@ suite('buildPlanTextSummary', () => {
         assert.ok(text.includes('1. JOIN [part 1]\n'), 'the operator line must not carry a trailing " — ..." suffix');
     });
 
-    test('includes duration, CPU, cost share, and rows out on the primary metrics line', () => {
+    test('includes duration, duration share, CPU, and rows out on the primary metrics line', () => {
         const text = buildPlanTextSummary(makePlan({
             nodes: [makeNode({ duration: 0.12, cpu: 38, costPercent: 33, rowsOut: 4500 })]
         }));
         assert.ok(text.includes('Duration: 120 ms'));
-        assert.ok(text.includes('CPU: 38%'));
-        assert.ok(text.includes('Cost: 33%'));
+        assert.ok(text.includes('Share (of query): 33%'), 'F12: the primary metrics line renamed "Cost:" to "Share:"');
+        assert.ok(text.includes('CPU (max node): 38%'), 'F24: CPU is labeled as a per-node max');
         assert.ok(text.includes('Rows out: 4.5k'));
+    });
+
+    suite('share denominator suffix (finding B)', () => {
+        test('a non-system node reads "Share (of query)"', () => {
+            const text = buildPlanTextSummary(makePlan({
+                nodes: [makeNode({ costPercent: 45, traits: { ...PASSTHROUGH_TRAITS, isSystemStep: false } })]
+            }));
+            assert.ok(text.includes('Share (of query): 45%'));
+        });
+
+        test('a system-step node reads "Share (of total)" instead', () => {
+            const text = buildPlanTextSummary(makePlan({
+                nodes: [makeNode({ costPercent: 31, traits: { ...PASSTHROUGH_TRAITS, isSystemStep: true } })]
+            }));
+            assert.ok(text.includes('Share (of total): 31%'));
+            assert.ok(!text.includes('Share (of query)'));
+        });
     });
 
     test('shows a dash for CPU when the profile row did not report it, not a fake 0%', () => {
         const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ cpu: undefined })] }));
-        assert.ok(text.includes('CPU: —'));
-        assert.ok(!text.includes('CPU: 0%'));
+        assert.ok(text.includes('CPU (max node): —'));
+        assert.ok(!text.includes('CPU (max node): 0%'));
     });
 
-    test('shows Net, HDD write, and Temp DB RAM peak on their own line, including real zero values', () => {
+    test('shows Net, Temp DB RAM peak, and HDD write on their own line, including real zero values', () => {
         const text = buildPlanTextSummary(makePlan({
             nodes: [makeNode({ net: 0, hddWrite: 340.2, tempDbRamPeak: 12 })]
         }));
@@ -135,6 +155,55 @@ suite('buildPlanTextSummary', () => {
         assert.ok(!text.includes('Temp DB RAM peak:'));
     });
 
+    suite('HDD read (finding 7)', () => {
+        test('is shown, as a rate, only when greater than zero', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ hddRead: 3.2 })] }));
+            assert.ok(text.includes('HDD read: 3.2 MiB/s'));
+        });
+
+        test('is omitted when zero — the overwhelming common case, not worth showing as noise', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ hddRead: 0 })] }));
+            assert.ok(!text.includes('HDD read:'));
+        });
+
+        test('is omitted when undefined (not measured)', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ hddRead: undefined })] }));
+            assert.ok(!text.includes('HDD read:'));
+        });
+    });
+
+    suite('scan selectivity (finding 3)', () => {
+        test('shows objectRows -> rowsOut with a one-decimal percentage when both are defined', () => {
+            const text = buildPlanTextSummary(makePlan({
+                nodes: [makeNode({ objectRows: 10000, rowsOut: 250 })]
+            }));
+            assert.ok(text.includes('Scanned: 10,000 rows → 250 (2.5%)'));
+        });
+
+        test('omits the Scanned line when objectRows is undefined', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ objectRows: undefined, rowsOut: 250 })] }));
+            assert.ok(!text.includes('Scanned:'));
+        });
+
+        test('omits the Scanned line when rowsOut is undefined', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ objectRows: 10000, rowsOut: undefined })] }));
+            assert.ok(!text.includes('Scanned:'));
+        });
+
+        test('omits the Scanned line when objectRows is zero, guarding the division', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ objectRows: 0, rowsOut: 0 })] }));
+            assert.ok(!text.includes('Scanned:'));
+        });
+
+        test('shows the raw row counts but omits the percentage when rowsOut exceeds objectRows (inconsistent data, not >100% selectivity)', () => {
+            const text = buildPlanTextSummary(makePlan({
+                nodes: [makeNode({ objectRows: 1594, rowsOut: 6314 })]
+            }));
+            assert.ok(text.includes('Scanned: 1,594 rows → 6,314'), 'the raw row counts must still be shown');
+            assert.ok(!/Scanned:[^\n]*%/.test(text), 'must never render a >100% selectivity percentage');
+        });
+    });
+
     test('shows "not available" for per-node rows when no per-node stats exist for that operator', () => {
         const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ perNodeStats: undefined })] }));
         assert.ok(text.includes('Per-node rows: not available'));
@@ -145,6 +214,47 @@ suite('buildPlanTextSummary', () => {
             nodes: [makeNode({ perNodeStats: { metric: 'rows', min: 4180, max: 4340, avg: 4300, nodeCount: 4 } })]
         }));
         assert.ok(text.includes('Per-node rows: min 4180 / max 4340 / avg 4300 / nodes 4'));
+    });
+
+    suite('per-node durations (finding 4)', () => {
+        test('is omitted entirely when perNodeDurationStats is undefined', () => {
+            const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ perNodeDurationStats: undefined })] }));
+            assert.ok(!text.includes('Per-node durations:'));
+        });
+
+        test('shows the min/max/avg/nodes breakdown, formatted the same way as Duration, when present', () => {
+            const text = buildPlanTextSummary(makePlan({
+                nodes: [makeNode({ perNodeDurationStats: { metric: 'duration', min: 0.01, max: 0.34, avg: 0.12, nodeCount: 4 } })]
+            }));
+            assert.ok(text.includes('Per-node durations: min 10.0 ms / max 340 ms / avg 120 ms / nodes 4'));
+        });
+
+        suite('1ms noise floor (finding C)', () => {
+            test('shows the line when the slowest node is exactly at the 1ms floor', () => {
+                const text = buildPlanTextSummary(makePlan({
+                    nodes: [makeNode({ perNodeDurationStats: { metric: 'duration', min: 0.0001, max: 0.001, avg: 0.0005, nodeCount: 4 } })]
+                }));
+                assert.ok(text.includes('Per-node durations:'), 'a 1ms max meets the floor and must render');
+            });
+
+            test('omits the line when the slowest node is just under the 1ms floor — measurement noise, not a real distribution', () => {
+                const text = buildPlanTextSummary(makePlan({
+                    nodes: [makeNode({ perNodeDurationStats: { metric: 'duration', min: 0.0001, max: 0.0009, avg: 0.0005, nodeCount: 4 } })]
+                }));
+                assert.ok(!text.includes('Per-node durations:'), 'a 0.9ms max is below the floor');
+            });
+
+            test('per-node ROWS behavior is unaffected by the duration floor', () => {
+                const text = buildPlanTextSummary(makePlan({
+                    nodes: [makeNode({
+                        perNodeStats: { metric: 'rows', min: 1, max: 2, avg: 1.5, nodeCount: 4 },
+                        perNodeDurationStats: { metric: 'duration', min: 0.0001, max: 0.0009, avg: 0.0005, nodeCount: 4 }
+                    })]
+                }));
+                assert.ok(text.includes('Per-node rows: min 1 / max 2 / avg 2 / nodes 4'), 'the rows line must still render regardless of the duration floor');
+                assert.ok(!text.includes('Per-node durations:'));
+            });
+        });
     });
 
     test('includes part info and remarks when present, omits them when absent', () => {
@@ -180,5 +290,23 @@ suite('buildPlanTextSummary', () => {
     test('a plan with no nodes says so plainly instead of an empty operator list', () => {
         const text = buildPlanTextSummary(makePlan({ nodes: [] }));
         assert.ok(text.includes('This statement produced no profiled operators.'));
+    });
+});
+
+suite('operatorBlock (finding 11 — per-node copy)', () => {
+    test('is exported directly, with no separate wrapper function', () => {
+        assert.strictEqual(typeof operatorBlock, 'function');
+    });
+
+    test('renders exactly the block buildPlanTextSummary embeds for that node, at the same index', () => {
+        const nodeA = makeNode({ id: '2', operatorLabel: 'PIPE SCAN', duration: 0.05, costPercent: 20 });
+        const nodeB = makeNode({ id: '5', operatorLabel: 'JOIN (HASH)', duration: 0.2, costPercent: 80 });
+        const plan = makePlan({ nodes: [nodeA, nodeB] });
+
+        const fullText = buildPlanTextSummary(plan);
+        const blockForB = operatorBlock(nodeB, 1);
+
+        assert.ok(fullText.includes(blockForB), 'the standalone block for node B must appear verbatim inside the full export');
+        assert.ok(blockForB.startsWith('2. JOIN (HASH) [part 5]'), 'the index parameter numbers the block the same way as the full export');
     });
 });

--- a/src/test/unit/planTextExport.test.ts
+++ b/src/test/unit/planTextExport.test.ts
@@ -1,0 +1,184 @@
+import * as assert from 'assert';
+import { buildPlanTextSummary } from '../../plan/planTextExport';
+import { Plan, PlanNode, OperatorTraits } from '../../plan/planModel';
+
+const PASSTHROUGH_TRAITS: OperatorTraits = {
+    producesRows: true, consumesRows: true, canSpill: true,
+    movesDataOverNetwork: true, blocking: true, isSystemStep: false
+};
+
+function makeNode(overrides: Partial<PlanNode> = {}): PlanNode {
+    return {
+        id: '1',
+        operatorType: 'JOIN',
+        operatorLabel: 'JOIN',
+        traits: PASSTHROUGH_TRAITS,
+        objectSchema: undefined,
+        objectName: undefined,
+        partInfo: undefined,
+        remarks: undefined,
+        rowsOut: 1000,
+        duration: 0.5,
+        cpu: 50,
+        net: undefined,
+        tempDbRamPeak: undefined,
+        hddWrite: undefined,
+        costPercent: 50,
+        perNodeStats: undefined,
+        warnings: [],
+        children: [],
+        ...overrides
+    };
+}
+
+function makePlan(overrides: Partial<Plan> = {}): Plan {
+    return {
+        sessionId: '42',
+        stmtId: '16',
+        queryText: undefined,
+        totalDuration: 1,
+        nodes: [makeNode()],
+        edges: [],
+        perNodeStatsAvailable: false,
+        source: 'DETAILS',
+        ...overrides
+    };
+}
+
+suite('buildPlanTextSummary', () => {
+
+    test('includes the session/statement id, source label, and total time in the header', () => {
+        const text = buildPlanTextSummary(makePlan({ sessionId: '1871224275982483456', stmtId: '27', source: 'USER_SUMMARY' }));
+        assert.ok(text.includes('session 1871224275982483456, statement 27'));
+        assert.ok(text.includes('Source: cluster summary'));
+    });
+
+    test('reports "not available" for node count when no per-node stats exist anywhere', () => {
+        const text = buildPlanTextSummary(makePlan());
+        assert.ok(text.includes('Nodes: not available'));
+    });
+
+    test('shows the max observed node count when per-node stats exist', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ perNodeStats: { metric: 'rows', min: 1, max: 10, avg: 5, nodeCount: 8 } })]
+        }));
+        assert.ok(text.includes('Nodes: 8'));
+    });
+
+    test('numbers each operator in plan order and tags it with its PART_ID, one block per node', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [
+                makeNode({ id: '2', operatorLabel: 'PIPE SCAN' }),
+                makeNode({ id: '5', operatorLabel: 'JOIN (HASH)' })
+            ]
+        }));
+        assert.ok(text.includes('1. PIPE SCAN [part 2]'));
+        assert.ok(text.includes('2. JOIN (HASH) [part 5]'));
+    });
+
+    test('includes the object name (schema-qualified) next to the operator label when present', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ id: '1', objectSchema: 'REPORTS', objectName: 'DAILY_SUMMARY' })]
+        }));
+        assert.ok(text.includes('1. JOIN [part 1] — REPORTS.DAILY_SUMMARY'));
+    });
+
+    test('omits the object suffix entirely when no object name is present', () => {
+        const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ id: '1', objectName: undefined })] }));
+        assert.ok(text.includes('1. JOIN [part 1]\n'), 'the operator line must not carry a trailing " — ..." suffix');
+    });
+
+    test('includes duration, CPU, cost share, and rows out on the primary metrics line', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ duration: 0.12, cpu: 38, costPercent: 33, rowsOut: 4500 })]
+        }));
+        assert.ok(text.includes('Duration: 120 ms'));
+        assert.ok(text.includes('CPU: 38%'));
+        assert.ok(text.includes('Cost: 33%'));
+        assert.ok(text.includes('Rows out: 4.5k'));
+    });
+
+    test('shows a dash for CPU when the profile row did not report it, not a fake 0%', () => {
+        const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ cpu: undefined })] }));
+        assert.ok(text.includes('CPU: —'));
+        assert.ok(!text.includes('CPU: 0%'));
+    });
+
+    test('shows Net, HDD write, and Temp DB RAM peak on their own line, including real zero values', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ net: 0, hddWrite: 340.2, tempDbRamPeak: 12 })]
+        }));
+        assert.ok(text.includes('Net: 0.0 MiB'), 'a real recorded zero must still be shown, not omitted');
+        assert.ok(text.includes('HDD write: 340.2 MiB'));
+        // Temp DB RAM peak now goes through the same fmtMiB() formatter as
+        // Net/HDD write for consistent precision (was a bare `${n} MiB`
+        // template, which showed "12 MiB" here but "340.2 MiB" for HDD write
+        // a line above — inconsistent decimal precision for the same unit).
+        assert.ok(text.includes('Temp DB RAM peak: 12.0 MiB'));
+    });
+
+    test('omits the Net/HDD write/Temp DB RAM peak line entirely when none of the three were reported', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ net: undefined, hddWrite: undefined, tempDbRamPeak: undefined })]
+        }));
+        assert.ok(!text.includes('Net:'));
+        assert.ok(!text.includes('HDD write:'));
+        assert.ok(!text.includes('Temp DB RAM peak:'));
+    });
+
+    test('includes only the reported fields when some of Net/HDD write/Temp DB RAM peak are undefined', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ net: undefined, hddWrite: 5.5, tempDbRamPeak: undefined })]
+        }));
+        assert.ok(text.includes('HDD write: 5.5 MiB'));
+        assert.ok(!text.includes('Net:'));
+        assert.ok(!text.includes('Temp DB RAM peak:'));
+    });
+
+    test('shows "not available" for per-node rows when no per-node stats exist for that operator', () => {
+        const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ perNodeStats: undefined })] }));
+        assert.ok(text.includes('Per-node rows: not available'));
+    });
+
+    test('shows the full min/max/avg/nodes breakdown when per-node stats exist for that operator', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ perNodeStats: { metric: 'rows', min: 4180, max: 4340, avg: 4300, nodeCount: 4 } })]
+        }));
+        assert.ok(text.includes('Per-node rows: min 4180 / max 4340 / avg 4300 / nodes 4'));
+    });
+
+    test('includes part info and remarks when present, omits them when absent', () => {
+        const withText = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({ partInfo: 'JOIN CONDITION: A.ID = B.ID', remarks: 'temporary result' })]
+        }));
+        assert.ok(withText.includes('Part info: JOIN CONDITION: A.ID = B.ID'));
+        assert.ok(withText.includes('Remarks: temporary result'));
+
+        const without = buildPlanTextSummary(makePlan({ nodes: [makeNode({ partInfo: undefined, remarks: undefined })] }));
+        assert.ok(!without.includes('Part info:'));
+        assert.ok(!without.includes('Remarks:'));
+    });
+
+    test('lists every warning message on its own line, prefixed with the warning glyph', () => {
+        const text = buildPlanTextSummary(makePlan({
+            nodes: [makeNode({
+                warnings: [
+                    { type: 'SPILLED_TO_DISK', message: 'Wrote 12.5 MiB to disk during execution', detail: {} },
+                    { type: 'HIGH_SKEW', message: 'Rows per node ranged 1-1000 (avg 300) across 4 nodes', detail: {} }
+                ]
+            })]
+        }));
+        assert.ok(text.includes('⚠ Wrote 12.5 MiB to disk during execution'));
+        assert.ok(text.includes('⚠ Rows per node ranged 1-1000 (avg 300) across 4 nodes'));
+    });
+
+    test('an operator with no warnings has no warning lines', () => {
+        const text = buildPlanTextSummary(makePlan({ nodes: [makeNode({ warnings: [] })] }));
+        assert.ok(!text.includes('⚠'));
+    });
+
+    test('a plan with no nodes says so plainly instead of an empty operator list', () => {
+        const text = buildPlanTextSummary(makePlan({ nodes: [] }));
+        assert.ok(text.includes('This statement produced no profiled operators.'));
+    });
+});

--- a/src/test/unit/planTextExport.test.ts
+++ b/src/test/unit/planTextExport.test.ts
@@ -55,14 +55,14 @@ suite('buildPlanTextSummary', () => {
 
     test('reports "not available" for node count when no per-node stats exist anywhere', () => {
         const text = buildPlanTextSummary(makePlan());
-        assert.ok(text.includes('Nodes: not available'));
+        assert.ok(text.includes('Nodes observed: not available'));
     });
 
     test('shows the max observed node count when per-node stats exist', () => {
         const text = buildPlanTextSummary(makePlan({
             nodes: [makeNode({ perNodeStats: { metric: 'rows', min: 1, max: 10, avg: 5, nodeCount: 8 } })]
         }));
-        assert.ok(text.includes('Nodes: 8'));
+        assert.ok(text.includes('Nodes observed: 8'));
     });
 
     test('numbers each operator in plan order and tags it with its PART_ID, one block per node', () => {

--- a/src/test/unit/planWarnings.test.ts
+++ b/src/test/unit/planWarnings.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import { computeWarnings, DEFAULT_WARNING_THRESHOLDS } from '../../plan/planWarnings';
+import { OperatorTraits } from '../../plan/planModel';
+
+const JOIN_TRAITS: OperatorTraits = {
+    producesRows: true, consumesRows: true, canSpill: true,
+    movesDataOverNetwork: true, blocking: true, isSystemStep: false
+};
+
+const SCAN_TRAITS: OperatorTraits = {
+    producesRows: true, consumesRows: false, canSpill: false,
+    movesDataOverNetwork: false, blocking: false, isSystemStep: false
+};
+
+suite('computeWarnings', () => {
+
+    suite('SPILLED_TO_DISK', () => {
+        test('fires when a spill-capable operator has nonzero HDD_WRITE', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: 12.5, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            assert.strictEqual(warnings.length, 1);
+            assert.strictEqual(warnings[0].type, 'SPILLED_TO_DISK');
+            assert.strictEqual(warnings[0].detail.hddWriteMiB, 12.5);
+        });
+
+        test('does not fire when HDD_WRITE is zero', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: 0, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire when HDD_WRITE is undefined (metric not reported)', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire on an operator that cannot spill even with nonzero HDD_WRITE', () => {
+            const warnings = computeWarnings({ traits: SCAN_TRAITS, hddWrite: 5, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            assert.strictEqual(warnings.length, 0);
+        });
+    });
+
+    suite('LARGE_REDISTRIBUTION', () => {
+        test('fires when a network-capable operator both moved data and dominates the query\'s time', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, costPercent: 25 });
+            assert.strictEqual(warnings.length, 1);
+            assert.strictEqual(warnings[0].type, 'LARGE_REDISTRIBUTION');
+            assert.strictEqual(warnings[0].detail.netMiB, 500);
+            assert.strictEqual(warnings[0].detail.costPercent, 25);
+        });
+
+        test('the message shows one decimal place, so a cost share just over the threshold reads as distinct from it', () => {
+            // Regression test: with toFixed(0), costPercent=20.4 against the
+            // default 20% threshold rendered as "20% ... threshold 20%" —
+            // identical numbers, reading as if the warning fired for no
+            // reason. One decimal place makes the real margin visible.
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 12.34, perNodeStats: undefined, costPercent: 20.4 });
+            assert.strictEqual(warnings.length, 1);
+            assert.ok(warnings[0].message.includes('20.4%'), `expected the exact cost share in the message, got: ${warnings[0].message}`);
+            assert.ok(!warnings[0].message.includes('20% of'), 'must not round costPercent down to match the threshold display');
+        });
+
+        test('does not fire when the operator\'s cost share is below the threshold, regardless of NET size', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, costPercent: 5 });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire when NET is zero even if the operator dominates query time', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 0, perNodeStats: undefined, costPercent: 90 });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire when costPercent is undefined (totalDuration was 0), even with large NET', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, costPercent: undefined });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire on an operator that never moves data over the network, no matter its cost share', () => {
+            const warnings = computeWarnings({ traits: SCAN_TRAITS, hddWrite: undefined, net: 999, perNodeStats: undefined, costPercent: 90 });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('respects a custom threshold', () => {
+            const warnings = computeWarnings(
+                { traits: JOIN_TRAITS, hddWrite: undefined, net: 50, perNodeStats: undefined, costPercent: 12 },
+                { ...DEFAULT_WARNING_THRESHOLDS, redistributionCostSharePercent: 10 }
+            );
+            assert.strictEqual(warnings.length, 1);
+        });
+    });
+
+    suite('HIGH_SKEW', () => {
+        test('fires when max deviates from avg beyond the skew ratio', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined,
+                perNodeStats: { metric: 'rows', min: 10, max: 1000, avg: 300, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 1);
+            assert.strictEqual(warnings[0].type, 'HIGH_SKEW');
+        });
+
+        test('does not fire when nodes are evenly balanced', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined,
+                perNodeStats: { metric: 'rows', min: 95, max: 105, avg: 100, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('never fires when perNodeStats is undefined, no matter how skewed the (unmeasured) data might be', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire for a single-node cluster even with a nonzero ratio', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined,
+                perNodeStats: { metric: 'rows', min: 100, max: 100, avg: 100, nodeCount: 1 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+    });
+
+    suite('ROW_ESTIMATE_MISMATCH', () => {
+        test('never fires in v1 — no estimated-rows input exists to compare against', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: 100, net: 500, costPercent: 50,
+                perNodeStats: { metric: 'rows', min: 1, max: 1000, avg: 100, nodeCount: 4 }
+            });
+            assert.ok(!warnings.some(w => w.type === 'ROW_ESTIMATE_MISMATCH'));
+        });
+    });
+
+    suite('multiple warnings on one node', () => {
+        test('an operator can accumulate more than one warning at once', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: 50, net: 500, costPercent: 50,
+                perNodeStats: { metric: 'rows', min: 1, max: 1000, avg: 100, nodeCount: 4 }
+            });
+            const types = warnings.map(w => w.type).sort();
+            assert.deepStrictEqual(types, ['HIGH_SKEW', 'LARGE_REDISTRIBUTION', 'SPILLED_TO_DISK']);
+        });
+    });
+});

--- a/src/test/unit/planWarnings.test.ts
+++ b/src/test/unit/planWarnings.test.ts
@@ -12,35 +12,45 @@ const SCAN_TRAITS: OperatorTraits = {
     movesDataOverNetwork: false, blocking: false, isSystemStep: false
 };
 
+const SYNC_TRAITS: OperatorTraits = {
+    producesRows: false, consumesRows: false, canSpill: false,
+    movesDataOverNetwork: false, blocking: true, isSystemStep: false
+};
+
+const SYSTEM_TRAITS: OperatorTraits = {
+    producesRows: false, consumesRows: false, canSpill: false,
+    movesDataOverNetwork: false, blocking: false, isSystemStep: true
+};
+
 suite('computeWarnings', () => {
 
     suite('SPILLED_TO_DISK', () => {
         test('fires when a spill-capable operator has nonzero HDD_WRITE', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: 12.5, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: 12.5, net: undefined, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: undefined });
             assert.strictEqual(warnings.length, 1);
             assert.strictEqual(warnings[0].type, 'SPILLED_TO_DISK');
             assert.strictEqual(warnings[0].detail.hddWriteMiB, 12.5);
         });
 
         test('does not fire when HDD_WRITE is zero', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: 0, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: 0, net: undefined, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: undefined });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('does not fire when HDD_WRITE is undefined (metric not reported)', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: undefined });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('does not fire on an operator that cannot spill even with nonzero HDD_WRITE', () => {
-            const warnings = computeWarnings({ traits: SCAN_TRAITS, hddWrite: 5, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            const warnings = computeWarnings({ traits: SCAN_TRAITS, hddWrite: 5, net: undefined, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: undefined });
             assert.strictEqual(warnings.length, 0);
         });
     });
 
     suite('LARGE_REDISTRIBUTION', () => {
         test('fires when a network-capable operator both moved data and dominates the query\'s time', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, costPercent: 25 });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: 25 });
             assert.strictEqual(warnings.length, 1);
             assert.strictEqual(warnings[0].type, 'LARGE_REDISTRIBUTION');
             assert.strictEqual(warnings[0].detail.netMiB, 500);
@@ -52,35 +62,35 @@ suite('computeWarnings', () => {
             // default 20% threshold rendered as "20% ... threshold 20%" —
             // identical numbers, reading as if the warning fired for no
             // reason. One decimal place makes the real margin visible.
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 12.34, perNodeStats: undefined, costPercent: 20.4 });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 12.34, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: 20.4 });
             assert.strictEqual(warnings.length, 1);
             assert.ok(warnings[0].message.includes('20.4%'), `expected the exact cost share in the message, got: ${warnings[0].message}`);
             assert.ok(!warnings[0].message.includes('20% of'), 'must not round costPercent down to match the threshold display');
         });
 
         test('does not fire when the operator\'s cost share is below the threshold, regardless of NET size', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, costPercent: 5 });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: 5 });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('does not fire when NET is zero even if the operator dominates query time', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 0, perNodeStats: undefined, costPercent: 90 });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 0, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: 90 });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('does not fire when costPercent is undefined (totalDuration was 0), even with large NET', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, costPercent: undefined });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: 500, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: undefined });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('does not fire on an operator that never moves data over the network, no matter its cost share', () => {
-            const warnings = computeWarnings({ traits: SCAN_TRAITS, hddWrite: undefined, net: 999, perNodeStats: undefined, costPercent: 90 });
+            const warnings = computeWarnings({ traits: SCAN_TRAITS, hddWrite: undefined, net: 999, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: 90 });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('respects a custom threshold', () => {
             const warnings = computeWarnings(
-                { traits: JOIN_TRAITS, hddWrite: undefined, net: 50, perNodeStats: undefined, costPercent: 12 },
+                { traits: JOIN_TRAITS, hddWrite: undefined, net: 50, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: 12 },
                 { ...DEFAULT_WARNING_THRESHOLDS, redistributionCostSharePercent: 10 }
             );
             assert.strictEqual(warnings.length, 1);
@@ -88,10 +98,10 @@ suite('computeWarnings', () => {
     });
 
     suite('HIGH_SKEW', () => {
-        test('fires when max deviates from avg beyond the skew ratio', () => {
+        test('fires when max deviates from avg beyond the skew ratio, above the row-count noise floor', () => {
             const warnings = computeWarnings({
-                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined,
-                perNodeStats: { metric: 'rows', min: 10, max: 1000, avg: 300, nodeCount: 4 }
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeDurationStats: undefined,
+                perNodeStats: { metric: 'rows', min: 10, max: 5000, avg: 2505, nodeCount: 4 }
             });
             assert.strictEqual(warnings.length, 1);
             assert.strictEqual(warnings[0].type, 'HIGH_SKEW');
@@ -99,23 +109,153 @@ suite('computeWarnings', () => {
 
         test('does not fire when nodes are evenly balanced', () => {
             const warnings = computeWarnings({
-                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined,
-                perNodeStats: { metric: 'rows', min: 95, max: 105, avg: 100, nodeCount: 4 }
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeDurationStats: undefined,
+                perNodeStats: { metric: 'rows', min: 9500, max: 10500, avg: 10000, nodeCount: 4 }
             });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('never fires when perNodeStats is undefined, no matter how skewed the (unmeasured) data might be', () => {
-            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, perNodeStats: undefined, costPercent: undefined });
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, perNodeStats: undefined, perNodeDurationStats: undefined, costPercent: undefined });
             assert.strictEqual(warnings.length, 0);
         });
 
         test('does not fire for a single-node cluster even with a nonzero ratio', () => {
             const warnings = computeWarnings({
-                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined,
-                perNodeStats: { metric: 'rows', min: 100, max: 100, avg: 100, nodeCount: 1 }
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeDurationStats: undefined,
+                perNodeStats: { metric: 'rows', min: 100000, max: 100000, avg: 100000, nodeCount: 1 }
             });
             assert.strictEqual(warnings.length, 0);
+        });
+
+        suite('skewMinRows noise floor (finding 1)', () => {
+            // Live data: median part outputs 1 row, 38.6% under 10 — a
+            // skewed-but-tiny row count (e.g. "0-1 rows across 4 nodes") is
+            // statistically meaningless, not a real signal, and used to fire
+            // just as loudly as a genuine multi-million-row skew.
+            test('a skewed max just under the floor (999) stays silent', () => {
+                const warnings = computeWarnings({
+                    traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeDurationStats: undefined,
+                    perNodeStats: { metric: 'rows', min: 0, max: 999, avg: 100, nodeCount: 4 }
+                });
+                assert.strictEqual(warnings.length, 0, 'a max of 999 rows is below the default 1000-row floor and must not fire');
+            });
+
+            test('a skewed max exactly at the floor (1000) is eligible to fire', () => {
+                const warnings = computeWarnings({
+                    traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeDurationStats: undefined,
+                    perNodeStats: { metric: 'rows', min: 0, max: 1000, avg: 100, nodeCount: 4 }
+                });
+                assert.strictEqual(warnings.length, 1, 'a max of exactly 1000 rows meets the default floor and, with this skew ratio, must fire');
+            });
+
+            test('respects a custom skewMinRows threshold', () => {
+                const warnings = computeWarnings(
+                    {
+                        traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeDurationStats: undefined,
+                        perNodeStats: { metric: 'rows', min: 0, max: 50, avg: 10, nodeCount: 4 }
+                    },
+                    { ...DEFAULT_WARNING_THRESHOLDS, skewMinRows: 10 }
+                );
+                assert.strictEqual(warnings.length, 1, 'a lowered floor of 10 rows must let a max of 50 fire');
+            });
+        });
+    });
+
+    suite('HIGH_DURATION_SKEW', () => {
+        test('fires on a blocking, non-system operator whose slowest node badly exceeds the average', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 1);
+            assert.strictEqual(warnings[0].type, 'HIGH_DURATION_SKEW');
+            assert.ok(warnings[0].message.includes('2000ms'), `expected the slowest node's ms in the message, got: ${warnings[0].message}`);
+            assert.ok(warnings[0].message.includes('500ms'), `expected the average ms in the message, got: ${warnings[0].message}`);
+            assert.ok(warnings[0].message.includes('4 nodes'));
+        });
+
+        test('does not fire on a non-blocking operator (e.g. SCAN), even with a large duration spread', () => {
+            const warnings = computeWarnings({
+                traits: SCAN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire on a system step, even one flagged blocking', () => {
+            const warnings = computeWarnings({
+                traits: { ...SYSTEM_TRAITS, blocking: true }, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire on a SYNC-shaped operator (blocking, not a system step, but produces/consumes nothing) — its spread just mirrors upstream skew already warned on elsewhere', () => {
+            const warnings = computeWarnings({
+                traits: SYNC_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('fires on a JOIN-shaped operator (blocking, non-system, real data-flow) with the same skew', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 1);
+            assert.strictEqual(warnings[0].type, 'HIGH_DURATION_SKEW');
+        });
+
+        test('does not fire when perNodeDurationStats is undefined', () => {
+            const warnings = computeWarnings({ traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined, perNodeDurationStats: undefined });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire for a single-node cluster', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 1, max: 1, avg: 1, nodeCount: 1 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        test('does not fire when nodes are evenly balanced', () => {
+            const warnings = computeWarnings({
+                traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                perNodeDurationStats: { metric: 'duration', min: 0.95, max: 1.05, avg: 1, nodeCount: 4 }
+            });
+            assert.strictEqual(warnings.length, 0);
+        });
+
+        suite('durationSkewMinSeconds noise floor', () => {
+            test('a skewed-but-trivial spread under the 50ms floor stays silent', () => {
+                const warnings = computeWarnings({
+                    traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                    perNodeDurationStats: { metric: 'duration', min: 0.001, max: 0.04, avg: 0.01, nodeCount: 4 }
+                });
+                assert.strictEqual(warnings.length, 0, 'the slowest node (40ms) is below the default 50ms floor');
+            });
+
+            test('a spread at exactly the 50ms floor is eligible to fire', () => {
+                const warnings = computeWarnings({
+                    traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                    perNodeDurationStats: { metric: 'duration', min: 0.001, max: 0.05, avg: 0.01, nodeCount: 4 }
+                });
+                assert.strictEqual(warnings.length, 1);
+            });
+
+            test('respects a custom durationSkewMinSeconds threshold', () => {
+                const warnings = computeWarnings(
+                    {
+                        traits: JOIN_TRAITS, hddWrite: undefined, net: undefined, costPercent: undefined, perNodeStats: undefined,
+                        perNodeDurationStats: { metric: 'duration', min: 0.001, max: 0.02, avg: 0.005, nodeCount: 4 }
+                    },
+                    { ...DEFAULT_WARNING_THRESHOLDS, durationSkewMinSeconds: 0.01 }
+                );
+                assert.strictEqual(warnings.length, 1, 'a lowered floor of 10ms must let a 20ms slowest node fire');
+            });
         });
     });
 
@@ -123,7 +263,8 @@ suite('computeWarnings', () => {
         test('never fires in v1 — no estimated-rows input exists to compare against', () => {
             const warnings = computeWarnings({
                 traits: JOIN_TRAITS, hddWrite: 100, net: 500, costPercent: 50,
-                perNodeStats: { metric: 'rows', min: 1, max: 1000, avg: 100, nodeCount: 4 }
+                perNodeStats: { metric: 'rows', min: 1, max: 5000, avg: 1000, nodeCount: 4 },
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
             });
             assert.ok(!warnings.some(w => w.type === 'ROW_ESTIMATE_MISMATCH'));
         });
@@ -133,10 +274,11 @@ suite('computeWarnings', () => {
         test('an operator can accumulate more than one warning at once', () => {
             const warnings = computeWarnings({
                 traits: JOIN_TRAITS, hddWrite: 50, net: 500, costPercent: 50,
-                perNodeStats: { metric: 'rows', min: 1, max: 1000, avg: 100, nodeCount: 4 }
+                perNodeStats: { metric: 'rows', min: 1, max: 5000, avg: 1000, nodeCount: 4 },
+                perNodeDurationStats: { metric: 'duration', min: 0.05, max: 2, avg: 0.5, nodeCount: 4 }
             });
             const types = warnings.map(w => w.type).sort();
-            assert.deepStrictEqual(types, ['HIGH_SKEW', 'LARGE_REDISTRIBUTION', 'SPILLED_TO_DISK']);
+            assert.deepStrictEqual(types, ['HIGH_DURATION_SKEW', 'HIGH_SKEW', 'LARGE_REDISTRIBUTION', 'SPILLED_TO_DISK']);
         });
     });
 });

--- a/src/test/unit/profileRowNormalizer.test.ts
+++ b/src/test/unit/profileRowNormalizer.test.ts
@@ -162,6 +162,179 @@ suite('normalizeProfileRows', () => {
         });
     });
 
+    suite('per-node duration stats (finding 4)', () => {
+        test('builds a duration PerNodeStat alongside the rows one, from real per-IPROC DURATION values', () => {
+            const rows = [
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 0, DURATION: 1, OUT_ROWS: 100 }),
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 1, DURATION: 9, OUT_ROWS: 100 }),
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 2, DURATION: 2, OUT_ROWS: 100 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.deepStrictEqual(
+                plan.nodes[0].perNodeDurationStats,
+                { metric: 'duration', min: 1, max: 9, avg: 4, nodeCount: 3 }
+            );
+        });
+
+        test('is undefined when source rows carry no IPROC (summary views)', () => {
+            const plan = normalizeProfileRows(
+                [row({ PART_ID: 1, PART_NAME: 'JOIN', DURATION: 1 })],
+                { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' }
+            );
+            assert.strictEqual(plan.nodes[0].perNodeDurationStats, undefined);
+        });
+
+        test('is computed independently of perNodeStats — present even when OUT_ROWS is missing entirely', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 0, DURATION: 0.1, OUT_ROWS: undefined }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 1, DURATION: 0.3, OUT_ROWS: undefined })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.strictEqual(plan.nodes[0].perNodeStats, undefined, 'precondition: no OUT_ROWS anywhere in the group');
+            assert.deepStrictEqual(
+                plan.nodes[0].perNodeDurationStats,
+                { metric: 'duration', min: 0.1, max: 0.3, avg: 0.2, nodeCount: 2 }
+            );
+        });
+
+        test('never fabricates perNodeDurationStats for a node whose rows lack DURATION entirely', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 0, DURATION: undefined }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 1, DURATION: undefined })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.strictEqual(plan.nodes[0].perNodeDurationStats, undefined);
+        });
+    });
+
+    suite('OBJECT_ROWS / scan selectivity (finding 3)', () => {
+        test('carries OBJECT_ROWS through onto the node, alongside OUT_ROWS', () => {
+            const rows = [row({ PART_ID: 1, PART_NAME: 'SCAN', OBJECT_ROWS: 10000, OUT_ROWS: 250 })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.nodes[0].objectRows, 10000);
+            assert.strictEqual(plan.nodes[0].rowsOut, 250);
+        });
+
+        test('collapses OBJECT_ROWS as a SUM across per-node rows, same as OUT_ROWS — not a max', () => {
+            // In the per-IPROC details tier, OBJECT_ROWS is the node-local
+            // shard row count (verified live: a 176,792-row temp table
+            // reported OBJECT_ROWS 44,632 per node across 4 nodes), the same
+            // per-node scale as OUT_ROWS. A prior max-vs-sum mismatch here
+            // mixed a per-node scale with a cluster scale and could render
+            // selectivity over 100% (real screenshot: "1,594 rows -> 6,314
+            // (396.1%)"). This fixture mirrors that shape: 4 nodes each
+            // reporting OBJECT_ROWS 1594, OUT_ROWS summing to 6314.
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 0, OBJECT_ROWS: 1594, OUT_ROWS: 1594 }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 1, OBJECT_ROWS: 1594, OUT_ROWS: 1594 }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 2, OBJECT_ROWS: 1594, OUT_ROWS: 1594 }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 3, OBJECT_ROWS: 1594, OUT_ROWS: 1532 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            const node = plan.nodes[0];
+            assert.strictEqual(node.objectRows, 6376, '4 * 1594 summed, not maxed to 1594');
+            assert.strictEqual(node.rowsOut, 6314);
+            const selectivity = (node.rowsOut! / node.objectRows!) * 100;
+            assert.ok(selectivity < 100, `selectivity must not exceed 100%, got ${selectivity}`);
+            assert.ok(Math.abs(selectivity - 99.03) < 0.01, `expected ~99%, got ${selectivity}`);
+        });
+
+        test('is undefined when OBJECT_ROWS was not reported', () => {
+            const plan = normalizeProfileRows(
+                [row({ PART_ID: 1, PART_NAME: 'JOIN', OBJECT_ROWS: undefined })],
+                { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' }
+            );
+            assert.strictEqual(plan.nodes[0].objectRows, undefined);
+        });
+    });
+
+    suite('HDD_READ (finding 7)', () => {
+        test('carries HDD_READ through onto the node', () => {
+            const rows = [row({ PART_ID: 1, PART_NAME: 'SCAN', HDD_READ: 3.2 })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.nodes[0].hddRead, 3.2);
+        });
+
+        test('collapses HDD_READ as a max across per-node rows — it is a rate (MiB/s), not a volume, so summing would not mean anything', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 0, HDD_READ: 1.5 }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 1, HDD_READ: 4.2 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.strictEqual(plan.nodes[0].hddRead, 4.2);
+        });
+
+        test('is undefined when HDD_READ was not reported', () => {
+            const plan = normalizeProfileRows(
+                [row({ PART_ID: 1, PART_NAME: 'SCAN', HDD_READ: undefined })],
+                { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' }
+            );
+            assert.strictEqual(plan.nodes[0].hddRead, undefined);
+        });
+    });
+
+    suite('cost-share denominator excludes system steps (finding 2)', () => {
+        test('a non-system node\'s costPercent divides by total duration minus system-step duration', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'COMPILE / EXECUTE', DURATION: 36 }),
+                row({ PART_ID: 2, PART_NAME: 'SCAN', DURATION: 32 }),
+                row({ PART_ID: 3, PART_NAME: 'JOIN', DURATION: 32 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+
+            assert.strictEqual(plan.totalDuration, 100, 'Plan.totalDuration stays wall-time-true over every node');
+
+            const compile = plan.nodes.find(n => n.id === '1')!;
+            const scan = plan.nodes.find(n => n.id === '2')!;
+            const join = plan.nodes.find(n => n.id === '3')!;
+
+            // System step: share of the WHOLE plan (36 / 100).
+            assert.strictEqual(compile.costPercent, 36);
+            // Non-system: share of total minus the system-step duration
+            // (32 / (100 - 36) = 32 / 64 = 50), not deflated by COMPILE.
+            assert.strictEqual(scan.costPercent, 50);
+            assert.strictEqual(join.costPercent, 50);
+        });
+
+        test('with no system steps present, the non-system denominator equals totalDuration (unaffected by this change)', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'SCAN', DURATION: 2 }),
+                row({ PART_ID: 2, PART_NAME: 'JOIN', DURATION: 3 }),
+                row({ PART_ID: 3, PART_NAME: 'GROUP BY', DURATION: 5 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.nodes[0].costPercent, 20);
+            assert.strictEqual(plan.nodes[1].costPercent, 30);
+            assert.strictEqual(plan.nodes[2].costPercent, 50);
+        });
+
+        test('a non-system node\'s costPercent is undefined (not NaN/Infinity) when every duration is a system step', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'COMPILE / EXECUTE', DURATION: 10 }),
+                row({ PART_ID: 2, PART_NAME: 'SCAN', DURATION: undefined })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            const scan = plan.nodes.find(n => n.id === '2')!;
+            assert.strictEqual(scan.duration, undefined);
+            assert.strictEqual(scan.costPercent, undefined);
+        });
+
+        test('NODE SYNC stays inside the non-system denominator rather than being excluded like COMPILE/EXECUTE', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'COMPILE / EXECUTE', DURATION: 10 }),
+                row({ PART_ID: 2, PART_NAME: 'NODE SYNC', DURATION: 45 }),
+                row({ PART_ID: 3, PART_NAME: 'SCAN', DURATION: 45 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            const sync = plan.nodes.find(n => n.id === '2')!;
+            const scan = plan.nodes.find(n => n.id === '3')!;
+            // Non-system denominator is 45 + 45 = 90 (COMPILE's 10 excluded);
+            // NODE SYNC and SCAN split it evenly at 50% each.
+            assert.strictEqual(sync.costPercent, 50);
+            assert.strictEqual(scan.costPercent, 50);
+        });
+    });
+
     suite('warnings integration', () => {
         test('a JOIN node with nonzero HDD_WRITE surfaces a SPILLED_TO_DISK warning', () => {
             const rows = [row({ PART_ID: 1, PART_NAME: 'JOIN', HDD_WRITE: 42 })];

--- a/src/test/unit/profileRowNormalizer.test.ts
+++ b/src/test/unit/profileRowNormalizer.test.ts
@@ -1,0 +1,203 @@
+import * as assert from 'assert';
+import { normalizeProfileRows } from '../../plan/profileRowNormalizer';
+
+/**
+ * Builds one raw driver row using the real EXA_*_PROFILE_* /
+ * $EXA_PROFILE_DETAILS_LAST_DAY column names verified live against an
+ * Exasol 2026.1.0 instance during Step 0 research. Numeric values below are
+ * simplified for assertion clarity, not copied verbatim from that session.
+ */
+function row(overrides: Record<string, unknown>): Record<string, unknown> {
+    return {
+        SESSION_ID: 1,
+        STMT_ID: 5,
+        PART_ID: 1,
+        PART_NAME: 'SCAN',
+        ...overrides
+    };
+}
+
+suite('normalizeProfileRows', () => {
+
+    suite('basic shape', () => {
+        test('produces one node per PART_ID, ordered by PART_ID', () => {
+            const rows = [
+                row({ PART_ID: 3, PART_NAME: 'GROUP BY', DURATION: 5 }),
+                row({ PART_ID: 1, PART_NAME: 'SCAN', DURATION: 2 }),
+                row({ PART_ID: 2, PART_NAME: 'JOIN', DURATION: 3 })
+            ];
+
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+
+            assert.strictEqual(plan.nodes.length, 3);
+            assert.deepStrictEqual(plan.nodes.map(n => n.id), ['1', '2', '3']);
+            assert.deepStrictEqual(plan.nodes.map(n => n.operatorType), ['SCAN', 'JOIN', 'GROUP_BY']);
+        });
+
+        test('computes costPercent as each node\'s share of total duration', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'SCAN', DURATION: 2 }),
+                row({ PART_ID: 2, PART_NAME: 'JOIN', DURATION: 3 }),
+                row({ PART_ID: 3, PART_NAME: 'GROUP BY', DURATION: 5 })
+            ];
+
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+
+            assert.strictEqual(plan.totalDuration, 10);
+            assert.strictEqual(plan.nodes[0].costPercent, 20);
+            assert.strictEqual(plan.nodes[1].costPercent, 30);
+            assert.strictEqual(plan.nodes[2].costPercent, 50);
+        });
+
+        test('costPercent is undefined rather than NaN when total duration is zero', () => {
+            const rows = [row({ PART_ID: 1, PART_NAME: 'COMMIT', DURATION: 0 })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.nodes[0].costPercent, undefined);
+        });
+
+        test('ignores rows belonging to a different session or statement', () => {
+            const rows = [
+                row({ PART_ID: 1, SESSION_ID: 1, STMT_ID: 5 }),
+                row({ PART_ID: 2, SESSION_ID: 1, STMT_ID: 999 }),
+                row({ PART_ID: 3, SESSION_ID: 999, STMT_ID: 5 })
+            ];
+
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+
+            assert.strictEqual(plan.nodes.length, 1);
+            assert.strictEqual(plan.nodes[0].id, '1');
+        });
+
+        test('extracts queryText from whichever row carries SQL_TEXT', () => {
+            const rows = [
+                row({ PART_ID: 1, SQL_TEXT: undefined }),
+                row({ PART_ID: 2, SQL_TEXT: 'SELECT 1' })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.queryText, 'SELECT 1');
+        });
+
+        test('passes the source through unchanged', () => {
+            const plan = normalizeProfileRows(
+                [row({ PART_ID: 1 })],
+                { sessionId: '1', stmtId: '5', source: 'DBA_SUMMARY' }
+            );
+            assert.strictEqual(plan.source, 'DBA_SUMMARY');
+        });
+
+        test('edges is always empty in v1 — no parent/child column exists in these views', () => {
+            const plan = normalizeProfileRows([row({ PART_ID: 1 })], { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.deepStrictEqual(plan.edges, []);
+            assert.deepStrictEqual(plan.nodes[0].children, []);
+        });
+    });
+
+    suite('per-node stats ($EXA_PROFILE_DETAILS_LAST_DAY rows, carrying IPROC)', () => {
+        test('is undefined when source rows carry no IPROC (summary views)', () => {
+            const plan = normalizeProfileRows(
+                [row({ PART_ID: 1, PART_NAME: 'JOIN', OUT_ROWS: 1000 })],
+                { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' }
+            );
+            assert.strictEqual(plan.nodes[0].perNodeStats, undefined);
+            assert.strictEqual(plan.perNodeStatsAvailable, false);
+        });
+
+        test('collapses multiple IPROC rows for one PART_ID into a single node with real min/max/avg', () => {
+            const rows = [
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 0, OUT_ROWS: 100 }),
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 1, OUT_ROWS: 900 }),
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 2, OUT_ROWS: 200 })
+            ];
+
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+
+            assert.strictEqual(plan.nodes.length, 1, 'the three per-node rows collapse into one operator node');
+            const node = plan.nodes[0];
+            assert.strictEqual(node.rowsOut, 1200, 'rowsOut is the sum across nodes');
+            assert.deepStrictEqual(node.perNodeStats, { metric: 'rows', min: 100, max: 900, avg: 400, nodeCount: 3 });
+            assert.strictEqual(plan.perNodeStatsAvailable, true);
+        });
+
+        test('duration collapses as the max across nodes (operator finishes when its slowest node does)', () => {
+            const rows = [
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 0, DURATION: 1.5, OUT_ROWS: 100 }),
+                row({ PART_ID: 6, PART_NAME: 'PIPE JOIN', IPROC: 1, DURATION: 4.2, OUT_ROWS: 100 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.strictEqual(plan.nodes[0].duration, 4.2);
+        });
+
+        test('a single-node cluster still yields a (trivial) perNodeStats rather than undefined', () => {
+            // Matches what was actually observed against the live single-node
+            // exasol-db test container: IPROC = 0 for every row.
+            const rows = [row({ PART_ID: 1, PART_NAME: 'PIPE SCAN', IPROC: 0, OUT_ROWS: 1000 })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.deepStrictEqual(plan.nodes[0].perNodeStats, { metric: 'rows', min: 1000, max: 1000, avg: 1000, nodeCount: 1 });
+        });
+
+        test('never fabricates perNodeStats for a node whose rows lack OUT_ROWS entirely', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 0, OUT_ROWS: undefined }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 1, OUT_ROWS: undefined })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.strictEqual(plan.nodes[0].perNodeStats, undefined);
+        });
+
+        test('when OUT_ROWS is only partially reported across a group, nodeCount matches the population min/max/avg were actually computed from', () => {
+            // Regression test: nodeCount used to be rows.length (every IPROC
+            // row, including ones with an undefined OUT_ROWS), while
+            // min/max/avg were computed only from the rows that actually had
+            // a defined OUT_ROWS — an internally-inconsistent stat (e.g. an
+            // avg over 2 real values mislabeled as spanning 3 nodes), which
+            // also understates the true skew ratio if the missing node was
+            // actually the outlier.
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 0, OUT_ROWS: 100 }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 1, OUT_ROWS: undefined }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 2, OUT_ROWS: 900 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.deepStrictEqual(plan.nodes[0].perNodeStats, { metric: 'rows', min: 100, max: 900, avg: 500, nodeCount: 2 });
+        });
+    });
+
+    suite('warnings integration', () => {
+        test('a JOIN node with nonzero HDD_WRITE surfaces a SPILLED_TO_DISK warning', () => {
+            const rows = [row({ PART_ID: 1, PART_NAME: 'JOIN', HDD_WRITE: 42 })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.ok(plan.nodes[0].warnings.some(w => w.type === 'SPILLED_TO_DISK'));
+        });
+
+        test('a plain SCAN with no spill/network/skew signal has no warnings', () => {
+            const rows = [row({ PART_ID: 1, PART_NAME: 'SCAN', OUT_ROWS: 1000, DURATION: 0.01 })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.nodes[0].warnings.length, 0);
+        });
+
+        test('skewed per-node rows on a JOIN surface a HIGH_SKEW warning', () => {
+            const rows = [
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 0, OUT_ROWS: 10 }),
+                row({ PART_ID: 1, PART_NAME: 'PIPE JOIN', IPROC: 1, OUT_ROWS: 5000 })
+            ];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'DETAILS' });
+            assert.ok(plan.nodes[0].warnings.some(w => w.type === 'HIGH_SKEW'));
+        });
+    });
+
+    suite('numeric tolerance', () => {
+        test('tolerates numeric columns arriving as strings (as some driver paths return decimals)', () => {
+            const rows = [row({ PART_ID: 1, PART_NAME: 'SCAN', DURATION: '1.500', OUT_ROWS: '2000' })];
+            const plan = normalizeProfileRows(rows, { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.strictEqual(plan.nodes[0].duration, 1.5);
+            assert.strictEqual(plan.nodes[0].rowsOut, 2000);
+        });
+
+        test('an empty row set produces an empty, valid plan rather than throwing', () => {
+            const plan = normalizeProfileRows([], { sessionId: '1', stmtId: '5', source: 'USER_SUMMARY' });
+            assert.deepStrictEqual(plan.nodes, []);
+            assert.strictEqual(plan.totalDuration, 0);
+            assert.strictEqual(plan.perNodeStatsAvailable, false);
+        });
+    });
+});

--- a/src/test/unit/queryExecutorRouting.test.ts
+++ b/src/test/unit/queryExecutorRouting.test.ts
@@ -1,9 +1,18 @@
 import * as assert from 'assert';
-import { registerVscodeMock, vscodeMock } from '../helpers/vscodeMock';
+import { registerVscodeMock, registerExtensionMock, vscodeMock } from '../helpers/vscodeMock';
 
 // QueryExecutor reads exasol config (maxResultRows, queryTimeout) at execute()
 // time; the per-test setup() below installs the config getter it needs.
+// registerExtensionMock() is also required here (not just registerVscodeMock):
+// queryExecutor.ts imports ./extension, which imports completionProvider.ts,
+// whose static initializer touches vscode fields the minimal vscodeMock alone
+// doesn't provide. Without this, the file crashes at load time when run on
+// its own — it was previously only passing because another test file loaded
+// earlier in the shared mocha process had already populated require.cache
+// for ./extension, which is not something this file's own setup should rely
+// on (confirmed by running `mocha ... queryExecutorRouting.test.ts` alone).
 registerVscodeMock();
+registerExtensionMock();
 
 // Load after the vscode mock is configured.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -62,7 +71,7 @@ suite('QueryExecutor.execute routing: local CSV import interception', () => {
         };
     });
 
-    test('a LOCAL CSV import calls importFromCsvFile and bypasses raw execute/query', async () => {
+    test('a LOCAL CSV import calls importFromCsvFile, bypasses raw execute(), but still captures plan identity', async () => {
         const { qe, calls } = makeExecutor();
 
         const result = await qe.execute("IMPORT INTO t FROM LOCAL CSV FILE '/abs/x.csv'");
@@ -73,7 +82,13 @@ suite('QueryExecutor.execute routing: local CSV import interception', () => {
         assert.strictEqual(absPath, '/abs/x.csv');
 
         assert.strictEqual(calls.execute.length, 0, 'must not hit raw execute()');
-        assert.strictEqual(calls.query.length, 0, 'must not hit raw query()');
+        // The one query() call is the baseline SESSION_ID/STMT_ID capture
+        // (captureBaselineStatementIdentity) — a local CSV import is still a
+        // real IMPORT statement from Exasol's own perspective and still gets
+        // profiled, so this path captures the same plan-lookup identity as
+        // every other statement type, not a second attempt at the import.
+        assert.strictEqual(calls.query.length, 1);
+        assert.ok(calls.query[0][0].includes('CURRENT_SESSION'));
 
         assert.strictEqual(result.rowCount, 42);
     });
@@ -86,6 +101,9 @@ suite('QueryExecutor.execute routing: local CSV import interception', () => {
         assert.strictEqual(calls.importFromCsvFile.length, 0, 'must not intercept a cloud import');
         // IMPORT is classified as a non-result-set command, so it routes to execute().
         assert.strictEqual(calls.execute.length, 1, 'cloud import should go through raw execute()');
-        assert.strictEqual(calls.query.length, 0);
+        // The one query() call is the post-execution SESSION_ID/STMT_ID capture
+        // (captureStatementIdentity), not a second attempt at the import itself.
+        assert.strictEqual(calls.query.length, 1);
+        assert.ok(calls.query[0][0].includes('CURRENT_SESSION'));
     });
 });

--- a/src/test/unit/queryExecutorRouting.test.ts
+++ b/src/test/unit/queryExecutorRouting.test.ts
@@ -101,8 +101,8 @@ suite('QueryExecutor.execute routing: local CSV import interception', () => {
         assert.strictEqual(calls.importFromCsvFile.length, 0, 'must not intercept a cloud import');
         // IMPORT is classified as a non-result-set command, so it routes to execute().
         assert.strictEqual(calls.execute.length, 1, 'cloud import should go through raw execute()');
-        // The one query() call is the post-execution SESSION_ID/STMT_ID capture
-        // (captureStatementIdentity), not a second attempt at the import itself.
+        // The one query() call is the pre-execution SESSION_ID/STMT_ID capture
+        // (captureBaselineStatementIdentity), not a second attempt at the import itself.
         assert.strictEqual(calls.query.length, 1);
         assert.ok(calls.query[0][0].includes('CURRENT_SESSION'));
     });

--- a/src/test/unit/queryExecutorStatementIdentity.test.ts
+++ b/src/test/unit/queryExecutorStatementIdentity.test.ts
@@ -15,7 +15,7 @@ import { createEmptyRawResult, createRawResult } from '../helpers/mockConnection
  * SESSION_ID/STMT_ID rows for the baseline identity-capture query
  * captureBaselineStatementIdentity() issues *before* the real statement.
  */
-function makeExecutor(options: { mainResult: any; identityRows?: any[] | 'throw' }): { qe: any; queryCalls: string[] } {
+function makeExecutor(options: { mainResult: any; identityRows?: any[] | 'throw'; executionPlanAvailable?: boolean }): { qe: any; queryCalls: string[] } {
     const queryCalls: string[] = [];
 
     const fakeDriver = {
@@ -34,6 +34,7 @@ function makeExecutor(options: { mainResult: any; identityRows?: any[] | 'throw'
 
     const fakeConnectionManager = {
         getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+        isExecutionPlanAvailable: () => options.executionPlanAvailable ?? true,
         getDriver: async () => fakeDriver,
         executeWithRetry: async (fn: () => Promise<any>) => fn()
     };
@@ -143,6 +144,40 @@ suite('QueryExecutor.execute: baseline statement identity capture', () => {
 
         const result = await qe.execute('SELECT 1 AS X');
 
+        assert.strictEqual(result.sessionId, undefined);
+        assert.strictEqual(result.baselineStmtId, undefined);
+    });
+
+    test('does not capture identity when execution plans are disabled', async () => {
+        (vscodeMock as any).workspace = {
+            getConfiguration: () => ({
+                get: (key: string, fallback?: unknown) => key === 'executionPlan' ? false : fallback
+            })
+        };
+        const { qe, queryCalls } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: [[42, 7]]
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(queryCalls.length, 1, 'only the real SELECT should run');
+        assert.ok(!queryCalls[0].includes('CURRENT_SESSION'));
+        assert.strictEqual(result.sessionId, undefined);
+        assert.strictEqual(result.baselineStmtId, undefined);
+    });
+
+    test('does not capture identity when connection-time profiling setup failed', async () => {
+        const { qe, queryCalls } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: [[42, 7]],
+            executionPlanAvailable: false
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(queryCalls.length, 1, 'only the real SELECT should run');
+        assert.ok(!queryCalls[0].includes('CURRENT_SESSION'));
         assert.strictEqual(result.sessionId, undefined);
         assert.strictEqual(result.baselineStmtId, undefined);
     });

--- a/src/test/unit/queryExecutorStatementIdentity.test.ts
+++ b/src/test/unit/queryExecutorStatementIdentity.test.ts
@@ -1,0 +1,247 @@
+import * as assert from 'assert';
+import { registerVscodeMock, registerExtensionMock, vscodeMock } from '../helpers/vscodeMock';
+
+registerVscodeMock();
+registerExtensionMock();
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { QueryExecutor } = require('../../queryExecutor');
+
+import { createEmptyRawResult, createRawResult } from '../helpers/mockConnectionManager';
+
+/**
+ * Builds a QueryExecutor whose fake driver returns `mainResult` for the real
+ * statement's query()/execute() call, and, if `identityRows` is given,
+ * SESSION_ID/STMT_ID rows for the baseline identity-capture query
+ * captureBaselineStatementIdentity() issues *before* the real statement.
+ */
+function makeExecutor(options: { mainResult: any; identityRows?: any[] | 'throw' }): { qe: any; queryCalls: string[] } {
+    const queryCalls: string[] = [];
+
+    const fakeDriver = {
+        execute: async () => options.mainResult,
+        query: async (sql: string) => {
+            queryCalls.push(sql);
+            if (sql.includes('CURRENT_SESSION')) {
+                if (options.identityRows === 'throw') {
+                    throw new Error('simulated identity capture failure');
+                }
+                return createRawResult(['SID', 'STID'], options.identityRows ?? []);
+            }
+            return options.mainResult;
+        }
+    };
+
+    const fakeConnectionManager = {
+        getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+        getDriver: async () => fakeDriver,
+        executeWithRetry: async (fn: () => Promise<any>) => fn()
+    };
+
+    return { qe: new QueryExecutor(fakeConnectionManager), queryCalls };
+}
+
+suite('QueryExecutor.execute: baseline statement identity capture', () => {
+    setup(() => {
+        (vscodeMock as any).workspace = {
+            getConfiguration: () => ({
+                get: (_key: string, fallback?: unknown) => fallback
+            })
+        };
+    });
+
+    test('attaches sessionId/baselineStmtId to a SELECT result when capture succeeds', async () => {
+        const { qe } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: [[42, 7]]
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(result.sessionId, '42');
+        assert.strictEqual(result.baselineStmtId, '7');
+    });
+
+    test('attaches the originating connectionId so the plan can be looked up against the right connection later', async () => {
+        const { qe } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: [[42, 7]]
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(result.connectionId, 'conn-1', 'must record which connection actually ran the query');
+    });
+
+    test('attaches sessionId/baselineStmtId to a DDL/DML result (execute() path) too', async () => {
+        const { qe } = makeExecutor({
+            mainResult: createEmptyRawResult([]),
+            identityRows: [[100, 3]]
+        });
+
+        const result = await qe.execute('CREATE TABLE t (x INT)');
+
+        assert.strictEqual(result.sessionId, '100');
+        assert.strictEqual(result.baselineStmtId, '3');
+    });
+
+    test('captures the baseline before the real statement runs, not after', async () => {
+        const calls: string[] = [];
+        const fakeDriver = {
+            query: async (sql: string) => {
+                calls.push(sql);
+                if (sql.includes('CURRENT_SESSION')) {
+                    return createRawResult(['SID', 'STID'], [[1, 1]]);
+                }
+                return createRawResult(['X'], [[1]]);
+            }
+        };
+        const fakeConnectionManager = {
+            getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+            getDriver: async () => fakeDriver,
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const qe = new QueryExecutor(fakeConnectionManager);
+
+        await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(calls.length, 2);
+        assert.ok(calls[0].includes('CURRENT_SESSION'), 'baseline capture must be the first call, before the real query');
+        assert.strictEqual(calls[1], 'SELECT 1 AS X LIMIT 10000');
+    });
+
+    test('round-trips a session id larger than Number.MAX_SAFE_INTEGER without truncation', async () => {
+        const huge = '1871214140502573056';
+        const { qe } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: [[huge, '16']]
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(result.sessionId, huge, 'must preserve every digit, not a rounded double');
+    });
+
+    test('leaves sessionId/baselineStmtId undefined (not throw) when identity capture fails', async () => {
+        const { qe } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: 'throw'
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(result.sessionId, undefined);
+        assert.strictEqual(result.baselineStmtId, undefined);
+        assert.strictEqual(result.rows.length, 1, 'the actual query result must still come through');
+    });
+
+    test('leaves sessionId/baselineStmtId undefined when the identity query returns no rows', async () => {
+        const { qe } = makeExecutor({
+            mainResult: createRawResult(['X'], [[1]]),
+            identityRows: []
+        });
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(result.sessionId, undefined);
+        assert.strictEqual(result.baselineStmtId, undefined);
+    });
+
+    test('does not inflate executionTime with the baseline capture round-trip', async () => {
+        let queryCallCount = 0;
+        const fakeDriver = {
+            query: async (sql: string) => {
+                queryCallCount++;
+                if (sql.includes('CURRENT_SESSION')) {
+                    // Simulate the baseline capture itself taking a while.
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                    return createRawResult(['SID', 'STID'], [[1, 1]]);
+                }
+                return createRawResult(['X'], [[1]]);
+            }
+        };
+        const fakeConnectionManager = {
+            getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+            getDriver: async () => fakeDriver,
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const qe = new QueryExecutor(fakeConnectionManager);
+
+        const result = await qe.execute('SELECT 1 AS X');
+
+        assert.strictEqual(queryCallCount, 2);
+        assert.ok(result.executionTime < 40, `executionTime (${result.executionTime}ms) should exclude the ~50ms baseline capture`);
+    });
+
+    test('captures identity for a local CSV import too — it is still a real, profiled IMPORT statement', async () => {
+        const calls: string[] = [];
+        const fakeDriver = {
+            importFromCsvFile: async () => 5,
+            query: async (sql: string) => {
+                calls.push(sql);
+                if (sql.includes('CURRENT_SESSION')) {
+                    return createRawResult(['SID', 'STID'], [[42, 7]]);
+                }
+                return createEmptyRawResult([]);
+            }
+        };
+        const fakeConnectionManager = {
+            getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+            getDriver: async () => fakeDriver,
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const qe = new QueryExecutor(fakeConnectionManager);
+
+        const result = await qe.execute("IMPORT INTO t FROM LOCAL CSV FILE '/abs/x.csv'");
+
+        assert.strictEqual(calls.length, 1, 'the baseline identity capture must run once, before the import');
+        assert.ok(calls[0].includes('CURRENT_SESSION'));
+        assert.strictEqual(result.sessionId, '42');
+        assert.strictEqual(result.baselineStmtId, '7');
+        assert.strictEqual(result.connectionId, 'conn-1');
+        assert.strictEqual(result.rowCount, 5, 'the actual import result must still come through');
+    });
+
+    test('leaves sessionId/baselineStmtId undefined (not throw) when identity capture fails for a local CSV import', async () => {
+        const fakeDriver = {
+            importFromCsvFile: async () => 5,
+            query: async () => { throw new Error('simulated identity capture failure'); }
+        };
+        const fakeConnectionManager = {
+            getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+            getDriver: async () => fakeDriver,
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const qe = new QueryExecutor(fakeConnectionManager);
+
+        const result = await qe.execute("IMPORT INTO t FROM LOCAL CSV FILE '/abs/x.csv'");
+
+        assert.strictEqual(result.sessionId, undefined);
+        assert.strictEqual(result.baselineStmtId, undefined);
+        assert.strictEqual(result.rowCount, 5, 'the import itself must still succeed even if identity capture fails');
+    });
+
+    test('does not inflate executionTime with the baseline capture round-trip, for a local CSV import too', async () => {
+        let queryCallCount = 0;
+        const fakeDriver = {
+            importFromCsvFile: async () => 5,
+            query: async () => {
+                queryCallCount++;
+                // Simulate the baseline capture itself taking a while.
+                await new Promise(resolve => setTimeout(resolve, 50));
+                return createRawResult(['SID', 'STID'], [[1, 1]]);
+            }
+        };
+        const fakeConnectionManager = {
+            getActiveConnection: () => ({ id: 'conn-1', name: 'Test' }),
+            getDriver: async () => fakeDriver,
+            executeWithRetry: async (fn: () => Promise<any>) => fn()
+        };
+        const qe = new QueryExecutor(fakeConnectionManager);
+
+        const result = await qe.execute("IMPORT INTO t FROM LOCAL CSV FILE '/abs/x.csv'");
+
+        assert.strictEqual(queryCallCount, 1);
+        assert.ok(result.executionTime < 40, `executionTime (${result.executionTime}ms) should exclude the ~50ms baseline capture`);
+    });
+});


### PR DESCRIPTION
Lets users see Exasol's own per-operator profile for any statement - SELECT, DML, DDL, IMPORT/EXPORT included - directly next to its results, so diagnosing slow queries (skew, disk spills, large redistributions) doesn't require a separate tool.

## How it works

- Every statement records its session and a baseline statement id before running; the Plan tab looks the profile up from `$EXA_PROFILE_DETAILS_LAST_DAY` with fallback to `EXA_DBA_PROFILE_LAST_DAY` and `EXA_USER_PROFILE_LAST_DAY`, so it degrades gracefully with user privileges.
- Gated by the new `exasol.executionPlan` setting (default on). When enabled, new user connections run `ALTER SESSION SET PROFILE = 'ON'` automatically - Exasol only historizes profile data for profiled sessions, so without this the plan views stay empty on a stock cluster. Disabling the setting removes the Plan tab and skips the per-statement identity capture entirely.
- Transient plan-fetch failures are retryable from the error view (retry button or re-clicking the Plan tab).

## Behavior notes

- Reported execution time now measures only the statement's own round trip; it no longer includes connection-queue wait or reconnect time.
- The Plan tab is available for single-statement results only (not the multi-statement Result-N tab bar yet).

## Release

Bumps the version to 1.7.0 with a changelog entry, so merging triggers the release. Merge is held until the branch VSIX has been test-driven against live clusters and confirmed good.
